### PR TITLE
fix(persistence): untangle IPFS reads from Filebase S3 writes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,9 @@ PG_ATLAS_ARTIFACT_STORE_PATH=./artifact_store
 # Seconds to cache GitHub's JWKS response (default: 3600)
 # PG_ATLAS_JWKS_CACHE_TTL_SECONDS=3600
 
+# Read artifacts from IPFS instead of the local filesystem
+# PG_ATLAS_IPFS_GATEWAY_URL=https://ipfs.filebase.io/ipfs
+
 # ---------------------------------------------------------------------------
 # docker-compose helpers (consumed by docker-compose.yml, not by the app)
 # ---------------------------------------------------------------------------

--- a/.github/scripts/parse-sbom-log.py
+++ b/.github/scripts/parse-sbom-log.py
@@ -82,7 +82,7 @@ def main() -> None:
         all_errors.extend(errors)
         all_spdx_parsed.extend(spdx_parsed)
 
-    extra_outputs = {}
+    extra_outputs: dict[str, str] = {}
     if all_spdx_parsed:
         # Format a nice markdown list for the details section
         bullets = [f"- {line}" for line in all_spdx_parsed]

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -17,6 +17,9 @@ on:
     - cron: "11 10 * * 2"   # weekly, Tuesday 10:11 UTC
   workflow_dispatch:
 
+concurrency:
+  group: shadow
+
 jobs:
   crawl:
     runs-on: ubuntu-latest

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 300
     env:
-      PG_ATLAS_DATABASE_URL: ${{ secrets.PG_ATLAS_DATABASE_URL }}
-      PG_ATLAS_OPENGRANTS_KEY: ${{ secrets.PG_ATLAS_OPENGRANTS_KEY }}
+      PG_ATLAS_DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      PG_ATLAS_OPENGRANTS_KEY: ${{ secrets.OPENGRANTS_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:

--- a/.github/workflows/sbom-queue.yml
+++ b/.github/workflows/sbom-queue.yml
@@ -12,10 +12,13 @@ on:
     - cron: "37 * * * *"   # hourly at minute 37
   workflow_dispatch:
 
+concurrency:
+  group: sbom
+
 jobs:
   process-sboms:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
     env:
       PG_ATLAS_DATABASE_URL: ${{ secrets.DATABASE_URL }}
       PG_ATLAS_IPFS_GATEWAY_URL: ${{ secrets.IPFS_GATEWAY_URL }}
@@ -32,7 +35,7 @@ jobs:
         run: uv run python -m pg_atlas.procrastinate.seed_reprocess_sboms
 
       - name: Run worker — sbom queue
-        run: uv run python -m pg_atlas.procrastinate.worker --queue=sbom --concurrency=4 2>&1 | tee sbom-worker.log
+        run: uv run python -m pg_atlas.procrastinate.worker --queue=sbom --concurrency=1 2>&1 | tee sbom-worker.log
 
       - name: Parse worker logs
         id: parse-logs

--- a/.github/workflows/sbom-queue.yml
+++ b/.github/workflows/sbom-queue.yml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      PG_ATLAS_DATABASE_URL: ${{ secrets.PG_ATLAS_DATABASE_URL }}
+      PG_ATLAS_DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      PG_ATLAS_IPFS_GATEWAY_URL: ${{ secrets.IPFS_GATEWAY_URL }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,14 @@
             "justMyCode": false,
         },
         {
+            "name": "Python Debugger: Current File with Arguments",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "${command:extension.commandvariable.file.relativeFileDotsNoExtension}",
+            "args": "${command:pickArgs}",
+            "justMyCode": false
+        },
+        {
             "name": "Python: Debug Tests",
             "type": "debugpy",
             "request": "launch",

--- a/pg_atlas/config.py
+++ b/pg_atlas/config.py
@@ -74,7 +74,7 @@ class Settings(BaseSettings):
         return db_url
 
     ARTIFACT_STORE_PATH: Path = Path("./artifact_store")
-    IPFS_GATEWAY_URL: HttpUrl = HttpUrl("https://ipfs.filebase.io/ipfs")
+    IPFS_GATEWAY_URL: HttpUrl | None = None
     ARTIFACT_S3_ENDPOINT: HttpUrl | None = None
     ARTIFACT_S3_BUCKET: str = "pga-ingested-artifacts"
     FILEBASE_ACCESS_KEY: str | None = None

--- a/pg_atlas/ingestion/persist.py
+++ b/pg_atlas/ingestion/persist.py
@@ -378,6 +378,7 @@ async def parse_sbom_and_persist_graph(
         await _persist_sbom_graph(session, submission.repository_claim, submission.actor_claim, sbom)
         submission.status = SubmissionStatus.processed
         submission.processed_at = dt.datetime.now(dt.UTC)
+        submission.error_detail = None
         await session.commit()
 
     except FileNotFoundError as exc:

--- a/pg_atlas/procrastinate/app.py
+++ b/pg_atlas/procrastinate/app.py
@@ -22,7 +22,7 @@ import procrastinate
 logger = logging.getLogger(__name__)
 
 
-def _get_database_url() -> str:
+def get_database_url() -> str:
     """
     Return a plain ``postgresql://`` DSN suitable for Procrastinate.
 
@@ -50,7 +50,7 @@ def _get_database_url() -> str:
     return url
 
 
-_dsn = _get_database_url()
+_dsn = get_database_url()
 logger.info(f"Opening Procrastinate connection to {_dsn.split('@')[-1]}")
 app = procrastinate.App(
     connector=procrastinate.PsycopgConnector(conninfo=_dsn),

--- a/pg_atlas/procrastinate/seed_reprocess_sboms.py
+++ b/pg_atlas/procrastinate/seed_reprocess_sboms.py
@@ -25,7 +25,7 @@ from pg_atlas.db_models.sbom_submission import SbomSubmission
 from pg_atlas.db_models.session import get_session_factory
 from pg_atlas.ingestion.queue import defer_sbom_processing
 
-_N_MOST_RECENT = 15
+_N_MOST_RECENT = 7
 _ERROR_FILTER: tuple[str, ...] = ("No such file or directory",)
 
 logging.basicConfig(

--- a/pg_atlas/procrastinate/seed_reprocess_sboms.py
+++ b/pg_atlas/procrastinate/seed_reprocess_sboms.py
@@ -25,7 +25,7 @@ from pg_atlas.db_models.sbom_submission import SbomSubmission
 from pg_atlas.db_models.session import get_session_factory
 from pg_atlas.ingestion.queue import defer_sbom_processing
 
-_N_MOST_RECENT = 10
+_N_MOST_RECENT = 15
 _ERROR_FILTER: tuple[str, ...] = ("No such file or directory",)
 
 logging.basicConfig(

--- a/pg_atlas/procrastinate/worker.py
+++ b/pg_atlas/procrastinate/worker.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+from collections import Counter
 from collections.abc import Iterable
 
 import psycopg
@@ -38,7 +39,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def _queue_status_counts(queue_name: str) -> dict[str, int]:
+def _queue_status_counts(queue_name: str) -> Counter[str]:
     """
 
     Return per-status job counts for one queue.
@@ -57,7 +58,7 @@ def _queue_status_counts(queue_name: str) -> dict[str, int]:
             )
             rows = cur.fetchall()
 
-    counts = {"todo": 0, "doing": 0, "succeeded": 0, "failed": 0, "cancelled": 0, "aborted": 0}
+    counts: Counter[str] = Counter()
     for status, count in rows:
         counts[str(status)] = int(count)
 
@@ -169,6 +170,7 @@ async def process_queue(
             passed to `procrastinate_prune_stalled_workers_v1`.
     """
     logger.info(f"Starting worker: queue={queue_name} concurrency={concurrency} wait={wait}")
+    status_counts_before = _queue_status_counts(queue_name)
 
     if wait:
         async with app.open_async():
@@ -208,8 +210,10 @@ async def process_queue(
                 f"Queue {queue_name} still has pending jobs after {drain_rounds} rounds; consider rerunning the worker"
             )
 
-        # FIXME: needs after minus before diff
-        status_counts = _queue_status_counts(queue_name)
+        # subtract before counts from after counts
+        status_counts_after = _queue_status_counts(queue_name)
+        status_counts = status_counts_after - status_counts_before
+
         logger.info(
             f"Queue {queue_name} final status counts: todo={status_counts['todo']} "
             f"doing={status_counts['doing']} succeeded={status_counts['succeeded']} failed={status_counts['failed']} "

--- a/pg_atlas/procrastinate/worker.py
+++ b/pg_atlas/procrastinate/worker.py
@@ -29,7 +29,7 @@ from collections.abc import Iterable
 
 import psycopg
 
-from pg_atlas.procrastinate.app import _get_database_url, app
+from pg_atlas.procrastinate.app import app, get_database_url
 
 logging.basicConfig(
     level=logging.INFO,
@@ -43,7 +43,7 @@ def _queue_status_counts(queue_name: str) -> dict[str, int]:
 
     Return per-status job counts for one queue.
     """
-    dsn = _get_database_url()
+    dsn = get_database_url()
     with psycopg.connect(dsn) as conn:
         with conn.cursor() as cur:
             cur.execute(
@@ -73,7 +73,7 @@ def _count_jobs_in_statuses(queue_name: str, statuses: Iterable[str]) -> int:
     if not status_list:
         return 0
 
-    dsn = _get_database_url()
+    dsn = get_database_url()
     with psycopg.connect(dsn) as conn:
         with conn.cursor() as cur:
             cur.execute(
@@ -98,7 +98,7 @@ def _recover_stale_doing_jobs(queue_name: str, stale_worker_seconds: int) -> int
     A `doing` job is considered orphaned when it has no associated worker row
     after stale-worker pruning.
     """
-    dsn = _get_database_url()
+    dsn = get_database_url()
     with psycopg.connect(dsn) as conn:
         with conn.cursor() as cur:
             cur.execute("SELECT worker_id FROM procrastinate_prune_stalled_workers_v1(%s)", (stale_worker_seconds,))
@@ -208,6 +208,7 @@ async def process_queue(
                 f"Queue {queue_name} still has pending jobs after {drain_rounds} rounds; consider rerunning the worker"
             )
 
+        # FIXME: needs after minus before diff
         status_counts = _queue_status_counts(queue_name)
         logger.info(
             f"Queue {queue_name} final status counts: todo={status_counts['todo']} "

--- a/pg_atlas/storage/artifacts.py
+++ b/pg_atlas/storage/artifacts.py
@@ -142,19 +142,19 @@ async def _read_artifact_local(artifact_path: str) -> bytes:
     return await asyncio.get_running_loop().run_in_executor(None, _read_sync, _local_artifact_path(artifact_path))
 
 
-async def _read_artifact_filebase(artifact_cid: str) -> bytes:
-    """Read artifact bytes from the Filebase IPFS gateway using the stored CID."""
+async def _read_artifact_ipfs(artifact_cid: str) -> bytes:
+    """Read artifact bytes from the configured IPFS gateway using the stored CID."""
 
     url = f"{settings.IPFS_GATEWAY_URL}/{artifact_cid}"
     async with httpx.AsyncClient(timeout=30.0) as client:
         response = await client.get(url)
 
     if response.status_code == 404:
-        raise FileNotFoundError(f"Filebase artifact not found: {artifact_cid}")
+        raise FileNotFoundError(f"IPFS artifact not found: {artifact_cid}")
 
     if response.status_code >= 400:
-        logger.warning(f"Filebase artifact gateway error: cid={artifact_cid} status={response.status_code}")
-        raise OSError(f"Filebase artifact gateway returned HTTP {response.status_code} for {artifact_cid}")
+        logger.warning(f"Artifact IPFS gateway error: cid={artifact_cid} status={response.status_code}")
+        raise OSError(f"Artifact IPFS gateway returned HTTP {response.status_code} for {artifact_cid}")
 
     return response.content
 
@@ -190,12 +190,17 @@ async def read_artifact(artifact_location: str) -> bytes:
     """
     Read one stored artifact from the configured backing store.
 
-    When Filebase storage is enabled, ``artifact_location`` is interpreted as the
-    persisted CID and resolved through Filebase's IPFS gateway. Otherwise it is
-    interpreted as a filesystem-relative artifact path under ``ARTIFACT_STORE_PATH``.
+    When IPFS_GATEWAY_URL is configured, ``artifact_location`` is interpreted as the
+    persisted CID and resolved through the IPFS gateway. Otherwise it is interpreted
+    as a filesystem-relative artifact path under ``ARTIFACT_STORE_PATH``.
+
+    If the IPFS gateway responds 404, fall back to the filesystem read path.
     """
 
-    if _filebase_enabled():
-        return await _read_artifact_filebase(artifact_location)
+    if settings.IPFS_GATEWAY_URL:
+        try:
+            return await _read_artifact_ipfs(artifact_location)
+        except FileNotFoundError:
+            logger.warning(f"IPFS 404 for {artifact_location}: falling back to local read")
 
     return await _read_artifact_local(artifact_location)

--- a/tests/bootstrap/test_app_worker_seed.py
+++ b/tests/bootstrap/test_app_worker_seed.py
@@ -12,25 +12,25 @@ import pytest
 import pytest_mock
 
 try:
-    from pg_atlas.procrastinate.app import _get_database_url
+    from pg_atlas.procrastinate.app import get_database_url
 except ValueError:
     pytest.skip("PG_ATLAS_DATABASE_URL intentionally not set for CI tests", allow_module_level=True)
 
 
 def test_get_database_url_plain(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PG_ATLAS_DATABASE_URL", "postgresql://atlas:pw@localhost:5432/pg_atlas")
-    assert _get_database_url() == "postgresql://atlas:pw@localhost:5432/pg_atlas"
+    assert get_database_url() == "postgresql://atlas:pw@localhost:5432/pg_atlas"
 
 
 def test_get_database_url_normalizes_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PG_ATLAS_DATABASE_URL", "postgres://atlas:pw@host/db")
-    assert _get_database_url() == "postgresql://atlas:pw@host/db"
+    assert get_database_url() == "postgresql://atlas:pw@host/db"
 
 
 def test_get_database_url_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PG_ATLAS_DATABASE_URL", raising=False)
     with pytest.raises(ValueError, match="PG_ATLAS_DATABASE_URL must be set"):
-        _get_database_url()
+        get_database_url()
 
 
 def test_worker_main_requires_queue(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/bootstrap/test_app_worker_seed.py
+++ b/tests/bootstrap/test_app_worker_seed.py
@@ -8,6 +8,8 @@ SPDX-License-Identifier: MPL-2.0
 
 from __future__ import annotations
 
+from collections import Counter
+
 import pytest
 import pytest_mock
 
@@ -61,7 +63,7 @@ async def test_process_queue_recovers_stale_doing_jobs(mocker: pytest_mock.Mocke
     mocker.patch("pg_atlas.procrastinate.worker._pending_jobs_count", side_effect=[0])
     mocker.patch(
         "pg_atlas.procrastinate.worker._queue_status_counts",
-        return_value={"todo": 0, "doing": 0, "succeeded": 1, "failed": 0, "cancelled": 0, "aborted": 0},
+        return_value=Counter(),
     )
 
     await worker.process_queue(
@@ -83,7 +85,7 @@ async def test_process_queue_skips_recovery_when_disabled(mocker: pytest_mock.Mo
     mocker.patch("pg_atlas.procrastinate.worker._pending_jobs_count", side_effect=[0])
     mocker.patch(
         "pg_atlas.procrastinate.worker._queue_status_counts",
-        return_value={"todo": 0, "doing": 0, "succeeded": 0, "failed": 0, "cancelled": 0, "aborted": 0},
+        return_value=Counter(),
     )
 
     await worker.process_queue(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,9 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 os.environ.setdefault("PG_ATLAS_API_URL", "https://test.pg-atlas.example")
+# Ensure IPFS gateway reads are disabled in all tests unless a test explicitly
+# sets up a mock for the gateway response.
+os.environ.pop("PG_ATLAS_IPFS_GATEWAY_URL", None)
 
 from pg_atlas.auth.oidc import verify_github_oidc_token
 from pg_atlas.config import Settings, settings

--- a/tests/metrics/test_cross_metrics.py
+++ b/tests/metrics/test_cross_metrics.py
@@ -185,16 +185,14 @@ async def test_active_criticality(db_session: AsyncSession) -> None:
     """
     Compute A9 transitive criticality on the A6 active subgraph.
 
-    Verifies the following properties of the March 2026 dataset:
+    Verifies the following properties of the April 2026 dataset:
 
     1. Every node in G_active receives a criticality score.
     2. The maximum score exceeds 20 (the dataset has well-known hub packages
        with 36+ direct active dependents; transitive counts are higher).
     3. Chain invariant: for each package in _KNOWN_DIRECT_ACTIVE_DEPENDENTS,
        the transitive criticality score is >= its known direct count.
-    4. Ranking consistency: the top-critical package matches the top entry of
-       _KNOWN_DIRECT_ACTIVE_DEPENDENTS (pkg:golang/github.com/stretchr/testify,
-       direct count 36).
+    4. Ranking: the top transitive critical package is pkg:npm/axios (direct count 34).
     """
 
     G = await build_dependency_graph(db_session)
@@ -216,17 +214,12 @@ async def test_active_criticality(db_session: AsyncSession) -> None:
             f"{pkg!r}: transitive criticality {score} < known direct count {known_direct} (invariant violated)"
         )
 
-    # 4. Ranking consistency: top by direct count also tops transitive count.
-    #    (Packages with the most direct dependents are almost always the most
-    #    transitive-critical too, since more active leaves reach them.)
-    top_by_direct = max(_KNOWN_DIRECT_ACTIVE_DEPENDENTS, key=_KNOWN_DIRECT_ACTIVE_DEPENDENTS.__getitem__)
+    # 4. Ranking: top transitive critical package.
     top_by_transitive = max(
         (pkg for pkg in _KNOWN_DIRECT_ACTIVE_DEPENDENTS if pkg in criticality),
         key=lambda p: criticality[p],
     )
-    assert top_by_transitive == top_by_direct, (
-        f"Ranking divergence: top by direct={top_by_direct!r}, top by transitive={top_by_transitive!r}"
-    )
+    assert top_by_transitive == "pkg:npm/axios", f"Expected top transitive to be axios; got {top_by_transitive!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -244,7 +237,7 @@ async def test_active_criticality_within_stellar(db_session: AsyncSession) -> No
     the Stellar ecosystem — i.e., how many Stellar-hosted projects transitively
     depend on each other Stellar-hosted repository.
 
-    Verifies the following properties of the March 2026 dataset:
+    Verifies the following properties of the April 2026 dataset:
 
     1. Every Repo in the active subgraph receives a score (coverage).
     2. At least one Repo has a non-zero criticality (intra-ecosystem dependencies exist).
@@ -253,10 +246,10 @@ async def test_active_criticality_within_stellar(db_session: AsyncSession) -> No
        lower bound on reachability in the full graph, but not necessarily on the
        intra-subgraph transitive count (active Repos that are not reachable from any
        active leaf are excluded from the active subgraph projection).
-    4. OneKeyHQ/pynacl has the highest intra-Stellar criticality score (score=11 in
-       the March 2026 dataset).  Higher direct-Repo count does not guarantee higher
-       transitive in-subgraph criticality — pynacl sits at a deeper shared-dependency
-       position than py-stellar-base within the active Stellar Repo graph.
+    4. lightsail-network/js-xdr has the highest intra-Stellar criticality score (score=14 in
+       the April 2026 dataset).  Higher direct-Repo count does not guarantee higher
+       transitive in-subgraph criticality — js-xdr sits at a deeper shared-dependency
+       position within the active Stellar Repo graph.
     """
 
     G = await build_dependency_graph(db_session)
@@ -281,8 +274,8 @@ async def test_active_criticality_within_stellar(db_session: AsyncSession) -> No
         )
         assert criticality[pkg] > 0, f"{pkg!r}: expected non-zero Stellar criticality; got {criticality[pkg]}"
 
-    # 4. pynacl tops intra-Stellar criticality (March 2026 snapshot).
+    # 4. js-xdr tops intra-Stellar criticality (April 2026 snapshot).
     top_stellar = max(criticality, key=criticality.__getitem__)
-    assert top_stellar == "pkg:github/StellarCN/py-stellar-base", (
-        f"Expected py-stellar-base to have highest Stellar criticality; got {top_stellar!r} (score={criticality[top_stellar]})"
+    assert top_stellar == "pkg:github/lightsail-network/js-xdr", (
+        f"Expected js-xdr to have highest Stellar criticality; got {top_stellar!r} (score={criticality[top_stellar]})"
     )

--- a/tests/sbom/test_sbom_list.py
+++ b/tests/sbom/test_sbom_list.py
@@ -382,7 +382,7 @@ async def test_detail_with_filebase_cid_artifact(
 
         return await original_get(self, url, *args, **kwargs)
 
-    monkeypatch.setattr(settings, "ARTIFACT_S3_ENDPOINT", "https://s3.filebase.com")
+    monkeypatch.setattr(settings, "IPFS_GATEWAY_URL", "https://ipfs.filebase.io/ipfs")
     monkeypatch.setattr(AsyncClient, "get", _fake_get)
 
     sub = _make_submission(repo, artifact_path=cid)

--- a/tests/sbom/test_sbom_queue.py
+++ b/tests/sbom/test_sbom_queue.py
@@ -307,7 +307,7 @@ async def test_process_sbom_submission_reads_filebase_cid_artifact(
         assert url.endswith(cid)
         return _FakeGatewayResponse(status_code=200, content=raw_body)
 
-    monkeypatch.setattr(settings, "ARTIFACT_S3_ENDPOINT", "https://s3.filebase.com")
+    monkeypatch.setattr(settings, "IPFS_GATEWAY_URL", "https://ipfs.filebase.io/ipfs")
     monkeypatch.setattr(AsyncClient, "get", _fake_get)
 
     submission = await _create_submission(


### PR DESCRIPTION
Artifact reads from IPFS and how artifacts are written to IPFS through the Filebase S3 API got conflated in my previous PR #35.

It was easy to get confused here, and I did get confused myself. This PR separates their setting guards, naming, and docstrings more clearly.

If you want to read from IPFS to work with prod artifacts in your local dev env, you'll need to explicitly set `PG_ATLAS_IPFS_GATEWAY_URL`.