### PR TITLE
feat(metrics): materialize A9 repo/project criticality

### DIFF
--- a/pg_atlas/metrics/materialize.py
+++ b/pg_atlas/metrics/materialize.py
@@ -1,0 +1,171 @@
+"""
+A9 criticality materialization for repo-resolution dependency graphs.
+
+This module turns the already-merged A6 and A9 in-memory metric functions into
+an offline persistence pass:
+
+1. Load the repo-resolution dependency graph from PostgreSQL.
+2. Project the active ecosystem with A6.
+3. Compute repo/external criticality with A9.
+4. Materialize dep-layer scores back onto ORM rows.
+5. Aggregate project scores from child repos.
+
+The core helper mutates the provided SQLAlchemy session but does not commit.
+Callers can therefore use it from a CLI, a background task, or a rollback-only
+test transaction.
+
+Usage::
+
+    uv run python -m pg_atlas.metrics.materialize
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from pg_atlas.db_models.project import Project
+from pg_atlas.db_models.repo_vertex import ExternalRepo, Repo
+from pg_atlas.db_models.session import get_session_factory
+from pg_atlas.metrics.active_subgraph import project_active_subgraph
+from pg_atlas.metrics.criticality import compute_criticality
+from pg_atlas.metrics.graph_builder import build_dependency_graph
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CriticalityMaterializationStats:
+    """
+    Summarize one A9 materialization pass.
+    """
+
+    dep_nodes_seen: int
+    active_dep_nodes_scored: int
+    repo_rows_updated: int
+    external_repo_rows_updated: int
+    project_rows_updated: int
+    duration_seconds: float
+
+
+async def materialize_criticality_scores(session: AsyncSession) -> CriticalityMaterializationStats:
+    """
+    Recompute and persist A9 criticality scores within one session.
+
+    The session is mutated and flushed, but not committed.
+
+    Behavior:
+    - Repo and ExternalRepo rows are always materialized to an integer score.
+      Nodes absent from the active subgraph are written as ``0``.
+    - Project rows are aggregated from child Repo rows only.
+      Projects with no repos remain ``NULL``.
+      Projects with repos but no active dependency pressure become ``0``.
+    - The computation path stays strictly at repo resolution; it never uses
+      ``build_full_graph()`` or project nodes in NetworkX.
+    """
+
+    started_at = time.perf_counter()
+
+    dependency_graph = await build_dependency_graph(session)
+    active_graph = project_active_subgraph(dependency_graph)
+    active_scores = compute_criticality(active_graph)
+
+    repos = (await session.execute(select(Repo))).scalars().all()
+    external_repos = (await session.execute(select(ExternalRepo))).scalars().all()
+    project_rows_updated = await session.scalar(select(func.count(Project.id))) or 0
+
+    dep_nodes_seen = len(repos) + len(external_repos)
+
+    for repo in repos:
+        repo.criticality_score = active_scores.get(repo.canonical_id, 0)
+
+    for external_repo in external_repos:
+        external_repo.criticality_score = active_scores.get(external_repo.canonical_id, 0)
+
+    await session.flush()
+
+    project_score_subquery = (
+        select(
+            Repo.project_id.label("project_id"),
+            func.sum(Repo.criticality_score).label("criticality_score"),
+        )
+        .where(Repo.project_id.is_not(None))
+        .group_by(Repo.project_id)
+        .subquery()
+    )
+
+    project_update = (
+        update(Project)
+        .values(
+            criticality_score=(
+                select(project_score_subquery.c.criticality_score)
+                .where(project_score_subquery.c.project_id == Project.id)
+                .scalar_subquery()
+            )
+        )
+        .execution_options(synchronize_session=False)
+    )
+    await session.execute(project_update)
+
+    # Keep already-loaded Project rows usable inside the current AsyncSession.
+    await session.execute(select(Project).execution_options(populate_existing=True))
+
+    await session.flush()
+
+    duration_seconds = time.perf_counter() - started_at
+
+    stats = CriticalityMaterializationStats(
+        dep_nodes_seen=dep_nodes_seen,
+        active_dep_nodes_scored=len(active_scores),
+        repo_rows_updated=len(repos),
+        external_repo_rows_updated=len(external_repos),
+        project_rows_updated=project_rows_updated,
+        duration_seconds=duration_seconds,
+    )
+
+    logger.info(
+        "materialize_criticality_scores: "
+        f"dep_nodes_seen={stats.dep_nodes_seen} "
+        f"active_dep_nodes_scored={stats.active_dep_nodes_scored} "
+        f"repo_rows_updated={stats.repo_rows_updated} "
+        f"external_repo_rows_updated={stats.external_repo_rows_updated} "
+        f"project_rows_updated={stats.project_rows_updated} "
+        f"duration_seconds={stats.duration_seconds:.3f}"
+    )
+
+    return stats
+
+
+async def main() -> None:
+    """
+    Run one offline A9 materialization pass and commit the results.
+    """
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+    )
+
+    factory = get_session_factory()
+    async with factory() as session:
+        stats = await materialize_criticality_scores(session)
+        await session.commit()
+
+    logger.info(
+        "A9 criticality materialization finished: "
+        f"dep_nodes_seen={stats.dep_nodes_seen} "
+        f"active_dep_nodes_scored={stats.active_dep_nodes_scored} "
+        f"duration_seconds={stats.duration_seconds:.3f}"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/metrics/test_materialize_criticality.py
+++ b/tests/metrics/test_materialize_criticality.py
@@ -1,0 +1,322 @@
+"""
+DB-backed tests for A9 criticality materialization.
+
+These tests create a disconnected mini-graph inside a rollback-only
+transaction so they can verify exact persisted scores without mutating the
+shared development dataset.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from pg_atlas.db_models import DependsOn, ExternalRepo, Project, Repo
+from pg_atlas.db_models.base import ActivityStatus, EdgeConfidence, ProjectType, Visibility
+from pg_atlas.metrics.materialize import CriticalityMaterializationStats, materialize_criticality_scores
+
+
+@dataclass(frozen=True)
+class SeededCriticalityFixture:
+    """
+    Hold the canonical IDs for one disconnected test component.
+    """
+
+    leaf_project_id: int
+    core_project_id: int
+    zero_project_id: int
+    dormant_project_id: int
+    empty_project_id: int
+    leaf_repo_id: int
+    core_repo_id: int
+    zero_repo_id: int
+    dormant_repo_id: int
+    external_repo_id: int
+
+
+@pytest.fixture
+async def rollback_db_session(db_session: AsyncSession) -> AsyncGenerator[AsyncSession, None]:
+    """
+    Run each materialization test inside a transaction that is rolled back.
+    """
+
+    transaction = await db_session.begin()
+    try:
+        yield db_session
+    finally:
+        if transaction.is_active:
+            await transaction.rollback()
+
+
+async def _seed_disconnected_component(session: AsyncSession) -> SeededCriticalityFixture:
+    """
+    Insert a disconnected graph component with deterministic A9 scores.
+
+    The seeded shape is:
+
+        leaf_repo (live) -> core_repo (discontinued) -> external_repo
+        zero_repo (live, isolated)
+        dormant_repo (discontinued, isolated)
+
+    Expected dep-layer criticality after A6 -> A9:
+        leaf_repo     = 0
+        core_repo     = 1
+        zero_repo     = 0
+        dormant_repo  = 0
+        external_repo = 2
+    """
+
+    suffix = uuid4().hex[:8]
+
+    leaf_project = Project(
+        canonical_id=f"daoip-5:stellar:project:leaf-{suffix}",
+        display_name=f"Leaf Project {suffix}",
+        project_type=ProjectType.scf_project,
+        activity_status=ActivityStatus.live,
+    )
+    core_project = Project(
+        canonical_id=f"daoip-5:stellar:project:core-{suffix}",
+        display_name=f"Core Project {suffix}",
+        project_type=ProjectType.scf_project,
+        activity_status=ActivityStatus.discontinued,
+    )
+    zero_project = Project(
+        canonical_id=f"daoip-5:stellar:project:zero-{suffix}",
+        display_name=f"Zero Project {suffix}",
+        project_type=ProjectType.scf_project,
+        activity_status=ActivityStatus.live,
+    )
+    dormant_project = Project(
+        canonical_id=f"daoip-5:stellar:project:dormant-{suffix}",
+        display_name=f"Dormant Project {suffix}",
+        project_type=ProjectType.scf_project,
+        activity_status=ActivityStatus.discontinued,
+    )
+    empty_project = Project(
+        canonical_id=f"daoip-5:stellar:project:empty-{suffix}",
+        display_name=f"Empty Project {suffix}",
+        project_type=ProjectType.scf_project,
+        activity_status=ActivityStatus.live,
+    )
+    session.add_all([leaf_project, core_project, zero_project, dormant_project, empty_project])
+    await session.flush()
+
+    leaf_repo = Repo(
+        canonical_id=f"pkg:github/test/leaf-{suffix}",
+        display_name=f"leaf-{suffix}",
+        visibility=Visibility.public,
+        latest_version="1.0.0",
+        project_id=leaf_project.id,
+    )
+    core_repo = Repo(
+        canonical_id=f"pkg:github/test/core-{suffix}",
+        display_name=f"core-{suffix}",
+        visibility=Visibility.public,
+        latest_version="1.0.0",
+        project_id=core_project.id,
+    )
+    zero_repo = Repo(
+        canonical_id=f"pkg:github/test/zero-{suffix}",
+        display_name=f"zero-{suffix}",
+        visibility=Visibility.public,
+        latest_version="1.0.0",
+        project_id=zero_project.id,
+    )
+    dormant_repo = Repo(
+        canonical_id=f"pkg:github/test/dormant-{suffix}",
+        display_name=f"dormant-{suffix}",
+        visibility=Visibility.public,
+        latest_version="1.0.0",
+        project_id=dormant_project.id,
+    )
+    external_repo = ExternalRepo(
+        canonical_id=f"pkg:npm/ext-{suffix}",
+        display_name=f"ext-{suffix}",
+        latest_version="1.0.0",
+    )
+    session.add_all([leaf_repo, core_repo, zero_repo, dormant_repo, external_repo])
+    await session.flush()
+
+    session.add_all(
+        [
+            DependsOn(
+                in_vertex_id=leaf_repo.id,
+                out_vertex_id=core_repo.id,
+                confidence=EdgeConfidence.verified_sbom,
+            ),
+            DependsOn(
+                in_vertex_id=core_repo.id,
+                out_vertex_id=external_repo.id,
+                confidence=EdgeConfidence.verified_sbom,
+            ),
+        ]
+    )
+    await session.flush()
+
+    return SeededCriticalityFixture(
+        leaf_project_id=leaf_project.id,
+        core_project_id=core_project.id,
+        zero_project_id=zero_project.id,
+        dormant_project_id=dormant_project.id,
+        empty_project_id=empty_project.id,
+        leaf_repo_id=leaf_repo.id,
+        core_repo_id=core_repo.id,
+        zero_repo_id=zero_repo.id,
+        dormant_repo_id=dormant_repo.id,
+        external_repo_id=external_repo.id,
+    )
+
+
+async def _get_repo(session: AsyncSession, repo_id: int) -> Repo:
+    """
+    Load one Repo row and assert it exists.
+    """
+
+    repo = await session.get(Repo, repo_id)
+    assert repo is not None
+
+    return repo
+
+
+async def _get_external_repo(session: AsyncSession, repo_id: int) -> ExternalRepo:
+    """
+    Load one ExternalRepo row and assert it exists.
+    """
+
+    external_repo = await session.get(ExternalRepo, repo_id)
+    assert external_repo is not None
+
+    return external_repo
+
+
+async def _get_project(session: AsyncSession, project_id: int) -> Project:
+    """
+    Load one Project row and assert it exists.
+    """
+
+    project = await session.get(Project, project_id)
+    assert project is not None
+
+    return project
+
+
+async def test_materialize_criticality_scores_persists_repo_external_and_project_scores(
+    rollback_db_session: AsyncSession,
+) -> None:
+    """
+    A9 materialization must persist dep-layer scores and project aggregates.
+    """
+
+    seeded = await _seed_disconnected_component(rollback_db_session)
+
+    stats = await materialize_criticality_scores(rollback_db_session)
+
+    assert isinstance(stats, CriticalityMaterializationStats)
+    assert stats.repo_rows_updated >= 4
+    assert stats.external_repo_rows_updated >= 1
+    assert stats.project_rows_updated >= 5
+
+    leaf_repo = await rollback_db_session.get(Repo, seeded.leaf_repo_id)
+    core_repo = await rollback_db_session.get(Repo, seeded.core_repo_id)
+    zero_repo = await rollback_db_session.get(Repo, seeded.zero_repo_id)
+    dormant_repo = await rollback_db_session.get(Repo, seeded.dormant_repo_id)
+    external_repo = await rollback_db_session.get(ExternalRepo, seeded.external_repo_id)
+
+    assert leaf_repo is not None
+    assert core_repo is not None
+    assert zero_repo is not None
+    assert dormant_repo is not None
+    assert external_repo is not None
+
+    assert leaf_repo.criticality_score == 0
+    assert core_repo.criticality_score == 1
+    assert zero_repo.criticality_score == 0
+    assert dormant_repo.criticality_score == 0
+    assert external_repo.criticality_score == 2
+
+    leaf_project = await rollback_db_session.get(Project, seeded.leaf_project_id)
+    core_project = await rollback_db_session.get(Project, seeded.core_project_id)
+    zero_project = await rollback_db_session.get(Project, seeded.zero_project_id)
+    dormant_project = await rollback_db_session.get(Project, seeded.dormant_project_id)
+    empty_project = await rollback_db_session.get(Project, seeded.empty_project_id)
+
+    assert leaf_project is not None
+    assert core_project is not None
+    assert zero_project is not None
+    assert dormant_project is not None
+    assert empty_project is not None
+
+    assert leaf_project.criticality_score == 0
+    assert core_project.criticality_score == 1
+    assert zero_project.criticality_score == 0
+    assert dormant_project.criticality_score == 0
+    assert empty_project.criticality_score is None
+
+
+async def test_materialize_criticality_scores_is_idempotent(
+    rollback_db_session: AsyncSession,
+) -> None:
+    """
+    Re-running A9 materialization must leave persisted scores unchanged.
+    """
+
+    seeded = await _seed_disconnected_component(rollback_db_session)
+
+    await materialize_criticality_scores(rollback_db_session)
+    leaf_repo = await _get_repo(rollback_db_session, seeded.leaf_repo_id)
+    core_repo = await _get_repo(rollback_db_session, seeded.core_repo_id)
+    zero_repo = await _get_repo(rollback_db_session, seeded.zero_repo_id)
+    dormant_repo = await _get_repo(rollback_db_session, seeded.dormant_repo_id)
+    external_repo = await _get_external_repo(rollback_db_session, seeded.external_repo_id)
+    leaf_project = await _get_project(rollback_db_session, seeded.leaf_project_id)
+    core_project = await _get_project(rollback_db_session, seeded.core_project_id)
+    zero_project = await _get_project(rollback_db_session, seeded.zero_project_id)
+    dormant_project = await _get_project(rollback_db_session, seeded.dormant_project_id)
+    empty_project = await _get_project(rollback_db_session, seeded.empty_project_id)
+
+    first_scores = (
+        leaf_repo.criticality_score,
+        core_repo.criticality_score,
+        zero_repo.criticality_score,
+        dormant_repo.criticality_score,
+        external_repo.criticality_score,
+        leaf_project.criticality_score,
+        core_project.criticality_score,
+        zero_project.criticality_score,
+        dormant_project.criticality_score,
+        empty_project.criticality_score,
+    )
+
+    await materialize_criticality_scores(rollback_db_session)
+    leaf_repo = await _get_repo(rollback_db_session, seeded.leaf_repo_id)
+    core_repo = await _get_repo(rollback_db_session, seeded.core_repo_id)
+    zero_repo = await _get_repo(rollback_db_session, seeded.zero_repo_id)
+    dormant_repo = await _get_repo(rollback_db_session, seeded.dormant_repo_id)
+    external_repo = await _get_external_repo(rollback_db_session, seeded.external_repo_id)
+    leaf_project = await _get_project(rollback_db_session, seeded.leaf_project_id)
+    core_project = await _get_project(rollback_db_session, seeded.core_project_id)
+    zero_project = await _get_project(rollback_db_session, seeded.zero_project_id)
+    dormant_project = await _get_project(rollback_db_session, seeded.dormant_project_id)
+    empty_project = await _get_project(rollback_db_session, seeded.empty_project_id)
+
+    second_scores = (
+        leaf_repo.criticality_score,
+        core_repo.criticality_score,
+        zero_repo.criticality_score,
+        dormant_repo.criticality_score,
+        external_repo.criticality_score,
+        leaf_project.criticality_score,
+        core_project.criticality_score,
+        zero_project.criticality_score,
+        dormant_project.criticality_score,
+        empty_project.criticality_score,
+    )
+
+    assert first_scores == second_scores


### PR DESCRIPTION
## Summary
- Implement the batch-first A9 materialization path for repo-resolution criticality.
- Run `build_dependency_graph()` -> A6 active subgraph -> `compute_criticality()`, then persist scores to `Repo` / `ExternalRepo` and aggregate `Project.criticality_score` from child repos.
- Add DB-backed tests for persistence, project aggregation, zeroing, and idempotency.

## Runtime Note
- Local seeded subset snapshot: `404` nodes, `287` edges, `358` active-subgraph nodes, `220` nonzero scores.
- Materialization runtime on that snapshot: `0.301s` on `2026-04-14`.
- Earlier seeded run on the same subset shape was `0.354s` on `2026-04-10`; current numbers are from the fresh verification pass before opening this PR.

## Out Of Scope
- No `build_full_graph()` usage.
- No `sbom-queue.yml` hookup.
- No incremental recompute / per-SBOM delta propagation.
- No pony factor or adoption work.
- Follow-up runtime and trigger-policy questions remain in #37.

## Test Plan
- `uv run basedpyright pg_atlas/metrics/materialize.py tests/metrics/test_materialize_criticality.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy pg_atlas/`
- `PG_ATLAS_API_URL=https://test.pg-atlas.example uv run pytest -v`
- `set -a && source /Users/jaygut/Documents/Side_Projects/pg-atlas-backend/.env && set +a && uv run pytest tests/metrics/test_materialize_criticality.py -q`
- `set -a && source /Users/jaygut/Documents/Side_Projects/pg-atlas-backend/.env && set +a && uv run python -m pg_atlas.metrics.materialize`

Closes #38
