### PR TITLE
feat(metrics): materialize pony factor from gitlog artifacts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,6 +105,8 @@ These rules MUST be enforced manually. No ruff rules are available to enforce th
 
 ## GitHub Actions
 
+- When you add a non-trivial step to a workflow (e.g. a metrics materialization or data-processing command), tee its output to a log file, parse the most pertinent fields, and incorporate them into the job summary so viewers can see at a glance what ran and what the outcome was.
+- **Never use shell `tee` (`cmd 2>&1 | tee file`)**; it swallows the exit code and makes failing steps appear green. Use `--tee=<file>` flags backed by `pg_atlas.instruments.tee.run_with_tee` instead.
 - The `gh` CLI is available as a fallback when the GitHub MCP gives a 403.
 - The SBOM action (`SCF-Public-Goods-Maintenance/pg-atlas-sbom-action`) is used by this repo too —
   it runs in CI on push to main.

--- a/.github/scripts/parse-materialize-criticality-log.py
+++ b/.github/scripts/parse-materialize-criticality-log.py
@@ -1,0 +1,72 @@
+"""
+Parse materialize_criticality stdout/tee output and emit GitHub Actions outputs.
+
+Reads captured output from ``uv run python -m pg_atlas.metrics.materialize_criticality``
+and extracts the summary fields from the final log line.
+
+Emits key=value pairs to ``$GITHUB_OUTPUT`` for use by downstream steps.
+
+Usage::
+
+    python .github/scripts/parse-materialize-criticality-log.py criticality.log
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+_SUMMARY_RE = re.compile(
+    r"A9 criticality materialization finished: "
+    r"dep_nodes_seen=(?P<dep_nodes>\d+) "
+    r"active_dep_nodes_scored=(?P<active_nodes>\d+) "
+    r"duration_seconds=(?P<duration>[\d.]+)"
+)
+
+
+def parse_log(log_path: str) -> dict[str, str]:
+    """
+    Scan a tee'd materialize_criticality log for the summary line.
+
+    Returns a dict of output key→value pairs.
+    """
+
+    result: dict[str, str] = {}
+
+    with open(log_path) as f:
+        for line in f:
+            m = _SUMMARY_RE.search(line)
+
+            if m:
+                result["criticality_dep_nodes_seen"] = m.group("dep_nodes")
+                result["criticality_active_nodes_scored"] = m.group("active_nodes")
+                result["criticality_duration_seconds"] = m.group("duration")
+
+    return result
+
+
+def main() -> None:
+    """Entry point."""
+
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <log-file>", file=sys.stderr)
+        sys.exit(1)
+
+    outputs = parse_log(sys.argv[1])
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as f:
+            for key, value in outputs.items():
+                f.write(f"{key}={value}\n")
+    else:
+        for key, value in outputs.items():
+            print(f"{key}={value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/parse-materialize-pony-log.py
+++ b/.github/scripts/parse-materialize-pony-log.py
@@ -1,0 +1,74 @@
+"""
+Parse materialize_pony stdout/tee output and emit GitHub Actions outputs.
+
+Reads captured output from ``uv run python -m pg_atlas.metrics.materialize_pony``
+and extracts the summary fields from the final log line.
+
+Emits key=value pairs to ``$GITHUB_OUTPUT`` for use by downstream steps.
+
+Usage::
+
+    python .github/scripts/parse-materialize-pony-log.py pony.log
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+_SUMMARY_RE = re.compile(
+    r"Pony-factor materialization finished: "
+    r"repo_rows_updated=(?P<repo_rows>\d+) "
+    r"project_rows_updated=(?P<project_rows>\d+) "
+    r"resolved_seed_run_ordinal=(?P<ordinal>\S+) "
+    r"duration_seconds=(?P<duration>[\d.]+)"
+)
+
+
+def parse_log(log_path: str) -> dict[str, str]:
+    """
+    Scan a tee'd materialize_pony log for the summary line.
+
+    Returns a dict of output key→value pairs.
+    """
+
+    result: dict[str, str] = {}
+
+    with open(log_path) as f:
+        for line in f:
+            m = _SUMMARY_RE.search(line)
+
+            if m:
+                result["pony_repo_rows_updated"] = m.group("repo_rows")
+                result["pony_project_rows_updated"] = m.group("project_rows")
+                result["pony_resolved_seed_run_ordinal"] = m.group("ordinal")
+                result["pony_duration_seconds"] = m.group("duration")
+
+    return result
+
+
+def main() -> None:
+    """Entry point."""
+
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <log-file>", file=sys.stderr)
+        sys.exit(1)
+
+    outputs = parse_log(sys.argv[1])
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as f:
+            for key, value in outputs.items():
+                f.write(f"{key}={value}\n")
+    else:
+        for key, value in outputs.items():
+            print(f"{key}={value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/templates/bootstrap-metrics-summary.md
+++ b/.github/templates/bootstrap-metrics-summary.md
@@ -1,0 +1,11 @@
+<!-- markdownlint-disable MD041 -->
+## Criticality Materialization
+<!-- markdownlint-enable MD041 -->
+
+| Dep nodes seen | Active nodes scored | Duration (s) |
+| -------------: | ------------------: | -----------: |
+| {criticality_dep_nodes_seen} | {criticality_active_nodes_scored} | {criticality_duration_seconds} |
+
+- **Trigger**: {trigger}
+- **Run**: [{run_id}]({server_url}/{repository}/actions/runs/{run_id})
+- **Finished**: {finished}

--- a/.github/templates/gitlog-queue-summary.md
+++ b/.github/templates/gitlog-queue-summary.md
@@ -13,7 +13,15 @@
 - **First rate-limit hit after N repos**: {first_rate_limit_hit_after_n_repos}
 - **Total rate-limit hits**: {total_rate_limit_hits}
 
+### Worker errors
+
 {error_detail}
+
+### Pony factor materialization
+
+| Repos updated | Projects updated | Seed run ordinal | Duration (s) |
+| ------------: | ---------------: | ---------------: | -----------: |
+| {pony_repo_rows_updated} | {pony_project_rows_updated} | {pony_resolved_seed_run_ordinal} | {pony_duration_seconds} |
 
 ### gh auth status
 

--- a/.github/templates/sbom-queue-summary.md
+++ b/.github/templates/sbom-queue-summary.md
@@ -16,3 +16,9 @@
 ### Parsed SPDX Documents
 
 {spdx_details}
+
+### Criticality Materialization
+
+| Dep nodes seen | Active nodes scored | Duration (s) |
+| -------------: | ------------------: | -----------: |
+| {criticality_dep_nodes_seen} | {criticality_active_nodes_scored} | {criticality_duration_seconds} |

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -90,4 +90,22 @@ jobs:
         run: uv sync --frozen
 
       - name: Materialize criticality
-        run: uv run python -m pg_atlas.metrics.materialize_criticality
+        run: uv run python -m pg_atlas.metrics.materialize_criticality --tee=criticality.log
+
+      - name: Parse criticality logs
+        id: parse-criticality
+        run: python .github/scripts/parse-materialize-criticality-log.py criticality.log
+
+      - name: Write job summary
+        run: |
+          python .github/scripts/render-template.py \
+            .github/templates/bootstrap-metrics-summary.md \
+            trigger="${{ github.event_name }}" \
+            run_id="${{ github.run_id }}" \
+            server_url="${{ github.server_url }}" \
+            repository="${{ github.repository }}" \
+            finished="$(date -u '+%Y-%m-%d %H:%M:%S UTC')" \
+            criticality_dep_nodes_seen="${{ steps.parse-criticality.outputs.criticality_dep_nodes_seen || '—' }}" \
+            criticality_active_nodes_scored="${{ steps.parse-criticality.outputs.criticality_active_nodes_scored || '—' }}" \
+            criticality_duration_seconds="${{ steps.parse-criticality.outputs.criticality_duration_seconds || '—' }}" \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -89,5 +89,5 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen
 
-      - name: Materialize A9 criticality
-        run: uv run python -m pg_atlas.metrics.materialize
+      - name: Materialize criticality
+        run: uv run python -m pg_atlas.metrics.materialize_criticality

--- a/.github/workflows/gitlog-queue.yml
+++ b/.github/workflows/gitlog-queue.yml
@@ -50,6 +50,9 @@ jobs:
           PG_ATLAS_FILEBASE_ACCESS_KEY: ${{ secrets.FILEBASE_ACCESS_KEY }}
           PG_ATLAS_FILEBASE_SECRET_KEY: ${{ secrets.FILEBASE_SECRET_KEY }}
 
+      - name: Materialize pony factor
+        run: uv run python -m pg_atlas.metrics.materialize_pony --latest-seed-run
+
       - name: Parse worker logs
         id: parse-logs
         run: python .github/scripts/parse-gitlog-log.py gitlog-worker.log gh-auth-status.log

--- a/.github/workflows/gitlog-queue.yml
+++ b/.github/workflows/gitlog-queue.yml
@@ -51,11 +51,15 @@ jobs:
           PG_ATLAS_FILEBASE_SECRET_KEY: ${{ secrets.FILEBASE_SECRET_KEY }}
 
       - name: Materialize pony factor
-        run: uv run python -m pg_atlas.metrics.materialize_pony --latest-seed-run
+        run: uv run python -m pg_atlas.metrics.materialize_pony --latest-seed-run --tee=pony.log
 
       - name: Parse worker logs
         id: parse-logs
         run: python .github/scripts/parse-gitlog-log.py gitlog-worker.log gh-auth-status.log
+
+      - name: Parse pony factor logs
+        id: parse-pony
+        run: python .github/scripts/parse-materialize-pony-log.py pony.log
 
       - name: Write job summary
         run: |
@@ -77,4 +81,8 @@ jobs:
             terminal_failures_marked_private="${{ steps.parse-logs.outputs.terminal_failures_marked_private || 'none' }}" \
             gh_auth_status="${{ steps.parse-logs.outputs.gh_auth_status || 'Unavailable' }}" \
             error_detail="${{ steps.parse-logs.outputs.errors || '' }}" \
+            pony_repo_rows_updated="${{ steps.parse-pony.outputs.pony_repo_rows_updated || '—' }}" \
+            pony_project_rows_updated="${{ steps.parse-pony.outputs.pony_project_rows_updated || '—' }}" \
+            pony_resolved_seed_run_ordinal="${{ steps.parse-pony.outputs.pony_resolved_seed_run_ordinal || '—' }}" \
+            pony_duration_seconds="${{ steps.parse-pony.outputs.pony_duration_seconds || '—' }}" \
             >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sbom-queue.yml
+++ b/.github/workflows/sbom-queue.yml
@@ -39,11 +39,15 @@ jobs:
         run: uv run python -m pg_atlas.procrastinate.worker --queue=sbom --concurrency=4 --tee=sbom-worker.log
 
       - name: Materialize criticality
-        run: uv run python -m pg_atlas.metrics.materialize_criticality
+        run: uv run python -m pg_atlas.metrics.materialize_criticality --tee=criticality.log
 
       - name: Parse worker logs
         id: parse-logs
         run: python .github/scripts/parse-sbom-log.py sbom-worker.log
+
+      - name: Parse criticality logs
+        id: parse-criticality
+        run: python .github/scripts/parse-materialize-criticality-log.py criticality.log
 
       - name: Write job summary
         run: |
@@ -62,4 +66,7 @@ jobs:
             error_count="${{ steps.parse-logs.outputs.error_count || '0' }}" \
             error_detail="${{ steps.parse-logs.outputs.errors || '' }}" \
             spdx_details="${{ steps.parse-logs.outputs.spdx_details || 'No records details available.' }}" \
+            criticality_dep_nodes_seen="${{ steps.parse-criticality.outputs.criticality_dep_nodes_seen || '—' }}" \
+            criticality_active_nodes_scored="${{ steps.parse-criticality.outputs.criticality_active_nodes_scored || '—' }}" \
+            criticality_duration_seconds="${{ steps.parse-criticality.outputs.criticality_duration_seconds || '—' }}" \
             >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sbom-queue.yml
+++ b/.github/workflows/sbom-queue.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Run worker — sbom queue
         run: uv run python -m pg_atlas.procrastinate.worker --queue=sbom --concurrency=4 --tee=sbom-worker.log
 
-      - name: Materialize A9 criticality
-        run: uv run python -m pg_atlas.metrics.materialize
+      - name: Materialize criticality
+        run: uv run python -m pg_atlas.metrics.materialize_criticality
 
       - name: Parse worker logs
         id: parse-logs

--- a/pg_atlas/instruments/tee.py
+++ b/pg_atlas/instruments/tee.py
@@ -1,0 +1,130 @@
+"""
+Python-level stdout/stderr tee for GitHub Actions log capture.
+
+Use ``run_with_tee`` instead of the shell ``tee`` command.  Shell ``tee``
+masks the exit code of the command to its left (``cmd | tee file`` always
+exits 0); Python-level tee keeps the original exit code because the
+exception propagates normally.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import sys
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import TextIO, TypeAlias
+
+
+class _StreamTee(io.TextIOBase):
+    """
+    Mirror writes to an original stream and a tee file stream.
+    """
+
+    def __init__(self, primary: TextIO | io.TextIOBase, tee_file: TextIO | io.TextIOBase) -> None:
+        self._primary = primary
+        self._tee_file = tee_file
+
+    def writable(self) -> bool:
+        return self._primary.writable()
+
+    def write(self, data: str) -> int:
+        written = self._primary.write(data)
+        self._tee_file.write(data)
+
+        return written
+
+    def flush(self) -> None:
+        self._primary.flush()
+
+        try:
+            self._tee_file.flush()
+        except ValueError:
+            pass
+
+    def isatty(self) -> bool:
+        return self._primary.isatty()
+
+    def fileno(self) -> int:
+        return self._primary.fileno()
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._primary, name)
+
+
+_StreamHandlerText: TypeAlias = logging.StreamHandler[io.TextIOBase]
+_StreamHandlerPatch: TypeAlias = tuple[_StreamHandlerText, io.TextIOBase]
+
+
+def _iter_loggers() -> Iterator[logging.Logger]:
+    yield logging.root
+
+    for logger in logging.root.manager.loggerDict.values():
+        if isinstance(logger, logging.Logger):
+            yield logger
+
+
+def _patch_stream_handlers(original_stream: object, replacement: io.TextIOBase) -> list[_StreamHandlerPatch]:
+    patched: list[_StreamHandlerPatch] = []
+
+    for logger in _iter_loggers():
+        for handler in logger.handlers:
+            if not isinstance(handler, logging.StreamHandler):
+                continue
+
+            if handler.stream is original_stream:  # pyright: ignore[reportUnknownMemberType]
+                patched.append(
+                    (handler, handler.stream)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+                )
+                handler.stream = replacement
+
+    return patched
+
+
+def _restore_stream_handlers(patched_handlers: list[_StreamHandlerPatch]) -> None:
+    for handler, original_stream in patched_handlers:
+        handler.stream = original_stream
+
+
+def run_with_tee(tee_path: Path | None, run: Callable[[], None]) -> None:
+    """
+    Run a callback while optionally mirroring stdout/stderr to a file.
+
+    The original streams remain active so output still appears in GitHub
+    Actions logs while also being persisted to ``tee_path``.
+
+    Unlike shell ``tee``, exceptions raised inside ``run`` propagate
+    normally so the process exits with a non-zero code on failure.
+    """
+
+    if tee_path is None:
+        run()
+
+        return
+
+    tee_path.parent.mkdir(parents=True, exist_ok=True)
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+
+    with tee_path.open("w", encoding="utf-8") as tee_file:
+        stdout_wrapper = _StreamTee(original_stdout, tee_file)
+        stderr_wrapper = _StreamTee(original_stderr, tee_file)
+
+        sys.stdout = stdout_wrapper
+        sys.stderr = stderr_wrapper
+
+        patched_handlers: list[_StreamHandlerPatch] = []
+        patched_handlers.extend(_patch_stream_handlers(original_stdout, stdout_wrapper))
+        patched_handlers.extend(_patch_stream_handlers(original_stderr, stderr_wrapper))
+
+        try:
+            run()
+        finally:
+            sys.stdout = original_stdout
+            sys.stderr = original_stderr
+            _restore_stream_handlers(patched_handlers)
+            tee_file.flush()

--- a/pg_atlas/metrics/materialize_criticality.py
+++ b/pg_atlas/metrics/materialize_criticality.py
@@ -16,7 +16,7 @@ test transaction.
 
 Usage::
 
-    uv run python -m pg_atlas.metrics.materialize
+    uv run python -m pg_atlas.metrics.materialize_criticality
 
 SPDX-FileCopyrightText: 2026 PG Atlas contributors
 SPDX-License-Identifier: MPL-2.0

--- a/pg_atlas/metrics/materialize_criticality.py
+++ b/pg_atlas/metrics/materialize_criticality.py
@@ -17,6 +17,7 @@ test transaction.
 Usage::
 
     uv run python -m pg_atlas.metrics.materialize_criticality
+    uv run python -m pg_atlas.metrics.materialize_criticality --tee=criticality.log
 
 SPDX-FileCopyrightText: 2026 PG Atlas contributors
 SPDX-License-Identifier: MPL-2.0
@@ -24,10 +25,12 @@ SPDX-License-Identifier: MPL-2.0
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import logging
 import time
 from dataclasses import dataclass
+from pathlib import Path
 
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -35,10 +38,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from pg_atlas.db_models.project import Project
 from pg_atlas.db_models.repo_vertex import ExternalRepo, Repo
 from pg_atlas.db_models.session import get_session_factory
+from pg_atlas.instruments.tee import run_with_tee
 from pg_atlas.metrics.active_subgraph import project_active_subgraph
 from pg_atlas.metrics.criticality import compute_criticality
 from pg_atlas.metrics.graph_builder import build_dependency_graph
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+)
 logger = logging.getLogger(__name__)
 
 
@@ -149,11 +157,6 @@ async def main() -> None:
     Run one offline A9 materialization pass and commit the results.
     """
 
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
-    )
-
     factory = get_session_factory()
     async with factory() as session:
         stats = await materialize_criticality_scores(session)
@@ -167,5 +170,34 @@ async def main() -> None:
     )
 
 
+def _build_parser() -> argparse.ArgumentParser:
+    """
+    Build the CLI parser for criticality materialization.
+    """
+
+    parser = argparse.ArgumentParser(description="Materialize repo/project criticality scores.")
+    parser.add_argument(
+        "--tee",
+        type=Path,
+        default=None,
+        help="Optional path to mirror stdout/stderr logs while preserving console output.",
+    )
+
+    return parser
+
+
+def entrypoint() -> None:
+    """
+    Parse CLI arguments and run the materialization pass.
+    """
+
+    args = _build_parser().parse_args()
+
+    def _run() -> None:
+        asyncio.run(main())
+
+    run_with_tee(args.tee, _run)
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    entrypoint()

--- a/pg_atlas/metrics/materialize_pony.py
+++ b/pg_atlas/metrics/materialize_pony.py
@@ -6,6 +6,7 @@ Usage::
     uv run python -m pg_atlas.metrics.materialize_pony
     uv run python -m pg_atlas.metrics.materialize_pony --latest-seed-run
     uv run python -m pg_atlas.metrics.materialize_pony --seed-run-ordinal 7
+    uv run python -m pg_atlas.metrics.materialize_pony --latest-seed-run --tee=pony.log
 
 SPDX-FileCopyrightText: 2026 PG Atlas contributors
 SPDX-License-Identifier: MPL-2.0
@@ -19,6 +20,7 @@ import logging
 import time
 from collections import defaultdict
 from dataclasses import dataclass
+from pathlib import Path
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -29,8 +31,13 @@ from pg_atlas.db_models.gitlog_artifact import GitLogArtifact
 from pg_atlas.db_models.project import Project
 from pg_atlas.db_models.repo_vertex import Repo
 from pg_atlas.db_models.session import get_session_factory
+from pg_atlas.instruments.tee import run_with_tee
 from pg_atlas.metrics.pony_factor import compute_pony_factor
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+)
 logger = logging.getLogger(__name__)
 
 
@@ -62,6 +69,12 @@ def _build_parser() -> argparse.ArgumentParser:
         "--seed-run-ordinal",
         type=int,
         help="Recompute only repos included in the given gitlog seed run ordinal and their projects.",
+    )
+    parser.add_argument(
+        "--tee",
+        type=Path,
+        default=None,
+        help="Optional path to mirror stdout/stderr logs while preserving console output.",
     )
 
     return parser
@@ -261,17 +274,10 @@ async def materialize_pony_factor_scores(
     return stats
 
 
-async def main() -> None:
+async def _async_main(args: argparse.Namespace) -> None:
     """
     Run one offline pony-factor materialization pass and commit the results.
     """
-
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
-    )
-
-    args = _build_parser().parse_args()
 
     factory = get_session_factory()
     async with factory() as session:
@@ -291,5 +297,18 @@ async def main() -> None:
     )
 
 
+def main() -> None:
+    """
+    Parse CLI arguments and run the materialization pass.
+    """
+
+    args = _build_parser().parse_args()
+
+    def _run() -> None:
+        asyncio.run(_async_main(args))
+
+    run_with_tee(args.tee, _run)
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/pg_atlas/metrics/materialize_pony.py
+++ b/pg_atlas/metrics/materialize_pony.py
@@ -1,0 +1,295 @@
+"""
+Pony-factor materialization from git log contributor edges.
+
+Usage::
+
+    uv run python -m pg_atlas.metrics.materialize_pony
+    uv run python -m pg_atlas.metrics.materialize_pony --latest-seed-run
+    uv run python -m pg_atlas.metrics.materialize_pony --seed-run-ordinal 7
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from pg_atlas.db_models.contributed_to import ContributedTo
+from pg_atlas.db_models.contributor import Contributor
+from pg_atlas.db_models.gitlog_artifact import GitLogArtifact
+from pg_atlas.db_models.project import Project
+from pg_atlas.db_models.repo_vertex import Repo
+from pg_atlas.db_models.session import get_session_factory
+from pg_atlas.metrics.pony_factor import compute_pony_factor
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PonyFactorMaterializationStats:
+    """
+    Summarize one pony-factor materialization pass.
+    """
+
+    repo_rows_updated: int
+    project_rows_updated: int
+    resolved_seed_run_ordinal: int | None
+    duration_seconds: float
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """
+    Build the CLI parser for pony-factor materialization.
+    """
+
+    parser = argparse.ArgumentParser(description="Materialize repo/project pony factor from gitlog artifacts.")
+    scope = parser.add_mutually_exclusive_group()
+    scope.add_argument(
+        "--latest-seed-run",
+        action="store_true",
+        help="Recompute only repos included in the latest gitlog seed run and their projects.",
+    )
+    scope.add_argument(
+        "--seed-run-ordinal",
+        type=int,
+        help="Recompute only repos included in the given gitlog seed run ordinal and their projects.",
+    )
+
+    return parser
+
+
+async def _resolve_target_repo_ids(
+    session: AsyncSession,
+    *,
+    latest_seed_run: bool,
+    seed_run_ordinal: int | None,
+) -> tuple[list[int], int | None]:
+    """
+    Resolve repo ids for the selected materialization scope.
+    """
+
+    if latest_seed_run:
+        resolved_seed_run_ordinal = await session.scalar(select(func.max(GitLogArtifact.seed_run_ordinal)))
+        if resolved_seed_run_ordinal is None:
+            return [], None
+
+        stmt = (
+            select(GitLogArtifact.repo_id)
+            .where(GitLogArtifact.seed_run_ordinal == resolved_seed_run_ordinal)
+            .distinct()
+            .order_by(GitLogArtifact.repo_id)
+        )
+        repo_ids = [int(repo_id) for repo_id in (await session.execute(stmt)).scalars().all()]
+
+        return repo_ids, int(resolved_seed_run_ordinal)
+
+    if seed_run_ordinal is not None:
+        stmt = (
+            select(GitLogArtifact.repo_id)
+            .where(GitLogArtifact.seed_run_ordinal == seed_run_ordinal)
+            .distinct()
+            .order_by(GitLogArtifact.repo_id)
+        )
+        repo_ids = [int(repo_id) for repo_id in (await session.execute(stmt)).scalars().all()]
+
+        return repo_ids, seed_run_ordinal
+
+    stmt = select(Repo.id).order_by(Repo.id)
+    repo_ids = [int(repo_id) for repo_id in (await session.execute(stmt)).scalars().all()]
+
+    return repo_ids, None
+
+
+async def _load_repo_email_commit_counts(
+    session: AsyncSession,
+    repo_ids: list[int],
+) -> dict[int, dict[str, int]]:
+    """
+    Return commit counts grouped by repo id and contributor email hash.
+    """
+
+    if not repo_ids:
+        return {}
+
+    stmt = (
+        select(ContributedTo.repo_id, Contributor.email_hash, ContributedTo.number_of_commits)
+        .select_from(ContributedTo)
+        .join(Contributor, Contributor.id == ContributedTo.contributor_id)
+        .where(ContributedTo.repo_id.in_(repo_ids))
+    )
+    rows = list((await session.execute(stmt)).all())
+
+    repo_counts: defaultdict[int, defaultdict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for repo_id, email_hash, commit_count in rows:
+        repo_counts[int(repo_id)][str(email_hash)] += int(commit_count)
+
+    return {repo_id: dict(counts_by_email) for repo_id, counts_by_email in repo_counts.items()}
+
+
+async def _load_project_repo_membership(
+    session: AsyncSession,
+    *,
+    full_recompute: bool,
+    target_repo_ids: list[int],
+) -> tuple[list[Project], dict[int, list[int]]]:
+    """
+    Return affected projects and their child repo ids.
+    """
+
+    if full_recompute:
+        projects = list((await session.execute(select(Project).order_by(Project.id))).scalars().all())
+        membership_rows = (await session.execute(select(Repo.id, Repo.project_id).where(Repo.project_id.is_not(None)))).all()
+    else:
+        if not target_repo_ids:
+            return [], {}
+
+        project_ids = (
+            (
+                await session.execute(
+                    select(Repo.project_id)
+                    .where(Repo.id.in_(target_repo_ids))
+                    .where(Repo.project_id.is_not(None))
+                    .distinct()
+                    .order_by(Repo.project_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        affected_project_ids = [int(project_id) for project_id in project_ids if project_id is not None]
+        if not affected_project_ids:
+            return [], {}
+
+        projects = list(
+            (await session.execute(select(Project).where(Project.id.in_(affected_project_ids)).order_by(Project.id)))
+            .scalars()
+            .all()
+        )
+        membership_rows = (
+            await session.execute(select(Repo.id, Repo.project_id).where(Repo.project_id.in_(affected_project_ids)))
+        ).all()
+
+    repos_by_project: defaultdict[int, list[int]] = defaultdict(list)
+    for repo_id, project_id in membership_rows:
+        if project_id is None:
+            continue
+
+        repos_by_project[int(project_id)].append(int(repo_id))
+
+    return projects, dict(repos_by_project)
+
+
+async def materialize_pony_factor_scores(
+    session: AsyncSession,
+    *,
+    latest_seed_run: bool = False,
+    seed_run_ordinal: int | None = None,
+) -> PonyFactorMaterializationStats:
+    """
+    Recompute and persist pony factor on Repo and Project rows within one session.
+
+    The session is mutated and flushed, but not committed.
+    """
+
+    if latest_seed_run and seed_run_ordinal is not None:
+        raise ValueError("latest_seed_run and seed_run_ordinal are mutually exclusive")
+
+    started_at = time.perf_counter()
+    full_recompute = not latest_seed_run and seed_run_ordinal is None
+    target_repo_ids, resolved_seed_run_ordinal = await _resolve_target_repo_ids(
+        session,
+        latest_seed_run=latest_seed_run,
+        seed_run_ordinal=seed_run_ordinal,
+    )
+
+    target_repos = list(
+        (await session.execute(select(Repo).where(Repo.id.in_(target_repo_ids)).order_by(Repo.id))).scalars().all()
+    )
+    repo_counts = await _load_repo_email_commit_counts(session, target_repo_ids)
+    for repo in target_repos:
+        counts_by_email = repo_counts.get(repo.id, {})
+        repo.pony_factor = compute_pony_factor(counts_by_email.values())
+
+    projects, repos_by_project = await _load_project_repo_membership(
+        session,
+        full_recompute=full_recompute,
+        target_repo_ids=target_repo_ids,
+    )
+    project_repo_ids = sorted({repo_id for repo_ids in repos_by_project.values() for repo_id in repo_ids})
+    project_repo_counts = await _load_repo_email_commit_counts(session, project_repo_ids)
+
+    for project in projects:
+        repo_ids = repos_by_project.get(project.id, [])
+        if not repo_ids:
+            project.pony_factor = None
+            continue
+
+        project_counts_by_email: defaultdict[str, int] = defaultdict(int)
+        for repo_id in repo_ids:
+            for email_hash, commit_count in project_repo_counts.get(repo_id, {}).items():
+                project_counts_by_email[email_hash] += commit_count
+
+        project.pony_factor = compute_pony_factor(project_counts_by_email.values())
+
+    await session.flush()
+
+    duration_seconds = time.perf_counter() - started_at
+    stats = PonyFactorMaterializationStats(
+        repo_rows_updated=len(target_repos),
+        project_rows_updated=len(projects),
+        resolved_seed_run_ordinal=resolved_seed_run_ordinal,
+        duration_seconds=duration_seconds,
+    )
+
+    logger.info(
+        "materialize_pony_factor_scores: "
+        f"repo_rows_updated={stats.repo_rows_updated} "
+        f"project_rows_updated={stats.project_rows_updated} "
+        f"resolved_seed_run_ordinal={stats.resolved_seed_run_ordinal} "
+        f"duration_seconds={stats.duration_seconds:.3f}"
+    )
+
+    return stats
+
+
+async def main() -> None:
+    """
+    Run one offline pony-factor materialization pass and commit the results.
+    """
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+    )
+
+    args = _build_parser().parse_args()
+
+    factory = get_session_factory()
+    async with factory() as session:
+        stats = await materialize_pony_factor_scores(
+            session,
+            latest_seed_run=args.latest_seed_run,
+            seed_run_ordinal=args.seed_run_ordinal,
+        )
+        await session.commit()
+
+    logger.info(
+        "Pony-factor materialization finished: "
+        f"repo_rows_updated={stats.repo_rows_updated} "
+        f"project_rows_updated={stats.project_rows_updated} "
+        f"resolved_seed_run_ordinal={stats.resolved_seed_run_ordinal} "
+        f"duration_seconds={stats.duration_seconds:.3f}"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pg_atlas/metrics/pony_factor.py
+++ b/pg_atlas/metrics/pony_factor.py
@@ -1,0 +1,42 @@
+"""
+Pony-factor computation helpers.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from pg_atlas.metrics.config import METRICS_CONFIG
+
+
+def compute_pony_factor(
+    commit_counts: Iterable[int],
+    *,
+    threshold_share: float = METRICS_CONFIG.pony_factor_threshold,
+) -> int:
+    """
+    Return the minimum number of contributors responsible for the threshold share of commits.
+
+    ``commit_counts`` may be in any order. Zero and negative values are ignored.
+    A repo or project with no positive commit counts receives pony factor ``0``.
+    """
+
+    if threshold_share <= 0.0 or threshold_share > 1.0:
+        raise ValueError(f"threshold_share must be within (0, 1], got {threshold_share}")
+
+    sorted_counts = sorted((count for count in commit_counts if count > 0), reverse=True)
+    total_commits = sum(sorted_counts)
+    if total_commits <= 0:
+        return 0
+
+    cutoff = float(total_commits) * threshold_share
+    cumulative = 0
+    for contributor_count, commit_count in enumerate(sorted_counts, start=1):
+        cumulative += commit_count
+        if float(cumulative) >= cutoff:
+            return contributor_count
+
+    return len(sorted_counts)

--- a/pg_atlas/procrastinate/worker.py
+++ b/pg_atlas/procrastinate/worker.py
@@ -24,16 +24,14 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import io
 import logging
-import sys
 from collections import Counter
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Iterable
 from pathlib import Path
-from typing import TextIO, TypeAlias
 
 import psycopg
 
+from pg_atlas.instruments.tee import run_with_tee
 from pg_atlas.procrastinate.app import app, get_database_url, mark_stalled_jobs_failed
 
 logging.basicConfig(
@@ -41,112 +39,6 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
 )
 logger = logging.getLogger(__name__)
-
-
-class _StreamTee(io.TextIOBase):
-    """
-    Mirror writes to an original stream and a tee file stream.
-    """
-
-    def __init__(self, primary: TextIO | io.TextIOBase, tee_file: TextIO | io.TextIOBase) -> None:
-        self._primary = primary
-        self._tee_file = tee_file
-
-    def writable(self) -> bool:
-        return self._primary.writable()
-
-    def write(self, data: str) -> int:
-        written = self._primary.write(data)
-        self._tee_file.write(data)
-
-        return written
-
-    def flush(self) -> None:
-        self._primary.flush()
-
-        try:
-            self._tee_file.flush()
-        except ValueError:
-            pass
-
-    def isatty(self) -> bool:
-        return self._primary.isatty()
-
-    def fileno(self) -> int:
-        return self._primary.fileno()
-
-    def __getattr__(self, name: str) -> object:
-        return getattr(self._primary, name)
-
-
-StreamHandlerText: TypeAlias = logging.StreamHandler[io.TextIOBase]
-StreamHandlerPatch: TypeAlias = tuple[StreamHandlerText, io.TextIOBase]
-
-
-def _iter_loggers() -> Iterator[logging.Logger]:
-    yield logging.root
-
-    for logger in logging.root.manager.loggerDict.values():
-        if isinstance(logger, logging.Logger):
-            yield logger
-
-
-def _patch_stream_handlers(original_stream: object, replacement: io.TextIOBase) -> list[StreamHandlerPatch]:
-    patched: list[StreamHandlerPatch] = []
-
-    for logger in _iter_loggers():
-        for handler in logger.handlers:
-            if not isinstance(handler, logging.StreamHandler):
-                continue
-
-            if handler.stream is original_stream:  # pyright: ignore[reportUnknownMemberType]
-                patched.append(
-                    (handler, handler.stream)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
-                )
-                handler.stream = replacement
-
-    return patched
-
-
-def _restore_stream_handlers(patched_handlers: list[StreamHandlerPatch]) -> None:
-    for handler, original_stream in patched_handlers:
-        handler.stream = original_stream
-
-
-def _run_with_optional_tee(tee_path: Path | None, run: Callable[[], None]) -> None:
-    """
-    Run a callback while optionally mirroring stdout/stderr to a file.
-
-    The original streams remain active so output still appears in GitHub
-    Actions logs while also being persisted to ``tee_path``.
-    """
-    if tee_path is None:
-        run()
-
-        return
-
-    tee_path.parent.mkdir(parents=True, exist_ok=True)
-    original_stdout = sys.stdout
-    original_stderr = sys.stderr
-
-    with tee_path.open("w", encoding="utf-8") as tee_file:
-        stdout_wrapper = _StreamTee(original_stdout, tee_file)
-        stderr_wrapper = _StreamTee(original_stderr, tee_file)
-
-        sys.stdout = stdout_wrapper
-        sys.stderr = stderr_wrapper
-
-        patched_handlers: list[StreamHandlerPatch] = []
-        patched_handlers.extend(_patch_stream_handlers(original_stdout, stdout_wrapper))
-        patched_handlers.extend(_patch_stream_handlers(original_stderr, stderr_wrapper))
-
-        try:
-            run()
-        finally:
-            sys.stdout = original_stdout
-            sys.stderr = original_stderr
-            _restore_stream_handlers(patched_handlers)
-            tee_file.flush()
 
 
 def _queue_status_counts(queue_name: str) -> Counter[str]:
@@ -335,7 +227,7 @@ def main() -> None:
             )
         )
 
-    _run_with_optional_tee(args.tee, _run_worker)
+    run_with_tee(args.tee, _run_worker)
 
 
 if __name__ == "__main__":

--- a/tests/metrics/test_materialize_criticality.py
+++ b/tests/metrics/test_materialize_criticality.py
@@ -20,7 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from pg_atlas.db_models import DependsOn, ExternalRepo, Project, Repo
 from pg_atlas.db_models.base import ActivityStatus, EdgeConfidence, ProjectType, Visibility
-from pg_atlas.metrics.materialize import CriticalityMaterializationStats, materialize_criticality_scores
+from pg_atlas.metrics.materialize_criticality import CriticalityMaterializationStats, materialize_criticality_scores
 
 
 @dataclass(frozen=True)

--- a/tests/metrics/test_materialize_pony.py
+++ b/tests/metrics/test_materialize_pony.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from pg_atlas.db_models import ContributedTo, Contributor, GitLogArtifact, Project, Repo
@@ -35,6 +36,8 @@ class SeededPonyFixture:
     repo_a2_id: int
     repo_b1_id: int
     repo_g1_id: int
+    seed_run_ordinal_lower: int
+    seed_run_ordinal_upper: int
 
 
 @pytest.fixture
@@ -67,6 +70,25 @@ async def _seed_pony_component(session: AsyncSession) -> SeededPonyFixture:
     """
 
     suffix = uuid4().hex[:8]
+
+    # Choose ordinals above any existing data so MAX() resolution is predictable.
+    current_max: int = int(await session.scalar(select(func.max(GitLogArtifact.seed_run_ordinal))) or 0)
+    ordinal_lower = current_max + 1
+    ordinal_upper = current_max + 2
+
+    # Guard: verify that neither ordinal is already in use.
+    existing = (
+        await session.execute(
+            select(GitLogArtifact.seed_run_ordinal)
+            .where(GitLogArtifact.seed_run_ordinal.in_([ordinal_lower, ordinal_upper]))
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise RuntimeError(
+            f"seed_run_ordinal collision: ordinal {existing} is already in use. "
+            "Cannot seed test data without causing downstream assertion failures."
+        )
 
     alpha_project = Project(
         canonical_id=f"daoip-5:stellar:project:alpha-{suffix}",
@@ -197,19 +219,19 @@ async def _seed_pony_component(session: AsyncSession) -> SeededPonyFixture:
             GitLogArtifact(
                 repo_id=repo_a1.id,
                 since_months=12,
-                seed_run_ordinal=1,
+                seed_run_ordinal=ordinal_lower,
                 status=SubmissionStatus.processed,
             ),
             GitLogArtifact(
                 repo_id=repo_g1.id,
                 since_months=12,
-                seed_run_ordinal=1,
+                seed_run_ordinal=ordinal_lower,
                 status=SubmissionStatus.processed,
             ),
             GitLogArtifact(
                 repo_id=repo_b1.id,
                 since_months=12,
-                seed_run_ordinal=2,
+                seed_run_ordinal=ordinal_upper,
                 status=SubmissionStatus.processed,
             ),
         ]
@@ -225,6 +247,8 @@ async def _seed_pony_component(session: AsyncSession) -> SeededPonyFixture:
         repo_a2_id=repo_a2.id,
         repo_b1_id=repo_b1.id,
         repo_g1_id=repo_g1.id,
+        seed_run_ordinal_lower=ordinal_lower,
+        seed_run_ordinal_upper=ordinal_upper,
     )
 
 
@@ -319,7 +343,7 @@ async def test_materialize_pony_factor_scores_latest_seed_run_limits_updates(
 
     stats = await materialize_pony_factor_scores(rollback_db_session, latest_seed_run=True)
 
-    assert stats.resolved_seed_run_ordinal == 2
+    assert stats.resolved_seed_run_ordinal == seeded.seed_run_ordinal_upper
     assert stats.repo_rows_updated == 1
     assert stats.project_rows_updated == 1
 
@@ -349,9 +373,9 @@ async def test_materialize_pony_factor_scores_explicit_seed_run_recomputes_affec
 
     seeded = await _seed_pony_component(rollback_db_session)
 
-    stats = await materialize_pony_factor_scores(rollback_db_session, seed_run_ordinal=1)
+    stats = await materialize_pony_factor_scores(rollback_db_session, seed_run_ordinal=seeded.seed_run_ordinal_lower)
 
-    assert stats.resolved_seed_run_ordinal == 1
+    assert stats.resolved_seed_run_ordinal == seeded.seed_run_ordinal_lower
     assert stats.repo_rows_updated == 2
     assert stats.project_rows_updated == 2
 

--- a/tests/metrics/test_materialize_pony.py
+++ b/tests/metrics/test_materialize_pony.py
@@ -1,0 +1,372 @@
+"""
+DB-backed tests for pony-factor materialization.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from pg_atlas.db_models import ContributedTo, Contributor, GitLogArtifact, Project, Repo
+from pg_atlas.db_models.base import ActivityStatus, ProjectType, SubmissionStatus, Visibility
+from pg_atlas.gitlog.parser import hash_email
+from pg_atlas.metrics.materialize_pony import PonyFactorMaterializationStats, materialize_pony_factor_scores
+
+
+@dataclass(frozen=True)
+class SeededPonyFixture:
+    """
+    Hold the row ids for one deterministic pony-factor component.
+    """
+
+    alpha_project_id: int
+    beta_project_id: int
+    gamma_project_id: int
+    empty_project_id: int
+    repo_a1_id: int
+    repo_a2_id: int
+    repo_b1_id: int
+    repo_g1_id: int
+
+
+@pytest.fixture
+async def rollback_db_session(db_session: AsyncSession) -> AsyncGenerator[AsyncSession, None]:
+    """
+    Run each pony-factor test inside a transaction that is rolled back.
+    """
+
+    transaction = await db_session.begin()
+    try:
+        yield db_session
+    finally:
+        if transaction.is_active:
+            await transaction.rollback()
+
+
+async def _seed_pony_component(session: AsyncSession) -> SeededPonyFixture:
+    """
+    Insert repos, contributors, and gitlog artifacts with deterministic outcomes.
+
+    Expected full recompute results:
+    - repo_a1 = 1  (shared=3, bob=2)
+    - repo_a2 = 1  (carol=5, shared=2)
+    - repo_b1 = 1  (dave=4, erin=4)
+    - repo_g1 = 0  (no contributor edges)
+    - project alpha = 2  (shared=5, carol=5, bob=2)
+    - project beta = 1
+    - project gamma = 0
+    - empty project = NULL
+    """
+
+    suffix = uuid4().hex[:8]
+
+    alpha_project = Project(
+        canonical_id=f"daoip-5:stellar:project:alpha-{suffix}",
+        display_name=f"Alpha Project {suffix}",
+        project_type=ProjectType.scf_project,
+        activity_status=ActivityStatus.live,
+        pony_factor=99,
+    )
+    beta_project = Project(
+        canonical_id=f"daoip-5:stellar:project:beta-{suffix}",
+        display_name=f"Beta Project {suffix}",
+        project_type=ProjectType.scf_project,
+        activity_status=ActivityStatus.live,
+        pony_factor=99,
+    )
+    gamma_project = Project(
+        canonical_id=f"daoip-5:stellar:project:gamma-{suffix}",
+        display_name=f"Gamma Project {suffix}",
+        project_type=ProjectType.scf_project,
+        activity_status=ActivityStatus.live,
+        pony_factor=99,
+    )
+    empty_project = Project(
+        canonical_id=f"daoip-5:stellar:project:empty-{suffix}",
+        display_name=f"Empty Project {suffix}",
+        project_type=ProjectType.scf_project,
+        activity_status=ActivityStatus.live,
+        pony_factor=99,
+    )
+    session.add_all([alpha_project, beta_project, gamma_project, empty_project])
+    await session.flush()
+
+    repo_a1 = Repo(
+        canonical_id=f"pkg:github/test/alpha-a1-{suffix}",
+        display_name=f"alpha-a1-{suffix}",
+        visibility=Visibility.public,
+        latest_version="1.0.0",
+        project_id=alpha_project.id,
+        pony_factor=99,
+    )
+    repo_a2 = Repo(
+        canonical_id=f"pkg:github/test/alpha-a2-{suffix}",
+        display_name=f"alpha-a2-{suffix}",
+        visibility=Visibility.public,
+        latest_version="1.0.0",
+        project_id=alpha_project.id,
+        pony_factor=99,
+    )
+    repo_b1 = Repo(
+        canonical_id=f"pkg:github/test/beta-b1-{suffix}",
+        display_name=f"beta-b1-{suffix}",
+        visibility=Visibility.public,
+        latest_version="1.0.0",
+        project_id=beta_project.id,
+        pony_factor=99,
+    )
+    repo_g1 = Repo(
+        canonical_id=f"pkg:github/test/gamma-g1-{suffix}",
+        display_name=f"gamma-g1-{suffix}",
+        visibility=Visibility.public,
+        latest_version="1.0.0",
+        project_id=gamma_project.id,
+        pony_factor=99,
+    )
+    session.add_all([repo_a1, repo_a2, repo_b1, repo_g1])
+    await session.flush()
+
+    contributors = [
+        Contributor(email_hash=hash_email("shared@example.com"), name="Shared Dev"),
+        Contributor(email_hash=hash_email("bob@example.com"), name="Bob"),
+        Contributor(email_hash=hash_email("carol@example.com"), name="Carol"),
+        Contributor(email_hash=hash_email("dave@example.com"), name="Dave"),
+        Contributor(email_hash=hash_email("erin@example.com"), name="Erin"),
+    ]
+    session.add_all(contributors)
+    await session.flush()
+
+    shared, bob, carol, dave, erin = contributors
+    session.add_all(
+        [
+            ContributedTo(
+                contributor_id=shared.id,
+                repo_id=repo_a1.id,
+                number_of_commits=3,
+                first_commit_date=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+                last_commit_date=dt.datetime(2025, 6, 1, tzinfo=dt.UTC),
+            ),
+            ContributedTo(
+                contributor_id=bob.id,
+                repo_id=repo_a1.id,
+                number_of_commits=2,
+                first_commit_date=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+                last_commit_date=dt.datetime(2025, 6, 1, tzinfo=dt.UTC),
+            ),
+            ContributedTo(
+                contributor_id=carol.id,
+                repo_id=repo_a2.id,
+                number_of_commits=5,
+                first_commit_date=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+                last_commit_date=dt.datetime(2025, 6, 1, tzinfo=dt.UTC),
+            ),
+            ContributedTo(
+                contributor_id=shared.id,
+                repo_id=repo_a2.id,
+                number_of_commits=2,
+                first_commit_date=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+                last_commit_date=dt.datetime(2025, 6, 1, tzinfo=dt.UTC),
+            ),
+            ContributedTo(
+                contributor_id=dave.id,
+                repo_id=repo_b1.id,
+                number_of_commits=4,
+                first_commit_date=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+                last_commit_date=dt.datetime(2025, 6, 1, tzinfo=dt.UTC),
+            ),
+            ContributedTo(
+                contributor_id=erin.id,
+                repo_id=repo_b1.id,
+                number_of_commits=4,
+                first_commit_date=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+                last_commit_date=dt.datetime(2025, 6, 1, tzinfo=dt.UTC),
+            ),
+        ]
+    )
+
+    session.add_all(
+        [
+            GitLogArtifact(
+                repo_id=repo_a1.id,
+                since_months=12,
+                seed_run_ordinal=1,
+                status=SubmissionStatus.processed,
+            ),
+            GitLogArtifact(
+                repo_id=repo_g1.id,
+                since_months=12,
+                seed_run_ordinal=1,
+                status=SubmissionStatus.processed,
+            ),
+            GitLogArtifact(
+                repo_id=repo_b1.id,
+                since_months=12,
+                seed_run_ordinal=2,
+                status=SubmissionStatus.processed,
+            ),
+        ]
+    )
+    await session.flush()
+
+    return SeededPonyFixture(
+        alpha_project_id=alpha_project.id,
+        beta_project_id=beta_project.id,
+        gamma_project_id=gamma_project.id,
+        empty_project_id=empty_project.id,
+        repo_a1_id=repo_a1.id,
+        repo_a2_id=repo_a2.id,
+        repo_b1_id=repo_b1.id,
+        repo_g1_id=repo_g1.id,
+    )
+
+
+async def _get_repo(session: AsyncSession, repo_id: int) -> Repo:
+    """
+    Load one Repo row and assert it exists.
+    """
+
+    repo = await session.get(Repo, repo_id)
+    assert repo is not None
+
+    return repo
+
+
+async def _get_project(session: AsyncSession, project_id: int) -> Project:
+    """
+    Load one Project row and assert it exists.
+    """
+
+    project = await session.get(Project, project_id)
+    assert project is not None
+
+    return project
+
+
+async def test_materialize_pony_factor_scores_persists_repo_and_project_scores(
+    rollback_db_session: AsyncSession,
+) -> None:
+    """
+    Full recompute must persist repo and project pony factors.
+    """
+
+    seeded = await _seed_pony_component(rollback_db_session)
+
+    stats = await materialize_pony_factor_scores(rollback_db_session)
+
+    assert isinstance(stats, PonyFactorMaterializationStats)
+    assert stats.resolved_seed_run_ordinal is None
+    assert stats.repo_rows_updated >= 4
+    assert stats.project_rows_updated >= 4
+
+    repo_a1 = await _get_repo(rollback_db_session, seeded.repo_a1_id)
+    repo_a2 = await _get_repo(rollback_db_session, seeded.repo_a2_id)
+    repo_b1 = await _get_repo(rollback_db_session, seeded.repo_b1_id)
+    repo_g1 = await _get_repo(rollback_db_session, seeded.repo_g1_id)
+
+    assert repo_a1.pony_factor == 1
+    assert repo_a2.pony_factor == 1
+    assert repo_b1.pony_factor == 1
+    assert repo_g1.pony_factor == 0
+
+    alpha_project = await _get_project(rollback_db_session, seeded.alpha_project_id)
+    beta_project = await _get_project(rollback_db_session, seeded.beta_project_id)
+    gamma_project = await _get_project(rollback_db_session, seeded.gamma_project_id)
+    empty_project = await _get_project(rollback_db_session, seeded.empty_project_id)
+
+    assert alpha_project.pony_factor == 2
+    assert beta_project.pony_factor == 1
+    assert gamma_project.pony_factor == 0
+    assert empty_project.pony_factor is None
+
+
+async def test_materialize_pony_factor_scores_is_idempotent(
+    rollback_db_session: AsyncSession,
+) -> None:
+    """
+    Re-running the same full recompute must preserve the same values.
+    """
+
+    seeded = await _seed_pony_component(rollback_db_session)
+
+    first_stats = await materialize_pony_factor_scores(rollback_db_session)
+    second_stats = await materialize_pony_factor_scores(rollback_db_session)
+
+    assert first_stats.repo_rows_updated == second_stats.repo_rows_updated
+    assert first_stats.project_rows_updated == second_stats.project_rows_updated
+
+    alpha_project = await _get_project(rollback_db_session, seeded.alpha_project_id)
+    gamma_project = await _get_project(rollback_db_session, seeded.gamma_project_id)
+    assert alpha_project.pony_factor == 2
+    assert gamma_project.pony_factor == 0
+
+
+async def test_materialize_pony_factor_scores_latest_seed_run_limits_updates(
+    rollback_db_session: AsyncSession,
+) -> None:
+    """
+    Latest-seed-run recompute must touch only repos in the latest seed run and their projects.
+    """
+
+    seeded = await _seed_pony_component(rollback_db_session)
+
+    stats = await materialize_pony_factor_scores(rollback_db_session, latest_seed_run=True)
+
+    assert stats.resolved_seed_run_ordinal == 2
+    assert stats.repo_rows_updated == 1
+    assert stats.project_rows_updated == 1
+
+    repo_a1 = await _get_repo(rollback_db_session, seeded.repo_a1_id)
+    repo_a2 = await _get_repo(rollback_db_session, seeded.repo_a2_id)
+    repo_b1 = await _get_repo(rollback_db_session, seeded.repo_b1_id)
+    repo_g1 = await _get_repo(rollback_db_session, seeded.repo_g1_id)
+    alpha_project = await _get_project(rollback_db_session, seeded.alpha_project_id)
+    beta_project = await _get_project(rollback_db_session, seeded.beta_project_id)
+    gamma_project = await _get_project(rollback_db_session, seeded.gamma_project_id)
+
+    assert repo_a1.pony_factor == 99
+    assert repo_a2.pony_factor == 99
+    assert repo_b1.pony_factor == 1
+    assert repo_g1.pony_factor == 99
+    assert alpha_project.pony_factor == 99
+    assert beta_project.pony_factor == 1
+    assert gamma_project.pony_factor == 99
+
+
+async def test_materialize_pony_factor_scores_explicit_seed_run_recomputes_affected_project(
+    rollback_db_session: AsyncSession,
+) -> None:
+    """
+    Explicit seed-run recompute must update affected projects from contributor edges, not repo rows.
+    """
+
+    seeded = await _seed_pony_component(rollback_db_session)
+
+    stats = await materialize_pony_factor_scores(rollback_db_session, seed_run_ordinal=1)
+
+    assert stats.resolved_seed_run_ordinal == 1
+    assert stats.repo_rows_updated == 2
+    assert stats.project_rows_updated == 2
+
+    repo_a1 = await _get_repo(rollback_db_session, seeded.repo_a1_id)
+    repo_a2 = await _get_repo(rollback_db_session, seeded.repo_a2_id)
+    repo_b1 = await _get_repo(rollback_db_session, seeded.repo_b1_id)
+    repo_g1 = await _get_repo(rollback_db_session, seeded.repo_g1_id)
+    alpha_project = await _get_project(rollback_db_session, seeded.alpha_project_id)
+    beta_project = await _get_project(rollback_db_session, seeded.beta_project_id)
+    gamma_project = await _get_project(rollback_db_session, seeded.gamma_project_id)
+
+    assert repo_a1.pony_factor == 1
+    assert repo_a2.pony_factor == 99
+    assert repo_b1.pony_factor == 99
+    assert repo_g1.pony_factor == 0
+    assert alpha_project.pony_factor == 2
+    assert beta_project.pony_factor == 99
+    assert gamma_project.pony_factor == 0

--- a/tests/metrics/test_metrics_pony_factor.py
+++ b/tests/metrics/test_metrics_pony_factor.py
@@ -1,0 +1,31 @@
+"""
+Unit tests for pg_atlas.metrics.pony_factor.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+from pg_atlas.metrics.pony_factor import compute_pony_factor
+
+
+def test_single_contributor_has_pony_factor_one() -> None:
+    assert compute_pony_factor([100]) == 1
+
+
+def test_exact_half_of_commits_counts_toward_threshold() -> None:
+    assert compute_pony_factor([5, 5]) == 1
+
+
+def test_equal_ten_contributors_require_five_people() -> None:
+    assert compute_pony_factor([1, 1, 1, 1, 1, 1, 1, 1, 1, 1]) == 5
+
+
+def test_majority_contributor_can_determine_pony_factor_alone() -> None:
+    assert compute_pony_factor([5, 60, 5, 5, 5, 5, 5, 5, 5, 5]) == 1
+
+
+def test_empty_or_zero_commit_distributions_return_zero() -> None:
+    assert compute_pony_factor([]) == 0
+    assert compute_pony_factor([0, 0, 0]) == 0


### PR DESCRIPTION
## Summary
- add `pg_atlas.metrics.pony_factor` and `pg_atlas.metrics.materialize_pony` to compute and persist repo/project pony factor from `ContributedTo` edges
- deduplicate project contributors by `Contributor.email_hash` and support full recompute, latest `seed_run_ordinal`, and explicit `seed_run_ordinal` scopes
- hook pony-factor materialization onto the end of `gitlog-queue.yml`

## Scope
- in scope: issue #54 only
- out of scope: HHI, Shannon entropy, extra bot filtering, adoption metrics, crawler changes

## Runtime Note
- local full recompute on the current DB: `repo_rows_updated=144`, `project_rows_updated=611`, `duration_seconds=0.192`

## Test Plan
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy pg_atlas/`
- `uv run basedpyright $(git diff --name-only refs/remotes/upstream/main...HEAD -- '*.py')`
- `set -a && source .env && set +a && unset PG_ATLAS_ARTIFACT_S3_ENDPOINT PG_ATLAS_ARTIFACT_S3_BUCKET PG_ATLAS_FILEBASE_ACCESS_KEY PG_ATLAS_FILEBASE_SECRET_KEY PG_ATLAS_IPFS_GATEWAY_URL && PG_ATLAS_API_URL=https://test.pg-atlas.example uv run pytest -v`

Closes #54
