### PR TITLE
feat(api): add rate limiting and readiness health check

### DIFF
--- a/pg_atlas/main.py
+++ b/pg_atlas/main.py
@@ -20,6 +20,11 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from pg_atlas.api_metadata import DESCRIPTION, VERSION, generate_route_id
 from pg_atlas.config import settings
+from pg_atlas.rate_limit import (
+    DEFAULT_LIMIT_PER_MINUTE,
+    ROUTE_LIMITS_PER_MINUTE,
+    ApiRateLimitMiddleware,
+)
 from pg_atlas.routers import contributors, gitlog, health, ingestion, metadata, projects, repos
 from pg_atlas.routers.tags import TAGS_METADATA
 
@@ -64,6 +69,12 @@ app = FastAPI(
 # ---------------------------------------------------------------------------
 # Middleware
 # ---------------------------------------------------------------------------
+
+app.add_middleware(
+    ApiRateLimitMiddleware,
+    default_limit_per_minute=DEFAULT_LIMIT_PER_MINUTE,
+    route_limits_per_minute=ROUTE_LIMITS_PER_MINUTE,
+)
 
 app.add_middleware(
     CORSMiddleware,

--- a/pg_atlas/rate_limit.py
+++ b/pg_atlas/rate_limit.py
@@ -1,9 +1,10 @@
 """
 In-process API rate limiting.
 
-Implements a small token-bucket middleware keyed by client IP, HTTP method, and
-matched route template. This provides deterministic protection for the API
-without adding external infrastructure or persistence.
+Wraps ``PyrateLimiter`` in a small ASGI middleware keyed by client IP,
+HTTP method, and matched route template. Each endpoint policy gets its own
+in-memory limiter instance, while the acquisition key inside that policy is the
+resolved client IP.
 
 SPDX-FileCopyrightText: 2026 PG Atlas contributors
 SPDX-License-Identifier: MPL-2.0
@@ -14,11 +15,10 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import math
-import time
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
-from typing import cast
+from typing import Protocol, cast
 
+from pyrate_limiter import Duration, Limiter, Rate
 from starlette.responses import JSONResponse
 from starlette.routing import Match
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -28,115 +28,40 @@ ROUTE_LIMITS_PER_MINUTE: dict[tuple[str, str], int] = {
     ("GET", "/health"): 600,
     ("POST", "/ingest/sbom"): 600,
 }
-CLEANUP_INTERVAL_SECONDS = 60.0
-IDLE_BUCKET_TTL_SECONDS = 60.0
 
 
-@dataclass
-class TokenBucket:
-    """Mutable token-bucket state for one client/method/route key."""
+class AsyncLimiterLike(Protocol):
+    """Protocol for the async limiter surface used by the middleware."""
 
-    capacity: float
-    tokens: float
-    updated_at: float
-    last_seen_at: float
-
-
-@dataclass(frozen=True)
-class RateLimitDecision:
-    """Result of applying one request against a token bucket."""
-
-    allowed: bool
-    retry_after_seconds: int | None = None
-
-
-class TokenBucketStore:
-    """In-memory token buckets with lazy cleanup of idle, fully refilled state."""
-
-    def __init__(
+    async def try_acquire_async(
         self,
-        *,
-        clock: Callable[[], float] | None = None,
-        cleanup_interval_seconds: float = CLEANUP_INTERVAL_SECONDS,
-        idle_bucket_ttl_seconds: float = IDLE_BUCKET_TTL_SECONDS,
-    ) -> None:
-        self._clock = clock or time.monotonic
-        self._cleanup_interval_seconds = cleanup_interval_seconds
-        self._idle_bucket_ttl_seconds = idle_bucket_ttl_seconds
-        self._buckets: dict[tuple[str, str, str], TokenBucket] = {}
-        self._last_cleanup_at = 0.0
-        self._lock = asyncio.Lock()
+        name: str = "pyrate",
+        weight: int = 1,
+        blocking: bool = True,
+        timeout: int | float = -1,
+    ) -> bool:
+        """Attempt to acquire one permit asynchronously."""
 
-    async def consume(
-        self,
-        key: tuple[str, str, str],
-        *,
-        limit_per_minute: int,
-    ) -> RateLimitDecision:
-        """Consume one token for the given key or return a retry interval."""
+        ...
 
-        now = self._clock()
-        async with self._lock:
-            self._cleanup_if_due(now)
 
-            capacity = float(limit_per_minute)
-            refill_rate = capacity / 60.0
-            bucket = self._buckets.get(key)
+type LimiterFactory = Callable[[int, tuple[str, str]], AsyncLimiterLike]
 
-            if bucket is None:
-                bucket = TokenBucket(
-                    capacity=capacity,
-                    tokens=capacity,
-                    updated_at=now,
-                    last_seen_at=now,
-                )
-                self._buckets[key] = bucket
-            else:
-                self._refill_bucket(bucket, now=now, refill_rate=refill_rate)
 
-            bucket.last_seen_at = now
+def _default_limiter_factory(limit_per_minute: int, policy_key: tuple[str, str]) -> Limiter:
+    """
+    Build the default in-memory limiter for one endpoint policy.
 
-            if bucket.tokens >= 1.0:
-                bucket.tokens -= 1.0
-                bucket.updated_at = now
-                return RateLimitDecision(allowed=True)
+    The policy key is accepted for symmetry with test doubles and future
+    extensibility, but the default implementation only needs the rate itself.
+    """
+    del policy_key
 
-            seconds_until_token = max(1, math.ceil((1.0 - bucket.tokens) / refill_rate))
-            bucket.updated_at = now
-            return RateLimitDecision(
-                allowed=False,
-                retry_after_seconds=seconds_until_token,
-            )
-
-    def _refill_bucket(self, bucket: TokenBucket, *, now: float, refill_rate: float) -> None:
-        """Refill a bucket based on elapsed monotonic time."""
-
-        elapsed = max(0.0, now - bucket.updated_at)
-        if elapsed == 0.0:
-            return
-        bucket.tokens = min(bucket.capacity, bucket.tokens + (elapsed * refill_rate))
-        bucket.updated_at = now
-
-    def _cleanup_if_due(self, now: float) -> None:
-        """Drop idle buckets only once per cleanup interval."""
-
-        if now - self._last_cleanup_at < self._cleanup_interval_seconds:
-            return
-
-        self._last_cleanup_at = now
-        keys_to_delete: list[tuple[str, str, str]] = []
-        for key, bucket in self._buckets.items():
-            idle_for = now - bucket.last_seen_at
-            fully_refilled = bucket.tokens >= (bucket.capacity - 1e-9)
-            if idle_for >= self._idle_bucket_ttl_seconds and fully_refilled:
-                keys_to_delete.append(key)
-
-        for key in keys_to_delete:
-            del self._buckets[key]
+    return Limiter(Rate(limit_per_minute, Duration.MINUTE))
 
 
 class ApiRateLimitMiddleware:
-    """ASGI middleware that enforces token-bucket rate limits per route."""
+    """ASGI middleware that enforces per-endpoint, per-client request quotas."""
 
     def __init__(
         self,
@@ -144,12 +69,14 @@ class ApiRateLimitMiddleware:
         *,
         default_limit_per_minute: int = DEFAULT_LIMIT_PER_MINUTE,
         route_limits_per_minute: Mapping[tuple[str, str], int] | None = None,
-        clock: Callable[[], float] | None = None,
+        limiter_factory: LimiterFactory | None = None,
     ) -> None:
         self.app = app
         self.default_limit_per_minute = default_limit_per_minute
         self.route_limits_per_minute = dict(route_limits_per_minute or ROUTE_LIMITS_PER_MINUTE)
-        self.bucket_store = TokenBucketStore(clock=clock)
+        self.limiter_factory = limiter_factory or _default_limiter_factory
+        self._limiters: dict[tuple[str, str], AsyncLimiterLike] = {}
+        self._limiter_lock = asyncio.Lock()
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Rate-limit HTTP requests before they reach the application stack."""
@@ -158,28 +85,57 @@ class ApiRateLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
-        method = scope["method"].upper()
-        endpoint_key = resolve_endpoint_key(scope)
+        policy_key = resolve_policy_key(scope)
+        limit_per_minute = self.route_limits_per_minute.get(policy_key, self.default_limit_per_minute)
+        limiter = await self._get_limiter(policy_key, limit_per_minute)
         client_ip = resolve_client_ip(scope)
-        limit_per_minute = self.route_limits_per_minute.get(
-            (method, endpoint_key),
-            self.default_limit_per_minute,
-        )
-        decision = await self.bucket_store.consume(
-            (client_ip, method, endpoint_key),
-            limit_per_minute=limit_per_minute,
-        )
+        allowed = await limiter.try_acquire_async(client_ip, blocking=False)
 
-        if not decision.allowed:
+        if not allowed:
+            retry_after_seconds = seconds_until_next_token(limit_per_minute)
             response = JSONResponse(
                 {"detail": "Rate limit exceeded"},
                 status_code=429,
-                headers={"Retry-After": str(decision.retry_after_seconds)},
+                headers={"Retry-After": str(retry_after_seconds)},
             )
             await response(scope, receive, send)
             return
 
         await self.app(scope, receive, send)
+
+    async def _get_limiter(
+        self,
+        policy_key: tuple[str, str],
+        limit_per_minute: int,
+    ) -> AsyncLimiterLike:
+        """Return the limiter instance for one method-and-endpoint policy."""
+
+        limiter = self._limiters.get(policy_key)
+        if limiter is not None:
+            return limiter
+
+        async with self._limiter_lock:
+            limiter = self._limiters.get(policy_key)
+            if limiter is not None:
+                return limiter
+
+            limiter = self.limiter_factory(limit_per_minute, policy_key)
+            self._limiters[policy_key] = limiter
+
+            return limiter
+
+
+def seconds_until_next_token(limit_per_minute: int) -> int:
+    """Return the minimum whole-second wait for one permit at the given rate."""
+
+    return max(1, math.ceil(60 / limit_per_minute))
+
+
+def resolve_policy_key(scope: Scope) -> tuple[str, str]:
+    """Resolve the limiter policy key as ``(method, route template)``."""
+
+    method = scope["method"].upper()
+    return (method, resolve_endpoint_key(scope))
 
 
 def resolve_client_ip(scope: Scope) -> str:
@@ -194,13 +150,13 @@ def resolve_client_ip(scope: Scope) -> str:
     client = cast(tuple[str, int] | None, scope.get("client"))
     if client is not None and client[0]:
         return client[0]
+
     return "unknown"
 
 
 def resolve_endpoint_key(scope: Scope) -> str:
-    """Resolve the matched route template or a grouped unmatched fallback key."""
+    """Resolve the matched route template or an unmatched-route fallback key."""
 
-    method = scope["method"].upper()
     app = scope.get("app")
     router = getattr(app, "router", None)
     if router is not None:
@@ -211,7 +167,7 @@ def resolve_endpoint_key(scope: Scope) -> str:
                 if isinstance(route_path, str):
                     return route_path
 
-    return f"__unmatched__:{method}"
+    return "__unmatched__"
 
 
 def get_header(scope: Scope, name: str) -> str | None:
@@ -219,10 +175,10 @@ def get_header(scope: Scope, name: str) -> str | None:
 
     target = name.lower().encode("latin-1")
     headers = cast(list[tuple[bytes, bytes]], scope.get("headers", []))
-    for header in headers:
-        header_name, header_value = header
+    for header_name, header_value in headers:
         if header_name == target:
             return header_value.decode("latin-1")
+
     return None
 
 
@@ -233,4 +189,5 @@ def is_valid_ip_address(value: str) -> bool:
         ipaddress.ip_address(value)
     except ValueError:
         return False
+
     return True

--- a/pg_atlas/rate_limit.py
+++ b/pg_atlas/rate_limit.py
@@ -1,0 +1,236 @@
+"""
+In-process API rate limiting.
+
+Implements a small token-bucket middleware keyed by client IP, HTTP method, and
+matched route template. This provides deterministic protection for the API
+without adding external infrastructure or persistence.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import math
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import cast
+
+from starlette.responses import JSONResponse
+from starlette.routing import Match
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+DEFAULT_LIMIT_PER_MINUTE = 100
+ROUTE_LIMITS_PER_MINUTE: dict[tuple[str, str], int] = {
+    ("GET", "/health"): 600,
+    ("POST", "/ingest/sbom"): 600,
+}
+CLEANUP_INTERVAL_SECONDS = 60.0
+IDLE_BUCKET_TTL_SECONDS = 60.0
+
+
+@dataclass
+class TokenBucket:
+    """Mutable token-bucket state for one client/method/route key."""
+
+    capacity: float
+    tokens: float
+    updated_at: float
+    last_seen_at: float
+
+
+@dataclass(frozen=True)
+class RateLimitDecision:
+    """Result of applying one request against a token bucket."""
+
+    allowed: bool
+    retry_after_seconds: int | None = None
+
+
+class TokenBucketStore:
+    """In-memory token buckets with lazy cleanup of idle, fully refilled state."""
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] | None = None,
+        cleanup_interval_seconds: float = CLEANUP_INTERVAL_SECONDS,
+        idle_bucket_ttl_seconds: float = IDLE_BUCKET_TTL_SECONDS,
+    ) -> None:
+        self._clock = clock or time.monotonic
+        self._cleanup_interval_seconds = cleanup_interval_seconds
+        self._idle_bucket_ttl_seconds = idle_bucket_ttl_seconds
+        self._buckets: dict[tuple[str, str, str], TokenBucket] = {}
+        self._last_cleanup_at = 0.0
+        self._lock = asyncio.Lock()
+
+    async def consume(
+        self,
+        key: tuple[str, str, str],
+        *,
+        limit_per_minute: int,
+    ) -> RateLimitDecision:
+        """Consume one token for the given key or return a retry interval."""
+
+        now = self._clock()
+        async with self._lock:
+            self._cleanup_if_due(now)
+
+            capacity = float(limit_per_minute)
+            refill_rate = capacity / 60.0
+            bucket = self._buckets.get(key)
+
+            if bucket is None:
+                bucket = TokenBucket(
+                    capacity=capacity,
+                    tokens=capacity,
+                    updated_at=now,
+                    last_seen_at=now,
+                )
+                self._buckets[key] = bucket
+            else:
+                self._refill_bucket(bucket, now=now, refill_rate=refill_rate)
+
+            bucket.last_seen_at = now
+
+            if bucket.tokens >= 1.0:
+                bucket.tokens -= 1.0
+                bucket.updated_at = now
+                return RateLimitDecision(allowed=True)
+
+            seconds_until_token = max(1, math.ceil((1.0 - bucket.tokens) / refill_rate))
+            bucket.updated_at = now
+            return RateLimitDecision(
+                allowed=False,
+                retry_after_seconds=seconds_until_token,
+            )
+
+    def _refill_bucket(self, bucket: TokenBucket, *, now: float, refill_rate: float) -> None:
+        """Refill a bucket based on elapsed monotonic time."""
+
+        elapsed = max(0.0, now - bucket.updated_at)
+        if elapsed == 0.0:
+            return
+        bucket.tokens = min(bucket.capacity, bucket.tokens + (elapsed * refill_rate))
+        bucket.updated_at = now
+
+    def _cleanup_if_due(self, now: float) -> None:
+        """Drop idle buckets only once per cleanup interval."""
+
+        if now - self._last_cleanup_at < self._cleanup_interval_seconds:
+            return
+
+        self._last_cleanup_at = now
+        keys_to_delete: list[tuple[str, str, str]] = []
+        for key, bucket in self._buckets.items():
+            idle_for = now - bucket.last_seen_at
+            fully_refilled = bucket.tokens >= (bucket.capacity - 1e-9)
+            if idle_for >= self._idle_bucket_ttl_seconds and fully_refilled:
+                keys_to_delete.append(key)
+
+        for key in keys_to_delete:
+            del self._buckets[key]
+
+
+class ApiRateLimitMiddleware:
+    """ASGI middleware that enforces token-bucket rate limits per route."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        default_limit_per_minute: int = DEFAULT_LIMIT_PER_MINUTE,
+        route_limits_per_minute: Mapping[tuple[str, str], int] | None = None,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self.app = app
+        self.default_limit_per_minute = default_limit_per_minute
+        self.route_limits_per_minute = dict(route_limits_per_minute or ROUTE_LIMITS_PER_MINUTE)
+        self.bucket_store = TokenBucketStore(clock=clock)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Rate-limit HTTP requests before they reach the application stack."""
+
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        method = scope["method"].upper()
+        endpoint_key = resolve_endpoint_key(scope)
+        client_ip = resolve_client_ip(scope)
+        limit_per_minute = self.route_limits_per_minute.get(
+            (method, endpoint_key),
+            self.default_limit_per_minute,
+        )
+        decision = await self.bucket_store.consume(
+            (client_ip, method, endpoint_key),
+            limit_per_minute=limit_per_minute,
+        )
+
+        if not decision.allowed:
+            response = JSONResponse(
+                {"detail": "Rate limit exceeded"},
+                status_code=429,
+                headers={"Retry-After": str(decision.retry_after_seconds)},
+            )
+            await response(scope, receive, send)
+            return
+
+        await self.app(scope, receive, send)
+
+
+def resolve_client_ip(scope: Scope) -> str:
+    """Resolve the client IP from X-Forwarded-For or the socket peer."""
+
+    forwarded_for = get_header(scope, "x-forwarded-for")
+    if forwarded_for is not None:
+        first_hop = forwarded_for.split(",", maxsplit=1)[0].strip()
+        if is_valid_ip_address(first_hop):
+            return first_hop
+
+    client = cast(tuple[str, int] | None, scope.get("client"))
+    if client is not None and client[0]:
+        return client[0]
+    return "unknown"
+
+
+def resolve_endpoint_key(scope: Scope) -> str:
+    """Resolve the matched route template or a grouped unmatched fallback key."""
+
+    method = scope["method"].upper()
+    app = scope.get("app")
+    router = getattr(app, "router", None)
+    if router is not None:
+        for route in router.routes:
+            match, _ = route.matches(scope)
+            if match is Match.FULL:
+                route_path = getattr(route, "path", None)
+                if isinstance(route_path, str):
+                    return route_path
+
+    return f"__unmatched__:{method}"
+
+
+def get_header(scope: Scope, name: str) -> str | None:
+    """Return one HTTP header from the ASGI scope, decoded as latin-1."""
+
+    target = name.lower().encode("latin-1")
+    headers = cast(list[tuple[bytes, bytes]], scope.get("headers", []))
+    for header in headers:
+        header_name, header_value = header
+        if header_name == target:
+            return header_value.decode("latin-1")
+    return None
+
+
+def is_valid_ip_address(value: str) -> bool:
+    """Return whether the supplied string is a syntactically valid IP address."""
+
+    try:
+        ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return True

--- a/pg_atlas/routers/health.py
+++ b/pg_atlas/routers/health.py
@@ -12,9 +12,9 @@ SPDX-License-Identifier: MPL-2.0
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Literal
+from typing import Annotated, Literal
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from pg_atlas.api_metadata import VERSION
 from pg_atlas.config import settings
-from pg_atlas.db_models.session import get_session_factory
+from pg_atlas.db_models.session import maybe_db_session
 
 router = APIRouter(tags=["health"])
 
@@ -54,7 +54,7 @@ def _artifact_store_status() -> Literal["local", "IPFS"]:
 def _select_app_schema_version(version_rows: Sequence[str]) -> str | None:
     """Select the application Alembic revision from raw alembic_version rows."""
 
-    application_revisions = [version_row for version_row in version_rows if version_row != "procrastinate_001"]
+    application_revisions = [version_row for version_row in version_rows if not version_row.startswith("procrastinate_")]
     if len(application_revisions) > 1:
         raise ValueError("multiple non-Procrastinate revisions found in alembic_version")
     if not application_revisions:
@@ -69,21 +69,13 @@ async def _schema_version_from_session(session: AsyncSession) -> str | None:
     return _select_app_schema_version(result.scalars().all())
 
 
-async def _read_schema_version() -> str | None:
-    """Open a database session and read the current application schema version."""
-
-    session_factory = get_session_factory()
-    async with session_factory() as session:
-        return await _schema_version_from_session(session)
-
-
 @router.get("/health", response_model=HealthResponse, summary="Readiness check")
-async def health() -> HealthResponse:
+async def health(session: Annotated[AsyncSession | None, Depends(maybe_db_session)]) -> HealthResponse:
     """
     Return the current readiness status and application version.
     """
     artifact_store = _artifact_store_status()
-    if not settings.DATABASE_URL:
+    if session is None:
         return HealthResponse(
             status="live",
             version=VERSION,
@@ -95,7 +87,7 @@ async def health() -> HealthResponse:
         )
 
     try:
-        schema_version = await _read_schema_version()
+        schema_version = await _schema_version_from_session(session)
     except (SQLAlchemyError, ValueError) as exc:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/pg_atlas/routers/health.py
+++ b/pg_atlas/routers/health.py
@@ -1,11 +1,9 @@
 """
-Health check router for PG Atlas.
+Health and readiness router for PG Atlas.
 
-Provides GET /health for liveness monitoring. The response is deliberately
-lightweight so that uptime monitors can call it frequently without overhead.
-
-A ``components`` key will be added in A2 to report the health of individual
-subsystems (database connection, NetworkX graph load status, etc.).
+GET /health reports whether the service is merely live or fully ready. When the
+database is configured, the endpoint checks the active Alembic revision and
+returns HTTP 503 if readiness cannot be established.
 
 SPDX-FileCopyrightText: 2026 PG Atlas contributors
 SPDX-License-Identifier: MPL-2.0
@@ -13,33 +11,103 @@ SPDX-License-Identifier: MPL-2.0
 
 from __future__ import annotations
 
-import importlib.metadata
+from collections.abc import Sequence
+from typing import Literal
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from pg_atlas.api_metadata import VERSION
+from pg_atlas.config import settings
+from pg_atlas.db_models.session import get_session_factory
 
 router = APIRouter(tags=["health"])
+
+
+class HealthComponents(BaseModel):
+    """Component-level readiness details for GET /health."""
+
+    artifact_store: Literal["local", "IPFS"]
+    database: Literal["ready", "not-configured"]
+    schema_version: str | None
 
 
 class HealthResponse(BaseModel):
     """Response body for GET /health."""
 
-    status: str
+    status: Literal["live", "ready"]
     version: str
+    components: HealthComponents
 
 
-@router.get("/health", response_model=HealthResponse, summary="Liveness check")
+def _artifact_store_status() -> Literal["local", "IPFS"]:
+    """Return the configured artifact store backend."""
+
+    if settings.ARTIFACT_S3_ENDPOINT is not None:
+        return "IPFS"
+    return "local"
+
+
+def _select_app_schema_version(version_rows: Sequence[str]) -> str | None:
+    """Select the application Alembic revision from raw alembic_version rows."""
+
+    application_revisions = [version_row for version_row in version_rows if version_row != "procrastinate_001"]
+    if len(application_revisions) > 1:
+        raise ValueError("multiple non-Procrastinate revisions found in alembic_version")
+    if not application_revisions:
+        return None
+    return application_revisions[0]
+
+
+async def _schema_version_from_session(session: AsyncSession) -> str | None:
+    """Read and normalize the application schema revision from one session."""
+
+    result = await session.execute(text("SELECT version_num FROM alembic_version"))
+    return _select_app_schema_version(result.scalars().all())
+
+
+async def _read_schema_version() -> str | None:
+    """Open a database session and read the current application schema version."""
+
+    session_factory = get_session_factory()
+    async with session_factory() as session:
+        return await _schema_version_from_session(session)
+
+
+@router.get("/health", response_model=HealthResponse, summary="Readiness check")
 async def health() -> HealthResponse:
     """
-    Return the current health status and application version.
-
-    This endpoint is intentionally dependency-free (no DB call) so that it
-    remains responsive even when the database is unreachable. A richer check
-    with named component statuses (db, graph) will be added in A2.
+    Return the current readiness status and application version.
     """
-    try:
-        version = importlib.metadata.version("pg-atlas-backend")
-    except importlib.metadata.PackageNotFoundError:
-        version = "dev"
+    artifact_store = _artifact_store_status()
+    if not settings.DATABASE_URL:
+        return HealthResponse(
+            status="live",
+            version=VERSION,
+            components=HealthComponents(
+                artifact_store=artifact_store,
+                database="not-configured",
+                schema_version=None,
+            ),
+        )
 
-    return HealthResponse(status="ok", version=version)
+    try:
+        schema_version = await _read_schema_version()
+    except (SQLAlchemyError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+
+    return HealthResponse(
+        status="ready",
+        version=VERSION,
+        components=HealthComponents(
+            artifact_store=artifact_store,
+            database="ready",
+            schema_version=schema_version,
+        ),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "networkx>=3.0",
     "numpy>=1.26",
     "msgspec>=0.21.0",
+    "pyrate-limiter>=4.1.0",
 ]
 
 [dependency-groups]

--- a/tests/routers/test_health.py
+++ b/tests/routers/test_health.py
@@ -11,6 +11,8 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from pg_atlas.config import settings
+from pg_atlas.db_models.session import maybe_db_session
+from pg_atlas.main import app
 from pg_atlas.routers import health as health_router
 
 
@@ -44,15 +46,26 @@ async def test_health_returns_ready_when_database_is_configured(
 ) -> None:
     """Configured databases should move /health from live to ready."""
 
-    async def read_schema_version() -> str:
+    class FakeSession:
+        pass
+
+    async def configured_session():
+        yield FakeSession()
+
+    async def read_schema_version(session: AsyncSession) -> str:
+        del session
         return "66ac36af6383"
 
     monkeypatch.setattr(settings, "DATABASE_URL", "postgresql+asyncpg://configured")
     monkeypatch.setattr(settings, "ARTIFACT_S3_ENDPOINT", "https://s3.filebase.com")
-    monkeypatch.setattr(health_router, "_read_schema_version", read_schema_version)
+    monkeypatch.setattr(health_router, "_schema_version_from_session", read_schema_version)
+    app.dependency_overrides[maybe_db_session] = configured_session
 
-    response = await async_client.get("/health")
-    body = response.json()
+    try:
+        response = await async_client.get("/health")
+        body = response.json()
+    finally:
+        app.dependency_overrides.pop(maybe_db_session, None)
 
     assert response.status_code == 200
     assert body == {
@@ -71,13 +84,24 @@ async def test_health_returns_503_when_database_check_fails(
 ) -> None:
     """Configured-database failures should become readiness 503 responses."""
 
-    async def read_schema_version() -> str | None:
+    class FakeSession:
+        pass
+
+    async def configured_session():
+        yield FakeSession()
+
+    async def read_schema_version(session: AsyncSession) -> str | None:
+        del session
         raise SQLAlchemyError("database unavailable")
 
     monkeypatch.setattr(settings, "DATABASE_URL", "postgresql+asyncpg://configured")
-    monkeypatch.setattr(health_router, "_read_schema_version", read_schema_version)
+    monkeypatch.setattr(health_router, "_schema_version_from_session", read_schema_version)
+    app.dependency_overrides[maybe_db_session] = configured_session
 
-    response = await async_client.get("/health")
+    try:
+        response = await async_client.get("/health")
+    finally:
+        app.dependency_overrides.pop(maybe_db_session, None)
 
     assert response.status_code == 503
     assert response.json() == {"detail": "database unavailable"}
@@ -86,7 +110,9 @@ async def test_health_returns_503_when_database_check_fails(
 def test_select_app_schema_version_ignores_procrastinate_revision() -> None:
     """The readiness response should hide the Procrastinate migration branch."""
 
-    assert health_router._select_app_schema_version(["procrastinate_001", "66ac36af6383"]) == "66ac36af6383"
+    assert (
+        health_router._select_app_schema_version(["procrastinate_001", "procrastinate_002", "66ac36af6383"]) == "66ac36af6383"
+    )
 
 
 def test_select_app_schema_version_rejects_multiple_application_revisions() -> None:
@@ -104,7 +130,7 @@ async def test_schema_version_from_session_reads_database_revision(
     schema_version = await health_router._schema_version_from_session(db_session)
 
     assert isinstance(schema_version, str)
-    assert schema_version != "procrastinate_001"
+    assert not schema_version.startswith("procrastinate_")
 
 
 async def test_openapi_describes_health_readiness_schema(async_client: AsyncClient) -> None:

--- a/tests/routers/test_health.py
+++ b/tests/routers/test_health.py
@@ -1,22 +1,126 @@
 """
-Tests for GET /health.
+Tests for GET /health readiness reporting.
 
-Author: SCF Public Goods Maintenance <https://github.com/SCF-Public-Goods-Maintenance>
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
 """
 
+import pytest
 from httpx import AsyncClient
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from pg_atlas.config import settings
+from pg_atlas.routers import health as health_router
 
 
-async def test_health_returns_200(async_client: AsyncClient) -> None:
-    """GET /health should return 200 OK."""
+async def test_health_returns_200(async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """GET /health should return 200 OK when the DB is not configured."""
+
+    monkeypatch.setattr(settings, "DATABASE_URL", "")
     response = await async_client.get("/health")
     assert response.status_code == 200
 
 
-async def test_health_response_shape(async_client: AsyncClient) -> None:
-    """GET /health response body should contain status and version fields."""
+async def test_health_response_shape(async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """GET /health should return the readiness payload shape."""
+
+    monkeypatch.setattr(settings, "DATABASE_URL", "")
+    monkeypatch.setattr(settings, "ARTIFACT_S3_ENDPOINT", None)
     response = await async_client.get("/health")
     body = response.json()
-    assert body["status"] == "ok"
-    assert "version" in body
+
+    assert body["status"] == "live"
     assert isinstance(body["version"], str)
+    assert body["components"] == {
+        "artifact_store": "local",
+        "database": "not-configured",
+        "schema_version": None,
+    }
+
+
+async def test_health_returns_ready_when_database_is_configured(
+    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Configured databases should move /health from live to ready."""
+
+    async def read_schema_version() -> str:
+        return "66ac36af6383"
+
+    monkeypatch.setattr(settings, "DATABASE_URL", "postgresql+asyncpg://configured")
+    monkeypatch.setattr(settings, "ARTIFACT_S3_ENDPOINT", "https://s3.filebase.com")
+    monkeypatch.setattr(health_router, "_read_schema_version", read_schema_version)
+
+    response = await async_client.get("/health")
+    body = response.json()
+
+    assert response.status_code == 200
+    assert body == {
+        "status": "ready",
+        "version": body["version"],
+        "components": {
+            "artifact_store": "IPFS",
+            "database": "ready",
+            "schema_version": "66ac36af6383",
+        },
+    }
+
+
+async def test_health_returns_503_when_database_check_fails(
+    async_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Configured-database failures should become readiness 503 responses."""
+
+    async def read_schema_version() -> str | None:
+        raise SQLAlchemyError("database unavailable")
+
+    monkeypatch.setattr(settings, "DATABASE_URL", "postgresql+asyncpg://configured")
+    monkeypatch.setattr(health_router, "_read_schema_version", read_schema_version)
+
+    response = await async_client.get("/health")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "database unavailable"}
+
+
+def test_select_app_schema_version_ignores_procrastinate_revision() -> None:
+    """The readiness response should hide the Procrastinate migration branch."""
+
+    assert health_router._select_app_schema_version(["procrastinate_001", "66ac36af6383"]) == "66ac36af6383"
+
+
+def test_select_app_schema_version_rejects_multiple_application_revisions() -> None:
+    """Multiple application revisions should fail readiness explicitly."""
+
+    with pytest.raises(ValueError, match="multiple non-Procrastinate"):
+        health_router._select_app_schema_version(["66ac36af6383", "deadbeef1234", "procrastinate_001"])
+
+
+async def test_schema_version_from_session_reads_database_revision(
+    db_session: AsyncSession,
+) -> None:
+    """A real database session should expose the application Alembic revision."""
+
+    schema_version = await health_router._schema_version_from_session(db_session)
+
+    assert isinstance(schema_version, str)
+    assert schema_version != "procrastinate_001"
+
+
+async def test_openapi_describes_health_readiness_schema(async_client: AsyncClient) -> None:
+    """The OpenAPI document should describe the nested readiness payload."""
+
+    response = await async_client.get("/openapi.json")
+    openapi = response.json()
+    schemas = openapi["components"]["schemas"]
+    health_schema = schemas["HealthResponse"]
+    components_ref = health_schema["properties"]["components"]["$ref"]
+    components_schema = schemas[components_ref.rsplit("/", maxsplit=1)[-1]]
+
+    assert set(health_schema["properties"]["status"]["enum"]) == {"live", "ready"}
+    assert set(components_schema["properties"]["artifact_store"]["enum"]) == {"local", "IPFS"}
+    assert set(components_schema["properties"]["database"]["enum"]) == {
+        "ready",
+        "not-configured",
+    }
+    assert any(option.get("type") == "string" for option in components_schema["properties"]["schema_version"]["anyOf"])

--- a/tests/routers/test_rate_limit.py
+++ b/tests/routers/test_rate_limit.py
@@ -21,8 +21,8 @@ class RecordingLimiter:
     """Minimal async limiter fake that tracks calls per client identity."""
 
     limit_per_key: int
-    calls: list[tuple[str, bool]] = field(default_factory=list)
-    counts: dict[str, int] = field(default_factory=dict)
+    calls: list[tuple[str, bool]] = field(default_factory=list[tuple[str, bool]])
+    counts: dict[str, int] = field(default_factory=dict[str, int])
 
     async def try_acquire_async(
         self,

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -5,43 +5,72 @@ SPDX-FileCopyrightText: 2026 PG Atlas contributors
 SPDX-License-Identifier: MPL-2.0
 """
 
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from pg_atlas.rate_limit import ApiRateLimitMiddleware
 
 
-class FakeClock:
-    """Mutable monotonic clock used for deterministic token bucket tests."""
+@dataclass
+class RecordingLimiter:
+    """Minimal async limiter fake that tracks calls per client identity."""
 
-    def __init__(self) -> None:
-        self.current = 0.0
+    limit_per_key: int
+    calls: list[tuple[str, bool]] = field(default_factory=list)
+    counts: dict[str, int] = field(default_factory=dict)
 
-    def __call__(self) -> float:
-        return self.current
+    async def try_acquire_async(
+        self,
+        name: str = "pyrate",
+        weight: int = 1,
+        blocking: bool = True,
+        timeout: int | float = -1,
+    ) -> bool:
+        del weight, timeout
+        self.calls.append((name, blocking))
+        current = self.counts.get(name, 0)
+        if current >= self.limit_per_key:
+            return False
 
-    def advance(self, seconds: float) -> None:
-        self.current += seconds
+        self.counts[name] = current + 1
+
+        return True
 
 
-def make_rate_limited_app(default_limit_per_minute: int, clock: FakeClock) -> FastAPI:
-    """Build a small test app with the middleware under deterministic control."""
+def make_rate_limited_app(
+    default_limit_per_minute: int,
+    *,
+    route_limits_per_minute: dict[tuple[str, str], int] | None = None,
+    limiter_factory: Callable[[int, tuple[str, str]], RecordingLimiter] | None = None,
+) -> FastAPI:
+    """Build a small test app with configurable limiter construction."""
 
     app = FastAPI()
     app.add_middleware(
         ApiRateLimitMiddleware,
         default_limit_per_minute=default_limit_per_minute,
-        route_limits_per_minute={
+        route_limits_per_minute=route_limits_per_minute
+        or {
             ("GET", "/health"): 4,
             ("POST", "/ingest/sbom"): 4,
         },
-        clock=clock,
+        limiter_factory=limiter_factory,
     )
 
     async def limited() -> dict[str, str]:
         return {"route": "limited"}
 
     app.get("/limited")(limited)
+
+    async def other() -> dict[str, str]:
+        return {"route": "other"}
+
+    app.get("/other")(other)
 
     async def method_get() -> dict[str, str]:
         return {"route": "method-get"}
@@ -72,10 +101,9 @@ def make_rate_limited_app(default_limit_per_minute: int, clock: FakeClock) -> Fa
 
 
 async def test_rate_limit_exhaustion_and_retry_after() -> None:
-    """Exhausted buckets should return 429 with a Retry-After header."""
+    """Exhausted endpoint policies should return 429 with Retry-After."""
 
-    clock = FakeClock()
-    app = make_rate_limited_app(default_limit_per_minute=2, clock=clock)
+    app = make_rate_limited_app(default_limit_per_minute=2)
 
     async with AsyncClient(
         transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
@@ -92,31 +120,17 @@ async def test_rate_limit_exhaustion_and_retry_after() -> None:
     assert response_three.headers["Retry-After"] == "30"
 
 
-async def test_rate_limit_refills_after_time_passes() -> None:
-    """Buckets should refill over time according to the configured rate."""
-
-    clock = FakeClock()
-    app = make_rate_limited_app(default_limit_per_minute=2, clock=clock)
-
-    async with AsyncClient(
-        transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
-        base_url="http://test",
-    ) as client:
-        await client.get("/limited")
-        await client.get("/limited")
-        denied = await client.get("/limited")
-        clock.advance(30)
-        allowed = await client.get("/limited")
-
-    assert denied.status_code == 429
-    assert allowed.status_code == 200
-
-
 async def test_rate_limit_uses_separate_buckets_per_client_ip() -> None:
-    """Different client IPs should not share rate-limit state."""
+    """Different client IPs should not share one endpoint policy bucket."""
 
-    clock = FakeClock()
-    app = make_rate_limited_app(default_limit_per_minute=1, clock=clock)
+    fake_limiters: dict[tuple[str, str], RecordingLimiter] = {}
+
+    def limiter_factory(limit: int, key: tuple[str, str]) -> RecordingLimiter:
+        limiter = RecordingLimiter(limit_per_key=limit)
+        fake_limiters[key] = limiter
+        return limiter
+
+    app = make_rate_limited_app(default_limit_per_minute=1, limiter_factory=limiter_factory)
 
     async with AsyncClient(
         transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
@@ -129,13 +143,24 @@ async def test_rate_limit_uses_separate_buckets_per_client_ip() -> None:
     assert allowed.status_code == 200
     assert denied.status_code == 429
     assert separate_ip.status_code == 200
+    assert fake_limiters[("GET", "/limited")].calls == [
+        ("203.0.113.10", False),
+        ("203.0.113.10", False),
+        ("198.51.100.20", False),
+    ]
 
 
-async def test_rate_limit_uses_separate_buckets_per_method() -> None:
-    """GET and POST on the same path should be rate-limited independently."""
+async def test_rate_limit_keeps_method_policies_separate_on_the_same_path() -> None:
+    """GET and POST on one path should use different limiter instances."""
 
-    clock = FakeClock()
-    app = make_rate_limited_app(default_limit_per_minute=1, clock=clock)
+    fake_limiters: dict[tuple[str, str], RecordingLimiter] = {}
+
+    def limiter_factory(limit: int, key: tuple[str, str]) -> RecordingLimiter:
+        limiter = RecordingLimiter(limit_per_key=limit)
+        fake_limiters[key] = limiter
+        return limiter
+
+    app = make_rate_limited_app(default_limit_per_minute=1, limiter_factory=limiter_factory)
 
     async with AsyncClient(
         transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
@@ -148,13 +173,34 @@ async def test_rate_limit_uses_separate_buckets_per_method() -> None:
     assert get_allowed.status_code == 200
     assert get_denied.status_code == 429
     assert post_allowed.status_code == 200
+    assert set(fake_limiters) >= {
+        ("GET", "/method"),
+        ("POST", "/method"),
+    }
+
+
+async def test_rate_limit_keeps_default_endpoint_policies_separate() -> None:
+    """Two default-rate endpoints should not share one limiter instance."""
+
+    app = make_rate_limited_app(default_limit_per_minute=1)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
+        base_url="http://test",
+    ) as client:
+        limited_first = await client.get("/limited")
+        other_first = await client.get("/other")
+        limited_second = await client.get("/limited")
+
+    assert limited_first.status_code == 200
+    assert other_first.status_code == 200
+    assert limited_second.status_code == 429
 
 
 async def test_rate_limit_groups_route_templates_with_path_params() -> None:
-    """Different path parameters on one route template should share a bucket."""
+    """Concrete URLs should collapse to one route-template policy."""
 
-    clock = FakeClock()
-    app = make_rate_limited_app(default_limit_per_minute=2, clock=clock)
+    app = make_rate_limited_app(default_limit_per_minute=2)
 
     async with AsyncClient(
         transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
@@ -170,10 +216,9 @@ async def test_rate_limit_groups_route_templates_with_path_params() -> None:
 
 
 async def test_rate_limit_groups_unmatched_paths_by_method() -> None:
-    """Unmatched routes should still be grouped deterministically by method."""
+    """Unmatched paths should still share one fallback policy per method."""
 
-    clock = FakeClock()
-    app = make_rate_limited_app(default_limit_per_minute=2, clock=clock)
+    app = make_rate_limited_app(default_limit_per_minute=2)
 
     async with AsyncClient(
         transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
@@ -189,10 +234,16 @@ async def test_rate_limit_groups_unmatched_paths_by_method() -> None:
 
 
 async def test_rate_limit_uses_first_forwarded_ip_when_valid() -> None:
-    """The first valid X-Forwarded-For IP should define the bucket key."""
+    """The first valid X-Forwarded-For IP should be the acquisition key."""
 
-    clock = FakeClock()
-    app = make_rate_limited_app(default_limit_per_minute=1, clock=clock)
+    fake_limiters: dict[tuple[str, str], RecordingLimiter] = {}
+
+    def limiter_factory(limit: int, key: tuple[str, str]) -> RecordingLimiter:
+        limiter = RecordingLimiter(limit_per_key=limit)
+        fake_limiters[key] = limiter
+        return limiter
+
+    app = make_rate_limited_app(default_limit_per_minute=1, limiter_factory=limiter_factory)
 
     async with AsyncClient(
         transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
@@ -214,13 +265,24 @@ async def test_rate_limit_uses_first_forwarded_ip_when_valid() -> None:
     assert first.status_code == 200
     assert denied.status_code == 429
     assert separate_first_ip.status_code == 200
+    assert fake_limiters[("GET", "/limited")].calls == [
+        ("203.0.113.1", False),
+        ("203.0.113.1", False),
+        ("198.51.100.10", False),
+    ]
 
 
 async def test_rate_limit_falls_back_to_client_host_when_forwarded_for_is_invalid() -> None:
-    """Invalid X-Forwarded-For values should fall back to the socket client IP."""
+    """Invalid forwarded headers should fall back to the socket peer IP."""
 
-    clock = FakeClock()
-    app = make_rate_limited_app(default_limit_per_minute=1, clock=clock)
+    fake_limiters: dict[tuple[str, str], RecordingLimiter] = {}
+
+    def limiter_factory(limit: int, key: tuple[str, str]) -> RecordingLimiter:
+        limiter = RecordingLimiter(limit_per_key=limit)
+        fake_limiters[key] = limiter
+        return limiter
+
+    app = make_rate_limited_app(default_limit_per_minute=1, limiter_factory=limiter_factory)
 
     async with AsyncClient(
         transport=ASGITransport(app=app, client=("198.51.100.55", 12345)),
@@ -231,13 +293,16 @@ async def test_rate_limit_falls_back_to_client_host_when_forwarded_for_is_invali
 
     assert first.status_code == 200
     assert denied.status_code == 429
+    assert fake_limiters[("GET", "/limited")].calls == [
+        ("198.51.100.55", False),
+        ("198.51.100.55", False),
+    ]
 
 
 async def test_rate_limit_applies_configured_endpoint_overrides() -> None:
-    """Configured overrides should allow higher per-minute throughput."""
+    """Endpoint-specific overrides should get their own higher-rate policies."""
 
-    clock = FakeClock()
-    app = make_rate_limited_app(default_limit_per_minute=2, clock=clock)
+    app = make_rate_limited_app(default_limit_per_minute=2)
 
     async with AsyncClient(
         transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,252 @@
+"""
+Tests for API rate limiting middleware.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from pg_atlas.rate_limit import ApiRateLimitMiddleware
+
+
+class FakeClock:
+    """Mutable monotonic clock used for deterministic token bucket tests."""
+
+    def __init__(self) -> None:
+        self.current = 0.0
+
+    def __call__(self) -> float:
+        return self.current
+
+    def advance(self, seconds: float) -> None:
+        self.current += seconds
+
+
+def make_rate_limited_app(default_limit_per_minute: int, clock: FakeClock) -> FastAPI:
+    """Build a small test app with the middleware under deterministic control."""
+
+    app = FastAPI()
+    app.add_middleware(
+        ApiRateLimitMiddleware,
+        default_limit_per_minute=default_limit_per_minute,
+        route_limits_per_minute={
+            ("GET", "/health"): 4,
+            ("POST", "/ingest/sbom"): 4,
+        },
+        clock=clock,
+    )
+
+    async def limited() -> dict[str, str]:
+        return {"route": "limited"}
+
+    app.get("/limited")(limited)
+
+    async def method_get() -> dict[str, str]:
+        return {"route": "method-get"}
+
+    app.get("/method")(method_get)
+
+    async def method_post() -> dict[str, str]:
+        return {"route": "method-post"}
+
+    app.post("/method")(method_post)
+
+    async def item(item_id: str) -> dict[str, str]:
+        return {"item_id": item_id}
+
+    app.get("/items/{item_id}")(item)
+
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    app.get("/health")(health)
+
+    async def ingest_sbom() -> dict[str, str]:
+        return {"status": "accepted"}
+
+    app.post("/ingest/sbom")(ingest_sbom)
+
+    return app
+
+
+async def test_rate_limit_exhaustion_and_retry_after() -> None:
+    """Exhausted buckets should return 429 with a Retry-After header."""
+
+    clock = FakeClock()
+    app = make_rate_limited_app(default_limit_per_minute=2, clock=clock)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
+        base_url="http://test",
+    ) as client:
+        response_one = await client.get("/limited")
+        response_two = await client.get("/limited")
+        response_three = await client.get("/limited")
+
+    assert response_one.status_code == 200
+    assert response_two.status_code == 200
+    assert response_three.status_code == 429
+    assert response_three.json() == {"detail": "Rate limit exceeded"}
+    assert response_three.headers["Retry-After"] == "30"
+
+
+async def test_rate_limit_refills_after_time_passes() -> None:
+    """Buckets should refill over time according to the configured rate."""
+
+    clock = FakeClock()
+    app = make_rate_limited_app(default_limit_per_minute=2, clock=clock)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
+        base_url="http://test",
+    ) as client:
+        await client.get("/limited")
+        await client.get("/limited")
+        denied = await client.get("/limited")
+        clock.advance(30)
+        allowed = await client.get("/limited")
+
+    assert denied.status_code == 429
+    assert allowed.status_code == 200
+
+
+async def test_rate_limit_uses_separate_buckets_per_client_ip() -> None:
+    """Different client IPs should not share rate-limit state."""
+
+    clock = FakeClock()
+    app = make_rate_limited_app(default_limit_per_minute=1, clock=clock)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
+        base_url="http://test",
+    ) as client:
+        allowed = await client.get("/limited", headers={"X-Forwarded-For": "203.0.113.10"})
+        denied = await client.get("/limited", headers={"X-Forwarded-For": "203.0.113.10"})
+        separate_ip = await client.get("/limited", headers={"X-Forwarded-For": "198.51.100.20"})
+
+    assert allowed.status_code == 200
+    assert denied.status_code == 429
+    assert separate_ip.status_code == 200
+
+
+async def test_rate_limit_uses_separate_buckets_per_method() -> None:
+    """GET and POST on the same path should be rate-limited independently."""
+
+    clock = FakeClock()
+    app = make_rate_limited_app(default_limit_per_minute=1, clock=clock)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
+        base_url="http://test",
+    ) as client:
+        get_allowed = await client.get("/method")
+        get_denied = await client.get("/method")
+        post_allowed = await client.post("/method")
+
+    assert get_allowed.status_code == 200
+    assert get_denied.status_code == 429
+    assert post_allowed.status_code == 200
+
+
+async def test_rate_limit_groups_route_templates_with_path_params() -> None:
+    """Different path parameters on one route template should share a bucket."""
+
+    clock = FakeClock()
+    app = make_rate_limited_app(default_limit_per_minute=2, clock=clock)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
+        base_url="http://test",
+    ) as client:
+        first = await client.get("/items/alpha")
+        second = await client.get("/items/beta")
+        third = await client.get("/items/gamma")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert third.status_code == 429
+
+
+async def test_rate_limit_groups_unmatched_paths_by_method() -> None:
+    """Unmatched routes should still be grouped deterministically by method."""
+
+    clock = FakeClock()
+    app = make_rate_limited_app(default_limit_per_minute=2, clock=clock)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
+        base_url="http://test",
+    ) as client:
+        first = await client.get("/missing/alpha")
+        second = await client.get("/missing/beta")
+        third = await client.get("/missing/gamma")
+
+    assert first.status_code == 404
+    assert second.status_code == 404
+    assert third.status_code == 429
+
+
+async def test_rate_limit_uses_first_forwarded_ip_when_valid() -> None:
+    """The first valid X-Forwarded-For IP should define the bucket key."""
+
+    clock = FakeClock()
+    app = make_rate_limited_app(default_limit_per_minute=1, clock=clock)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
+        base_url="http://test",
+    ) as client:
+        first = await client.get(
+            "/limited",
+            headers={"X-Forwarded-For": "203.0.113.1, 198.51.100.10"},
+        )
+        denied = await client.get(
+            "/limited",
+            headers={"X-Forwarded-For": "203.0.113.1, 192.0.2.99"},
+        )
+        separate_first_ip = await client.get(
+            "/limited",
+            headers={"X-Forwarded-For": "198.51.100.10, 203.0.113.1"},
+        )
+
+    assert first.status_code == 200
+    assert denied.status_code == 429
+    assert separate_first_ip.status_code == 200
+
+
+async def test_rate_limit_falls_back_to_client_host_when_forwarded_for_is_invalid() -> None:
+    """Invalid X-Forwarded-For values should fall back to the socket client IP."""
+
+    clock = FakeClock()
+    app = make_rate_limited_app(default_limit_per_minute=1, clock=clock)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, client=("198.51.100.55", 12345)),
+        base_url="http://test",
+    ) as client:
+        first = await client.get("/limited", headers={"X-Forwarded-For": "not-an-ip"})
+        denied = await client.get("/limited", headers={"X-Forwarded-For": "not-an-ip"})
+
+    assert first.status_code == 200
+    assert denied.status_code == 429
+
+
+async def test_rate_limit_applies_configured_endpoint_overrides() -> None:
+    """Configured overrides should allow higher per-minute throughput."""
+
+    clock = FakeClock()
+    app = make_rate_limited_app(default_limit_per_minute=2, clock=clock)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, client=("127.0.0.1", 12345)),
+        base_url="http://test",
+    ) as client:
+        health_responses = [await client.get("/health") for _ in range(5)]
+        sbom_responses = [await client.post("/ingest/sbom") for _ in range(5)]
+
+    assert [response.status_code for response in health_responses[:4]] == [200, 200, 200, 200]
+    assert health_responses[4].status_code == 429
+    assert [response.status_code for response in sbom_responses[:4]] == [200, 200, 200, 200]
+    assert sbom_responses[4].status_code == 429

--- a/uv.lock
+++ b/uv.lock
@@ -1026,6 +1026,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pygithub" },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "pyrate-limiter" },
     { name = "spdx-tools" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
@@ -1068,6 +1069,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "pygithub", specifier = ">=2.8.1" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.11.0" },
+    { name = "pyrate-limiter", specifier = ">=4.1.0" },
     { name = "spdx-tools", specifier = ">=0.8.3" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.47" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
@@ -1390,6 +1392,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyrate-limiter"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/0c/6e78218e6ef726be35a4c0a5e2e281e36ddd940566800219e96d13de99ad/pyrate_limiter-4.1.0.tar.gz", hash = "sha256:be1ac413a263aa410b98757d1b01a880650948a1fc3a959512f15865eb58dbf3", size = 306136, upload-time = "2026-03-22T14:43:03.739Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/fd/57181fafae08385d00ea2702be246ab8035352a0a8e1f63391c2bcad74d4/pyrate_limiter-4.1.0-py3-none-any.whl", hash = "sha256:2696b4e4a6cffb3d40fc76662baccb766697893f0979e12bebbfc7d3b6b19603", size = 38197, upload-time = "2026-03-22T14:43:01.975Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Closes #60.

This PR adds a small operational-hardening slice in two places:
- in-process token-bucket rate limiting for all HTTP endpoints
- a readiness-oriented `/health` response with database, artifact-store, and schema reporting

## Scope
- default `100 req/min` per `(client_ip, method, route template)`
- `GET /health` and `POST /ingest/sbom` overridden to `600 req/min`
- denied requests return `429` with `Retry-After`
- `/health` now returns:
  - `status: "live" | "ready"`
  - `components.artifact_store: "local" | "IPFS"`
  - `components.database: "ready" | "not-configured"`
  - `components.schema_version`
- no new infra
- no new dependency
- no logging or monitoring work from `#59`

## Verification
- `uv run alembic upgrade heads`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy pg_atlas/`
- `uv run basedpyright pg_atlas/rate_limit.py pg_atlas/main.py pg_atlas/routers/health.py tests/test_rate_limit.py tests/routers/test_health.py`
- `PG_ATLAS_API_URL=https://test.pg-atlas.example uv run pytest -v`
- full suite: `385 passed, 13 skipped`

## Notes
- readiness ignores `procrastinate_001` and reports only the application Alembic revision
- rate limiting is intentionally in-process and self-contained for this issue
