### PR TITLE
feat(crawlers): fetch and materialize download counts from package registries

### DIFF
--- a/.github/agent-handoff/implementation-notes.md
+++ b/.github/agent-handoff/implementation-notes.md
@@ -246,3 +246,38 @@ These conventions emerged while validating SBOM queue behavior locally with real
   - clean replay set `893-899` processed targeted queued rows without deadlocks;
   - final log showed `elapsed_s=19.17` for two drain rounds including background failed-artifact retries.
 - Practical guidance: when investigating SBOM worker concurrency, optimize both nested edge writes and external-repo upsert ordering; the latter can dominate deadlock behavior.
+
+## A10 Implementation Notes
+
+These conventions emerged during A10 adoption-signal wiring and apply to future crawler/metric work.
+
+### System taxonomy separation
+
+- `package-deps` (deps.dev) and `registry-crawl` (direct ecosystem registries) are intentionally separate paths.
+- deps.dev scope is fixed to seven systems (`PYPI`, `NPM`, `CARGO`, `MAVEN`, `GO`, `RUBYGEMS`, `NUGET`) and should not be extended in A10 code.
+- Direct registry crawling currently supports `DART` (pub.dev) and `COMPOSER` (Packagist) via `pg_atlas.crawlers.factory`.
+
+### Monorepo adoption downloads map-reduce
+
+- Registry crawls now persist per-package download snapshots under
+  `Repo.repo_metadata["adoption_downloads_by_purl"]`.
+- Map phase: each registry package crawl updates only its own PURL key.
+- Reduce phase: adoption materialization sums per-PURL values and writes the total back to `Repo.adoption_downloads` before percentile ranking.
+
+### Bootstrap queue topology
+
+- `bootstrap.yml` now runs four jobs:
+  - `crawl` (`opengrants` queue)
+  - `deps-dev` (`package-deps` queue)
+  - `registries` (`registry-crawl` queue)
+  - `metrics` (criticality + adoption materialization)
+- `deps-dev` and `registries` run in parallel after `crawl` completes; `metrics` depends on both.
+
+### Unsupported ecosystem observability
+
+- `crawl_github_repo` logs unsupported registry systems using a structured line:
+  `registry-crawl unsupported ecosystem: system=<SYSTEM> purls=<SPACE_SEPARATED_PURLS>`
+- `.github/scripts/parse-bootstrap-log.py` groups these by ecosystem and emits:
+  - `unsupported_ecosystem_group_count`
+  - `unsupported_ecosystem_purl_count`
+  - `unsupported_ecosystems` (grouped full PURL list lines)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,7 +55,7 @@ whichever is being built; stubs for later deliverables are marked `# TODO A<n>:`
 - **mypy** in strict mode (`disallow_untyped_defs`, `explicit_package_bases`, `ignore_missing_imports`).
 - **basedpyright** in strict mode. Run diagnostics and fix problems for every file you touch. Strict
   really is strict, also for test files. Check for `types-*` packages on PyPI. Write missing `.pyi`
-  stubs. Wrap fetched JSON in Pydantic models. Never cast. Only suppress warnings if you have
+  stubs. Wrap fetched JSON in msgspec or Pydantic models. Never cast. Only suppress warnings if you have
   exhausted these options.
 - **pytest-asyncio** with `asyncio_mode = "auto"` — no `@pytest.mark.asyncio` on individual tests.
 - Translate all `pytest` commands to the `runTests` tool equivalent, and run them with the tool.

--- a/.github/scripts/parse-bootstrap-log.py
+++ b/.github/scripts/parse-bootstrap-log.py
@@ -26,16 +26,17 @@ sys.path.insert(0, str(Path(__file__).parent))
 from worker_log_utils import emit_github_output, parse_base_log_line
 
 
-def parse_log(log_path: str) -> tuple[dict[str, dict[str, int]], list[str], list[str]]:
+def parse_log(log_path: str) -> tuple[dict[str, dict[str, int]], list[str], list[str], dict[str, set[str]]]:
     """
     Parse a single log file.
 
     Returns:
-        A tuple of (status_counts_by_queue, warnings, errors).
+        A tuple of (status_counts_by_queue, warnings, errors, unsupported_purls).
     """
     status_counts: dict[str, dict[str, int]] = {}
     warnings: list[str] = []
     errors: list[str] = []
+    unsupported_purls: dict[str, set[str]] = {}
 
     with open(log_path) as f:
         for line in f:
@@ -51,8 +52,29 @@ def parse_log(log_path: str) -> tuple[dict[str, dict[str, int]], list[str], list
                 warnings.append(data)
             elif tag == "error":
                 errors.append(data)
+            elif tag == "unsupported":
+                system = data["system"]
+                purls = data["purls"]
+                unsupported_purls.setdefault(system, set()).update(purls)
 
-    return status_counts, warnings, errors
+    return status_counts, warnings, errors, unsupported_purls
+
+
+def _format_unsupported_ecosystems(unsupported_purls: dict[str, set[str]]) -> str:
+    """
+    Build one markdown-ready grouped summary for unsupported ecosystems.
+    """
+
+    if not unsupported_purls:
+        return "None"
+
+    lines: list[str] = []
+    for system in sorted(unsupported_purls):
+        purls = sorted(unsupported_purls[system])
+        joined = " ".join(purls)
+        lines.append(f"- {system} ({len(purls)}): {joined}")
+
+    return "\n".join(lines)
 
 
 def main() -> None:
@@ -64,14 +86,30 @@ def main() -> None:
     all_counts: dict[str, dict[str, int]] = {}
     all_warnings: list[str] = []
     all_errors: list[str] = []
+    all_unsupported_purls: dict[str, set[str]] = {}
 
     for path in sys.argv[1:]:
-        counts, warnings, errors = parse_log(path)
+        counts, warnings, errors, unsupported_purls = parse_log(path)
         all_counts.update(counts)
         all_warnings.extend(warnings)
         all_errors.extend(errors)
+        for system, purls in unsupported_purls.items():
+            all_unsupported_purls.setdefault(system, set()).update(purls)
 
-    emit_github_output(all_counts, all_warnings, all_errors)
+    unsupported_group_count = len(all_unsupported_purls)
+    unsupported_purl_count = sum(len(values) for values in all_unsupported_purls.values())
+    unsupported_summary = _format_unsupported_ecosystems(all_unsupported_purls)
+
+    emit_github_output(
+        all_counts,
+        all_warnings,
+        all_errors,
+        extra_outputs={
+            "unsupported_ecosystem_group_count": str(unsupported_group_count),
+            "unsupported_ecosystem_purl_count": str(unsupported_purl_count),
+            "unsupported_ecosystems": unsupported_summary,
+        },
+    )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/worker_log_utils.py
+++ b/.github/scripts/worker_log_utils.py
@@ -25,6 +25,10 @@ _STATUS_RE = re.compile(
 # Capture WARNING and ERROR lines for the detail section.
 _WARN_ERROR_RE = re.compile(r"^\S+ \S+ (?P<level>WARNING|ERROR)\s+\S+: (?P<message>.+)$")
 
+_UNSUPPORTED_ECOSYSTEM_RE = re.compile(
+    r"registry-crawl unsupported ecosystem: system=(?P<system>[A-Z0-9_+-]+) purls=(?P<purls>.+)$"
+)
+
 
 def parse_base_log_line(line: str) -> tuple[str, Any] | None:
     """
@@ -46,6 +50,15 @@ def parse_base_log_line(line: str) -> tuple[str, Any] | None:
             "failed": int(m.group("failed")),
             "cancelled": int(m.group("cancelled")),
             "aborted": int(m.group("aborted")),
+        }
+
+    unsupported_match = _UNSUPPORTED_ECOSYSTEM_RE.search(line)
+    if unsupported_match:
+        purls_text = unsupported_match.group("purls").strip()
+        purls = [purl for purl in purls_text.split(" ") if purl]
+        return "unsupported", {
+            "system": unsupported_match.group("system"),
+            "purls": purls,
         }
 
     wm = _WARN_ERROR_RE.search(line)

--- a/.github/templates/bootstrap-summary.md
+++ b/.github/templates/bootstrap-summary.md
@@ -6,10 +6,16 @@
 | ----- | --------: | -----: | ------: | --------: |
 | `opengrants` | {opengrants_succeeded} | {opengrants_failed} | {opengrants_todo} | {opengrants_cancelled} |
 | `package-deps` | {package_deps_succeeded} | {package_deps_failed} | {package_deps_todo} | {package_deps_cancelled} |
+| `registry-crawl` | {registry_crawl_succeeded} | {registry_crawl_failed} | {registry_crawl_todo} | {registry_crawl_cancelled} |
 
 - **Trigger**: {trigger}
 - **Run**: [{run_id}]({server_url}/{repository}/actions/runs/{run_id})
 - **Finished**: {finished}
 - **Warnings**: {warning_count} | **Errors**: {error_count}
+- **Unsupported ecosystems**: {unsupported_ecosystem_group_count} groups / {unsupported_ecosystem_purl_count} packages
+
+### Unsupported Ecosystems
+
+{unsupported_ecosystems}
 
 {error_detail}

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -117,7 +117,7 @@ jobs:
         run: uv sync --frozen
 
       - name: Run worker — registry-crawl queue
-        run: uv run python -m pg_atlas.procrastinate.worker --queue=registry-crawl --drain-rounds=20 --concurrency=8 --tee=registry-crawl-worker.log
+        run: uv run python -m pg_atlas.procrastinate.worker --queue=registry-crawl --drain-rounds=2 --concurrency=2 --tee=registry-crawl-worker.log
 
       - name: Parse worker logs
         id: parse-logs

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,11 +1,13 @@
 # Reference Graph Bootstrap — weekly crawl of OpenGrants, GitHub, and deps.dev.
 #
-# Runs two sequential worker steps:
-#   1. opengrants queue (sync_opengrants → process_project → crawl_github_repo)
-#   2. package-deps queue (crawl_package_deps)
+# Runs four jobs:
+#   1. crawl       (opengrants queue)
+#   2. deps-dev    (package-deps queue)
+#   3. registries  (registry-crawl queue)
+#   4. metrics     (materialize criticality/adoption)
 #
-# The separation ensures all Repo vertices and Project associations exist
-# before the dependency crawler checks them.
+# deps-dev and registries run in parallel after crawl completes.
+# metrics runs after both queue jobs complete.
 #
 # SPDX-FileCopyrightText: 2026 PG Atlas contributors
 # SPDX-License-Identifier: MPL-2.0
@@ -23,6 +25,14 @@ concurrency:
 jobs:
   crawl:
     runs-on: ubuntu-latest
+    outputs:
+      opengrants_succeeded: ${{ steps.parse-logs.outputs.opengrants_succeeded }}
+      opengrants_failed: ${{ steps.parse-logs.outputs.opengrants_failed }}
+      opengrants_todo: ${{ steps.parse-logs.outputs.opengrants_todo }}
+      opengrants_cancelled: ${{ steps.parse-logs.outputs.opengrants_cancelled }}
+      warning_count: ${{ steps.parse-logs.outputs.warning_count }}
+      error_count: ${{ steps.parse-logs.outputs.error_count }}
+      errors: ${{ steps.parse-logs.outputs.errors }}
     timeout-minutes: 300
     env:
       PG_ATLAS_DATABASE_URL: ${{ secrets.DATABASE_URL }}
@@ -44,38 +54,81 @@ jobs:
       - name: Run worker — opengrants queue
         run: uv run python -m pg_atlas.procrastinate.worker --queue=opengrants --drain-rounds=4 --concurrency=8 --tee=opengrants-worker.log
 
+      - name: Parse worker logs
+        id: parse-logs
+        run: python .github/scripts/parse-bootstrap-log.py opengrants-worker.log
+
+  deps-dev:
+    runs-on: ubuntu-latest
+    needs: crawl
+    outputs:
+      package_deps_succeeded: ${{ steps.parse-logs.outputs.package_deps_succeeded }}
+      package_deps_failed: ${{ steps.parse-logs.outputs.package_deps_failed }}
+      package_deps_todo: ${{ steps.parse-logs.outputs.package_deps_todo }}
+      package_deps_cancelled: ${{ steps.parse-logs.outputs.package_deps_cancelled }}
+      warning_count: ${{ steps.parse-logs.outputs.warning_count }}
+      error_count: ${{ steps.parse-logs.outputs.error_count }}
+      errors: ${{ steps.parse-logs.outputs.errors }}
+    timeout-minutes: 240
+    env:
+      PG_ATLAS_DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      UV_NO_GROUP: dev
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
       - name: Run worker — package-deps queue
         run: uv run python -m pg_atlas.procrastinate.worker --queue=package-deps --drain-rounds=30 --concurrency=8 --tee=package-deps-worker.log
 
       - name: Parse worker logs
         id: parse-logs
-        run: python .github/scripts/parse-bootstrap-log.py opengrants-worker.log package-deps-worker.log
+        run: python .github/scripts/parse-bootstrap-log.py package-deps-worker.log
 
-      - name: Write job summary
-        run: |
-          python .github/scripts/render-template.py \
-            .github/templates/bootstrap-summary.md \
-            trigger="${{ github.event_name }}" \
-            run_id="${{ github.run_id }}" \
-            server_url="${{ github.server_url }}" \
-            repository="${{ github.repository }}" \
-            finished="$(date -u '+%Y-%m-%d %H:%M:%S UTC')" \
-            opengrants_succeeded="${{ steps.parse-logs.outputs.opengrants_succeeded || '—' }}" \
-            opengrants_failed="${{ steps.parse-logs.outputs.opengrants_failed || '—' }}" \
-            opengrants_todo="${{ steps.parse-logs.outputs.opengrants_todo || '—' }}" \
-            opengrants_cancelled="${{ steps.parse-logs.outputs.opengrants_cancelled || '—' }}" \
-            package_deps_succeeded="${{ steps.parse-logs.outputs.package_deps_succeeded || '—' }}" \
-            package_deps_failed="${{ steps.parse-logs.outputs.package_deps_failed || '—' }}" \
-            package_deps_todo="${{ steps.parse-logs.outputs.package_deps_todo || '—–' }}" \
-            package_deps_cancelled="${{ steps.parse-logs.outputs.package_deps_cancelled || '—' }}" \
-            warning_count="${{ steps.parse-logs.outputs.warning_count || '0' }}" \
-            error_count="${{ steps.parse-logs.outputs.error_count || '0' }}" \
-            error_detail="${{ steps.parse-logs.outputs.errors || '' }}" \
-            >> "$GITHUB_STEP_SUMMARY"
+  registries:
+    runs-on: ubuntu-latest
+    needs: crawl
+    outputs:
+      registry_crawl_succeeded: ${{ steps.parse-logs.outputs.registry_crawl_succeeded }}
+      registry_crawl_failed: ${{ steps.parse-logs.outputs.registry_crawl_failed }}
+      registry_crawl_todo: ${{ steps.parse-logs.outputs.registry_crawl_todo }}
+      registry_crawl_cancelled: ${{ steps.parse-logs.outputs.registry_crawl_cancelled }}
+      unsupported_ecosystem_group_count: ${{ steps.parse-logs.outputs.unsupported_ecosystem_group_count }}
+      unsupported_ecosystem_purl_count: ${{ steps.parse-logs.outputs.unsupported_ecosystem_purl_count }}
+      unsupported_ecosystems: ${{ steps.parse-logs.outputs.unsupported_ecosystems }}
+      warning_count: ${{ steps.parse-logs.outputs.warning_count }}
+      error_count: ${{ steps.parse-logs.outputs.error_count }}
+      errors: ${{ steps.parse-logs.outputs.errors }}
+    timeout-minutes: 180
+    env:
+      PG_ATLAS_DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      UV_NO_GROUP: dev
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run worker — registry-crawl queue
+        run: uv run python -m pg_atlas.procrastinate.worker --queue=registry-crawl --drain-rounds=20 --concurrency=8 --tee=registry-crawl-worker.log
+
+      - name: Parse worker logs
+        id: parse-logs
+        run: python .github/scripts/parse-bootstrap-log.py registry-crawl-worker.log
 
   metrics:
     runs-on: ubuntu-latest
-    needs: crawl
+    needs:
+      - crawl
+      - deps-dev
+      - registries
     timeout-minutes: 60
     env:
       PG_ATLAS_DATABASE_URL: ${{ secrets.DATABASE_URL }}
@@ -88,6 +141,45 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --frozen
+
+      - name: Write bootstrap summary
+        env:
+          WARN_CRAWL: ${{ needs.crawl.outputs.warning_count || '0' }}
+          WARN_DEPS: ${{ needs.deps-dev.outputs.warning_count || '0' }}
+          WARN_REG: ${{ needs.registries.outputs.warning_count || '0' }}
+          ERR_CRAWL: ${{ needs.crawl.outputs.error_count || '0' }}
+          ERR_DEPS: ${{ needs.deps-dev.outputs.error_count || '0' }}
+          ERR_REG: ${{ needs.registries.outputs.error_count || '0' }}
+        run: |
+          warning_total=$((WARN_CRAWL + WARN_DEPS + WARN_REG))
+          error_total=$((ERR_CRAWL + ERR_DEPS + ERR_REG))
+
+          python .github/scripts/render-template.py \
+            .github/templates/bootstrap-summary.md \
+            trigger="${{ github.event_name }}" \
+            run_id="${{ github.run_id }}" \
+            server_url="${{ github.server_url }}" \
+            repository="${{ github.repository }}" \
+            finished="$(date -u '+%Y-%m-%d %H:%M:%S UTC')" \
+            opengrants_succeeded="${{ needs.crawl.outputs.opengrants_succeeded || '—' }}" \
+            opengrants_failed="${{ needs.crawl.outputs.opengrants_failed || '—' }}" \
+            opengrants_todo="${{ needs.crawl.outputs.opengrants_todo || '—' }}" \
+            opengrants_cancelled="${{ needs.crawl.outputs.opengrants_cancelled || '—' }}" \
+            package_deps_succeeded="${{ needs.deps-dev.outputs.package_deps_succeeded || '—' }}" \
+            package_deps_failed="${{ needs.deps-dev.outputs.package_deps_failed || '—' }}" \
+            package_deps_todo="${{ needs.deps-dev.outputs.package_deps_todo || '—' }}" \
+            package_deps_cancelled="${{ needs.deps-dev.outputs.package_deps_cancelled || '—' }}" \
+            registry_crawl_succeeded="${{ needs.registries.outputs.registry_crawl_succeeded || '—' }}" \
+            registry_crawl_failed="${{ needs.registries.outputs.registry_crawl_failed || '—' }}" \
+            registry_crawl_todo="${{ needs.registries.outputs.registry_crawl_todo || '—' }}" \
+            registry_crawl_cancelled="${{ needs.registries.outputs.registry_crawl_cancelled || '—' }}" \
+            warning_count="$warning_total" \
+            error_count="$error_total" \
+            unsupported_ecosystem_group_count="${{ needs.registries.outputs.unsupported_ecosystem_group_count || '0' }}" \
+            unsupported_ecosystem_purl_count="${{ needs.registries.outputs.unsupported_ecosystem_purl_count || '0' }}" \
+            unsupported_ecosystems="${{ needs.registries.outputs.unsupported_ecosystems || 'None' }}" \
+            error_detail="${{ needs.crawl.outputs.errors || '' }}${{ needs.deps-dev.outputs.errors || '' }}${{ needs.registries.outputs.errors || '' }}" \
+            >> "$GITHUB_STEP_SUMMARY"
 
       - name: Materialize criticality
         run: uv run python -m pg_atlas.metrics.materialize_criticality --tee=criticality.log

--- a/pg_atlas/crawlers/__main__.py
+++ b/pg_atlas/crawlers/__main__.py
@@ -17,9 +17,10 @@ import asyncio
 import logging
 
 import httpx
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from pg_atlas.config import settings
+from pg_atlas.crawlers.factory import build_registry_crawler, normalize_registry_system
+from pg_atlas.db_models.session import get_session_factory
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ logger = logging.getLogger(__name__)
 async def main() -> None:
     """Parse arguments, configure the crawler, and run the crawl."""
     parser = argparse.ArgumentParser(description="PG Atlas registry crawler")
-    parser.add_argument("registry", choices=["pubdev", "packagist"])
+    parser.add_argument("registry", choices=["pubdev", "packagist", "dart", "composer", "flutter", "php"])
     parser.add_argument("packages", nargs="+", help="Package names to crawl")
     args = parser.parse_args()
 
@@ -37,32 +38,30 @@ async def main() -> None:
         logger.error("PG_ATLAS_DATABASE_URL is required for crawling")
         raise SystemExit(1)
 
-    # Import crawlers here to avoid circular imports at module level
-    from pg_atlas.crawlers.packagist import PackagistCrawler
-    from pg_atlas.crawlers.pubdev import PubDevCrawler
+    session_factory = get_session_factory()
+    normalized_system = normalize_registry_system(args.registry)
+    if normalized_system is None:
+        logger.error(f"Unsupported registry argument: {args.registry}")
+        raise SystemExit(2)
 
-    engine = create_async_engine(settings.DATABASE_URL, pool_pre_ping=True)
-    try:
-        session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker(
-            engine,
-            expire_on_commit=False,
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(settings.CRAWLER_TIMEOUT, connect=10.0),
+        follow_redirects=True,
+        headers={"User-Agent": "pg-atlas-crawler/0.1"},
+    ) as client:
+        crawler = build_registry_crawler(
+            normalized_system,
+            client=client,
+            session_factory=session_factory,
+            rate_limit=settings.CRAWLER_RATE_LIMIT,
+            max_retries=settings.CRAWLER_MAX_RETRIES,
         )
 
-        async with httpx.AsyncClient(
-            timeout=httpx.Timeout(settings.CRAWLER_TIMEOUT, connect=10.0),
-            follow_redirects=True,
-            headers={"User-Agent": "pg-atlas-crawler/0.1"},
-        ) as client:
-            crawler_cls = PubDevCrawler if args.registry == "pubdev" else PackagistCrawler
-            crawler = crawler_cls(
-                client=client,
-                session_factory=session_factory,
-                rate_limit=settings.CRAWLER_RATE_LIMIT,
-                max_retries=settings.CRAWLER_MAX_RETRIES,
-            )
-            result = await crawler.crawl_and_persist(args.packages)
-    finally:
-        await engine.dispose()
+        if crawler is None:
+            logger.error(f"No crawler available for system: {normalized_system}")
+            raise SystemExit(2)
+
+        result = await crawler.crawl_and_persist(args.packages)
 
     logger.info(
         f"Crawl complete: {result.packages_processed} packages, {result.vertices_upserted} vertices, "

--- a/pg_atlas/crawlers/base.py
+++ b/pg_atlas/crawlers/base.py
@@ -75,7 +75,7 @@ class CrawlResult:
     vertices_upserted: int = 0
     edges_created: int = 0
     edges_skipped: int = 0
-    errors: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list[str])
 
 
 # ---------------------------------------------------------------------------
@@ -126,8 +126,7 @@ async def _upsert_vertex(
             await session.flush()
     except IntegrityError:
         session.expunge(ext)
-        ext = await get_vertex(session, canonical_id)  # type: ignore[assignment]
-
+        ext = await get_vertex(session, canonical_id)
     return ext
 
 

--- a/pg_atlas/crawlers/base.py
+++ b/pg_atlas/crawlers/base.py
@@ -6,6 +6,9 @@ Provides ``RegistryCrawler`` — the base class that all concrete crawlers
 handling, rate limiting, vertex upsert, edge creation with confidence
 preservation, and per-package transaction boundaries.
 
+The name "crawler" does not really apply yet, since we don't traverse any
+of the found dependency edges. We might extend this behavior in the future.
+
 SPDX-FileCopyrightText: 2026 PG Atlas contributors
 SPDX-License-Identifier: MPL-2.0
 """
@@ -20,14 +23,12 @@ from typing import Any
 
 import httpx
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from pg_atlas.db_models.base import EdgeConfidence
-from pg_atlas.db_models.depends_on import DependsOn
-from pg_atlas.db_models.repo_vertex import ExternalRepo, Repo, RepoVertex
-from pg_atlas.db_models.vertex_ops import get_vertex
+from pg_atlas.db_models.repo_vertex import Repo
+from pg_atlas.db_models.vertex_ops import upsert_external_repo
 from pg_atlas.metrics.adoption import merge_download_into_repo_metadata
+from pg_atlas.procrastinate.upserts import find_repo_by_release_purl, upsert_depends_on
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +63,7 @@ class CrawledPackage:
     display_name: str
     latest_version: str
     repo_url: str | None
-    downloads: int | None
+    downloads_30d: int | None
     stars: int | None
     metadata: dict[str, Any]
     dependencies: list[CrawledDependency]
@@ -80,111 +81,11 @@ class CrawlResult:
 
 
 # ---------------------------------------------------------------------------
-# Vertex upsert (self-contained — does NOT import from persist.py)
+# Exceptions
 # ---------------------------------------------------------------------------
 
 
-async def _upsert_vertex(
-    session: AsyncSession,
-    canonical_id: str,
-    display_name: str,
-    latest_version: str,
-    repo_url: str | None,
-) -> RepoVertex:
-    """
-    Upsert a RepoVertex, preserving the existing subtype.
-
-    - If a Repo exists with this canonical_id: update mutable fields, return it.
-    - If an ExternalRepo exists: update mutable fields, return it.
-    - If nothing exists: create as ExternalRepo and return it.
-
-    NEVER create a Repo — only SBOM ingestion creates Repos (via OIDC claims).
-    NEVER downgrade a Repo to ExternalRepo.
-    """
-    vertex = await get_vertex(session, canonical_id)
-
-    if vertex is not None:
-        # Both Repo and ExternalRepo have these attributes but RepoVertex (the
-        # JTI base) does not declare them, so we narrow the type for mypy.
-        if isinstance(vertex, (Repo, ExternalRepo)):
-            vertex.display_name = display_name
-            if latest_version:
-                vertex.latest_version = latest_version
-            if repo_url:
-                vertex.repo_url = repo_url
-        await session.flush()
-        return vertex
-
-    ext = ExternalRepo(
-        canonical_id=canonical_id,
-        display_name=display_name,
-        latest_version=latest_version,
-        repo_url=repo_url,
-    )
-    session.add(ext)
-    try:
-        async with session.begin_nested():
-            await session.flush()
-    except IntegrityError:
-        session.expunge(ext)
-        existing = await get_vertex(session, canonical_id)
-        if existing is not None:
-            return existing
-
-        raise
-
-    return ext
-
-
-# ---------------------------------------------------------------------------
-# Edge upsert (never overwrites verified_sbom with inferred_shadow)
-# ---------------------------------------------------------------------------
-
-
-async def _upsert_edge(
-    session: AsyncSession,
-    in_vertex_id: int,
-    out_vertex_id: int,
-    version_range: str | None,
-) -> bool | None:
-    """
-    Create or update a DependsOn edge with inferred_shadow confidence.
-
-    Returns True if an edge was created, False if an inferred edge was updated,
-    or None if a verified_sbom edge was preserved (skipped).
-    """
-    existing = await session.execute(
-        select(DependsOn).where(
-            DependsOn.in_vertex_id == in_vertex_id,
-            DependsOn.out_vertex_id == out_vertex_id,
-        )
-    )
-    edge = existing.scalar_one_or_none()
-
-    if edge is None:
-        new_edge = DependsOn(
-            in_vertex_id=in_vertex_id,
-            out_vertex_id=out_vertex_id,
-            version_range=version_range or None,
-            confidence=EdgeConfidence.inferred_shadow,
-        )
-        session.add(new_edge)
-        try:
-            async with session.begin_nested():
-                await session.flush()
-        except IntegrityError as exc:
-            session.expunge(new_edge)
-            logger.debug(f"Edge {in_vertex_id}->{out_vertex_id} already exists: {exc}")
-            return None
-        return True
-
-    if edge.confidence == EdgeConfidence.inferred_shadow:
-        edge.version_range = version_range or None
-        await session.flush()
-        return False
-
-    # verified_sbom — leave untouched
-    return None
+class SourceRepoNotFound(Exception): ...
 
 
 # ---------------------------------------------------------------------------
@@ -280,7 +181,6 @@ class RegistryCrawler(ABC):
     async def crawl_and_persist(
         self,
         package_names: list[str],
-        source_repo_canonical_id: str | None = None,
     ) -> CrawlResult:
         """
         Crawl a list of packages and persist vertices/edges to the database.
@@ -298,7 +198,6 @@ class RegistryCrawler(ABC):
                         session,
                         package_name,
                         result,
-                        source_repo_canonical_id=source_repo_canonical_id,
                     )
                     await session.commit()
                     result.packages_processed += 1
@@ -318,40 +217,39 @@ class RegistryCrawler(ABC):
         session: AsyncSession,
         package_name: str,
         result: CrawlResult,
-        source_repo_canonical_id: str | None,
     ) -> None:
         """
-        Fetch, upsert, and create edges for a single package.
+        Merge package metadata into the source Repo, and create dependency edges.
 
         This runs inside a session context managed by ``crawl_and_persist``.
         """
         crawled = await self.fetch_package(package_name)
+        source_repo: Repo | None = None
+        if crawled.repo_url:
+            package_repo_url = crawled.repo_url.removesuffix(".git")
+            source_repo = await session.scalar(select(Repo).where(Repo.repo_url == package_repo_url))
 
-        # Upsert the main package vertex
-        vertex = await _upsert_vertex(
-            session,
-            canonical_id=crawled.canonical_id,
-            display_name=crawled.display_name,
-            latest_version=crawled.latest_version,
-            repo_url=crawled.repo_url,
-        )
-        result.vertices_upserted += 1
+        if not source_repo:
+            repo_match = await find_repo_by_release_purl(crawled.canonical_id)
+            if repo_match:
+                vertex_id, _, _ = repo_match
+                source_repo = await session.get(Repo, vertex_id)
 
-        if source_repo_canonical_id and crawled.downloads is not None:
-            source_repo = await session.scalar(select(Repo).where(Repo.canonical_id == source_repo_canonical_id))
+        if not source_repo:
+            raise SourceRepoNotFound(f"No source repo found for package {package_name}")
 
-            if source_repo is not None:
-                source_repo.repo_metadata = merge_download_into_repo_metadata(
-                    source_repo.repo_metadata,
-                    package_purl=crawled.canonical_id,
-                    downloads=crawled.downloads,
-                    repo_canonical_id=source_repo.canonical_id,
-                )
-                await session.flush()
+        if crawled.downloads_30d is not None:
+            source_repo.repo_metadata = merge_download_into_repo_metadata(
+                source_repo.repo_metadata,
+                package_purl=crawled.canonical_id,
+                downloads=crawled.downloads_30d,
+                repo_canonical_id=source_repo.canonical_id,
+            )
+            await session.flush()
 
         # Forward dependencies: this package depends on each dep
         for dep in crawled.dependencies:
-            dep_vertex = await _upsert_vertex(
+            dep_vertex = await upsert_external_repo(
                 session,
                 canonical_id=dep.canonical_id,
                 display_name=dep.display_name,
@@ -360,21 +258,21 @@ class RegistryCrawler(ABC):
             )
             result.vertices_upserted += 1
 
-            edge_result = await _upsert_edge(
+            edge_result = await upsert_depends_on(
                 session,
-                in_vertex_id=vertex.id,
+                in_vertex_id=source_repo.id,
                 out_vertex_id=dep_vertex.id,
                 version_range=dep.version_range,
             )
             if edge_result is True:
                 result.edges_created += 1
-            elif edge_result is None:
+            else:
                 result.edges_skipped += 1
 
         # Reverse dependents: each dependent depends on this package
         dependents = await self.fetch_dependents(package_name)
         for dependent in dependents:
-            dep_vertex = await _upsert_vertex(
+            dep_vertex = await upsert_external_repo(
                 session,
                 canonical_id=dependent.canonical_id,
                 display_name=dependent.display_name,
@@ -383,13 +281,13 @@ class RegistryCrawler(ABC):
             )
             result.vertices_upserted += 1
 
-            edge_result = await _upsert_edge(
+            edge_result = await upsert_depends_on(
                 session,
                 in_vertex_id=dep_vertex.id,
-                out_vertex_id=vertex.id,
+                out_vertex_id=source_repo.id,
                 version_range=None,
             )
             if edge_result is True:
                 result.edges_created += 1
-            elif edge_result is None:
+            else:
                 result.edges_skipped += 1

--- a/pg_atlas/crawlers/base.py
+++ b/pg_atlas/crawlers/base.py
@@ -100,6 +100,15 @@ class RegistryCrawler(ABC):
     Concrete subclasses implement ``fetch_package`` and ``fetch_dependents`` for
     their specific registry API.  The shared ``crawl_and_persist`` method handles
     DB writes, transaction boundaries, and rate limiting.
+
+    Current write contract:
+    - crawler package canonical IDs stay as package PURLs
+    - a package must resolve to an existing source ``Repo`` by repository URL
+        (or release-PURL fallback)
+    - download counts are written only to
+        ``Repo.repo_metadata['adoption_downloads_by_purl']``
+    - scalar ``Repo.adoption_downloads`` is reduced and persisted later by
+        adoption materialization.
     """
 
     def __init__(
@@ -183,11 +192,14 @@ class RegistryCrawler(ABC):
         package_names: list[str],
     ) -> CrawlResult:
         """
-        Crawl a list of packages and persist vertices/edges to the database.
+        Crawl packages and persist source-repo edges + metadata.
 
         Each package is processed in its own transaction (commit per-package).
         Failures are logged and collected in ``CrawlResult.errors`` — the crawl
         continues with the remaining packages.
+
+        A package is counted as processed only if its source ``Repo`` can be
+        resolved and all writes commit successfully.
         """
         result = CrawlResult()
 
@@ -219,7 +231,11 @@ class RegistryCrawler(ABC):
         result: CrawlResult,
     ) -> None:
         """
-        Merge package metadata into the source Repo, and create dependency edges.
+        Merge package metadata into the source Repo and write dependency edges.
+
+        The package vertex itself is not promoted to ``Repo`` in this path.
+        Instead, dependency graph edges are anchored on the resolved source
+        ``Repo`` vertex.
 
         This runs inside a session context managed by ``crawl_and_persist``.
         """

--- a/pg_atlas/crawlers/base.py
+++ b/pg_atlas/crawlers/base.py
@@ -22,9 +22,11 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
+import msgspec
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from pg_atlas.db_models.release import Release, merge_releases
 from pg_atlas.db_models.repo_vertex import Repo
 from pg_atlas.db_models.vertex_ops import upsert_external_repo
 from pg_atlas.metrics.adoption import merge_download_into_repo_metadata
@@ -67,6 +69,7 @@ class CrawledPackage:
     stars: int | None
     metadata: dict[str, Any]
     dependencies: list[CrawledDependency]
+    releases: list[Release]
 
 
 @dataclass
@@ -261,6 +264,22 @@ class RegistryCrawler(ABC):
                 downloads=crawled.downloads_30d,
                 repo_canonical_id=source_repo.canonical_id,
             )
+
+        package_releases = crawled.releases
+        # ensure that `crawled.canonical_id` is in the releases
+        if not any(release.purl == crawled.canonical_id for release in package_releases):
+            package_releases = [
+                *package_releases,
+                Release(
+                    purl=crawled.canonical_id,
+                    version=crawled.latest_version,
+                    release_date="",
+                ),
+            ]
+
+        source_repo.releases = merge_releases(source_repo.releases, package_releases)
+
+        if crawled.downloads_30d is not None or package_releases:
             await session.flush()
 
         # Forward dependencies: this package depends on each dep
@@ -307,3 +326,17 @@ class RegistryCrawler(ABC):
                 result.edges_created += 1
             else:
                 result.edges_skipped += 1
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def as_str_key_dict(value: Any) -> dict[str, Any]:
+    """Return a dict with only string keys; otherwise return an empty dict."""
+
+    try:
+        return msgspec.convert(value, type=dict[str, Any])
+    except msgspec.ValidationError:
+        return {}

--- a/pg_atlas/crawlers/base.py
+++ b/pg_atlas/crawlers/base.py
@@ -27,6 +27,7 @@ from pg_atlas.db_models.base import EdgeConfidence
 from pg_atlas.db_models.depends_on import DependsOn
 from pg_atlas.db_models.repo_vertex import ExternalRepo, Repo, RepoVertex
 from pg_atlas.db_models.vertex_ops import get_vertex
+from pg_atlas.metrics.adoption import merge_download_into_repo_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +127,12 @@ async def _upsert_vertex(
             await session.flush()
     except IntegrityError:
         session.expunge(ext)
-        ext = await get_vertex(session, canonical_id)
+        existing = await get_vertex(session, canonical_id)
+        if existing is not None:
+            return existing
+
+        raise
+
     return ext
 
 
@@ -271,7 +277,11 @@ class RegistryCrawler(ABC):
             raise last_exc
         raise RuntimeError(f"Exhausted retries for {url}")
 
-    async def crawl_and_persist(self, package_names: list[str]) -> CrawlResult:
+    async def crawl_and_persist(
+        self,
+        package_names: list[str],
+        source_repo_canonical_id: str | None = None,
+    ) -> CrawlResult:
         """
         Crawl a list of packages and persist vertices/edges to the database.
 
@@ -284,7 +294,12 @@ class RegistryCrawler(ABC):
         for i, package_name in enumerate(package_names):
             async with self.session_factory() as session:
                 try:
-                    await self._process_package(session, package_name, result)
+                    await self._process_package(
+                        session,
+                        package_name,
+                        result,
+                        source_repo_canonical_id=source_repo_canonical_id,
+                    )
                     await session.commit()
                     result.packages_processed += 1
                 except Exception as exc:
@@ -303,6 +318,7 @@ class RegistryCrawler(ABC):
         session: AsyncSession,
         package_name: str,
         result: CrawlResult,
+        source_repo_canonical_id: str | None,
     ) -> None:
         """
         Fetch, upsert, and create edges for a single package.
@@ -321,15 +337,17 @@ class RegistryCrawler(ABC):
         )
         result.vertices_upserted += 1
 
-        # Write adoption data only if this is a Repo (Rule 1)
-        if isinstance(vertex, Repo):
-            if crawled.downloads is not None:
-                vertex.adoption_downloads = crawled.downloads
-            if crawled.stars is not None:
-                vertex.adoption_stars = crawled.stars
-            if crawled.metadata:
-                vertex.repo_metadata = crawled.metadata
-            await session.flush()
+        if source_repo_canonical_id and crawled.downloads is not None:
+            source_repo = await session.scalar(select(Repo).where(Repo.canonical_id == source_repo_canonical_id))
+
+            if source_repo is not None:
+                source_repo.repo_metadata = merge_download_into_repo_metadata(
+                    source_repo.repo_metadata,
+                    package_purl=crawled.canonical_id,
+                    downloads=crawled.downloads,
+                    repo_canonical_id=source_repo.canonical_id,
+                )
+                await session.flush()
 
         # Forward dependencies: this package depends on each dep
         for dep in crawled.dependencies:

--- a/pg_atlas/crawlers/base.py
+++ b/pg_atlas/crawlers/base.py
@@ -91,6 +91,9 @@ class CrawlResult:
 class SourceRepoNotFound(Exception): ...
 
 
+class AllPackagesFailed(Exception): ...
+
+
 # ---------------------------------------------------------------------------
 # Abstract base crawler
 # ---------------------------------------------------------------------------
@@ -128,7 +131,11 @@ class RegistryCrawler(ABC):
 
     @abstractmethod
     async def fetch_package(self, package_name: str) -> CrawledPackage:
-        """Fetch package metadata from the registry API."""
+        """
+        Fetch package metadata from the registry API.
+
+        This SHOULD populate `releases[].release_date` and it MUST be `isoformat`.
+        """
         ...
 
     @abstractmethod
@@ -269,12 +276,12 @@ class RegistryCrawler(ABC):
         # ensure that `crawled.canonical_id` is in the releases
         if not any(release.purl == crawled.canonical_id for release in package_releases):
             package_releases = [
-                *package_releases,
                 Release(
                     purl=crawled.canonical_id,
                     version=crawled.latest_version,
                     release_date="",
                 ),
+                *package_releases,
             ]
 
         source_repo.releases = merge_releases(source_repo.releases, package_releases)

--- a/pg_atlas/crawlers/factory.py
+++ b/pg_atlas/crawlers/factory.py
@@ -1,0 +1,76 @@
+"""
+Shared factory helpers for registry crawler construction.
+
+These helpers keep queue-driven task execution and CLI invocation aligned on
+the same system normalization and crawler mapping behavior.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from pg_atlas.crawlers.base import RegistryCrawler
+from pg_atlas.crawlers.packagist import PackagistCrawler
+from pg_atlas.crawlers.pubdev import PubDevCrawler
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_registry_system(system: str) -> str | None:
+    """
+    Normalize one registry ecosystem alias to its canonical system token.
+    """
+
+    normalized = system.strip().upper()
+
+    match normalized:
+        case "DART" | "FLUTTER" | "PUB" | "PUBDEV":
+            return "DART"
+        case "COMPOSER" | "PHP" | "PACKAGIST":
+            return "COMPOSER"
+        case _:
+            return None
+
+
+def build_registry_crawler(
+    system: str,
+    client: httpx.AsyncClient,
+    session_factory: async_sessionmaker[AsyncSession],
+    rate_limit: float,
+    max_retries: int,
+) -> RegistryCrawler | None:
+    """
+    Build a concrete crawler instance for the requested registry system.
+    """
+
+    normalized = normalize_registry_system(system)
+    if normalized is None:
+        logger.warning(f"Unsupported registry system: {system}")
+
+        return None
+
+    match normalized:
+        case "DART":
+            return PubDevCrawler(
+                client=client,
+                session_factory=session_factory,
+                rate_limit=rate_limit,
+                max_retries=max_retries,
+            )
+        case "COMPOSER":
+            return PackagistCrawler(
+                client=client,
+                session_factory=session_factory,
+                rate_limit=rate_limit,
+                max_retries=max_retries,
+            )
+        case _:
+            logger.warning(f"Unsupported registry system after normalization: {normalized}")
+
+            return None

--- a/pg_atlas/crawlers/packagist.py
+++ b/pg_atlas/crawlers/packagist.py
@@ -49,8 +49,9 @@ class PackagistCrawler(RegistryCrawler):
     """
     Crawler for Packagist (PHP/Composer package registry).
 
-    ``adoption_downloads`` is set to the last-30-days (monthly) download count,
-    matching the spec definition.  All-time total is stored in metadata.
+    ``downloads_30d`` is captured on ``CrawledPackage`` from Packagist monthly
+    download counts. The base crawler persists that value under the source
+    repo metadata PURL map (not directly to scalar adoption columns).
     """
 
     REGISTRY = "packagist.org"

--- a/pg_atlas/crawlers/packagist.py
+++ b/pg_atlas/crawlers/packagist.py
@@ -18,7 +18,8 @@ from typing import Any
 
 import httpx
 
-from pg_atlas.crawlers.base import CrawledDependency, CrawledDependent, CrawledPackage, RegistryCrawler
+from pg_atlas.crawlers.base import CrawledDependency, CrawledDependent, CrawledPackage, RegistryCrawler, as_str_key_dict
+from pg_atlas.db_models.release import Release
 
 logger = logging.getLogger(__name__)
 
@@ -114,23 +115,28 @@ class PackagistCrawler(RegistryCrawler):
 
     def _parse_package(self, pkg_data: dict[str, Any], downloads_data: dict[str, Any]) -> CrawledPackage:
         """Parse Packagist API responses into a CrawledPackage."""
-        package = pkg_data.get("package", {})
-        name = package.get("name", "")
-        versions: dict[str, Any] = package.get("versions", {})
+        package = as_str_key_dict(pkg_data.get("package"))
+        name_obj = package.get("name")
+        name = name_obj if isinstance(name_obj, str) else ""
+        versions = as_str_key_dict(package.get("versions"))
+        package_purl = f"pkg:composer/{name}"
 
         # Select latest stable version
         latest_version, version_data = self._select_latest_version(versions)
 
         # Extract repo URL from source
-        source = version_data.get("source", {})
-        repo_url: str | None = source.get("url") if source else None
+        source = as_str_key_dict(version_data.get("source"))
+        repo_url_obj = source.get("url")
+        repo_url: str | None = repo_url_obj if isinstance(repo_url_obj, str) else None
 
         # Parse dependencies from require dict
-        require: dict[str, str] = version_data.get("require", {}) or {}
+        require = as_str_key_dict(version_data.get("require"))
         dependencies: list[CrawledDependency] = []
-        for dep_name, version_range in require.items():
+        for dep_name, version_range_obj in require.items():
             if self._should_filter(dep_name):
                 continue
+
+            version_range = version_range_obj if isinstance(version_range_obj, str) else None
             dependencies.append(
                 CrawledDependency(
                     canonical_id=f"pkg:composer/{dep_name}",
@@ -140,7 +146,9 @@ class PackagistCrawler(RegistryCrawler):
             )
 
         # Parse download stats from /downloads.json (nested under package.downloads.total)
-        dl_totals = downloads_data.get("package", {}).get("downloads", {}).get("total", {})
+        downloads_pkg = as_str_key_dict(downloads_data.get("package"))
+        downloads_by_type = as_str_key_dict(downloads_pkg.get("downloads"))
+        dl_totals = as_str_key_dict(downloads_by_type.get("total"))
         total = dl_totals.get("total")
 
         metadata: dict[str, Any] = {}
@@ -153,8 +161,22 @@ class PackagistCrawler(RegistryCrawler):
         if daily is not None:
             metadata["downloads_daily"] = daily
 
+        releases: list[Release] = []
+        for version_key, version_payload_obj in versions.items():
+            if not isinstance(version_payload_obj, dict):
+                continue
+
+            version_payload = as_str_key_dict(version_payload_obj)
+
+            version_value = version_payload.get("version")
+            release_version = version_value if isinstance(version_value, str) and version_value else version_key
+
+            released_at = version_payload.get("time")
+            release_date = released_at if isinstance(released_at, str) else ""
+            releases.append(Release(purl=package_purl, version=release_version, release_date=release_date))
+
         return CrawledPackage(
-            canonical_id=f"pkg:composer/{name}",
+            canonical_id=package_purl,
             display_name=name,
             latest_version=latest_version,
             repo_url=repo_url,
@@ -162,6 +184,7 @@ class PackagistCrawler(RegistryCrawler):
             stars=None,
             metadata=metadata,
             dependencies=dependencies,
+            releases=releases,
         )
 
     def _select_latest_version(self, versions: dict[str, Any]) -> tuple[str, dict[str, Any]]:
@@ -175,7 +198,11 @@ class PackagistCrawler(RegistryCrawler):
         stable: list[tuple[tuple[int, ...], str, dict[str, Any]]] = []
         dev_fallbacks: dict[str, dict[str, Any]] = {}
 
-        for version_key, data in versions.items():
+        for version_key, data_obj in versions.items():
+            if not isinstance(data_obj, dict):
+                continue
+
+            data = as_str_key_dict(data_obj)
             if _is_dev_version(version_key):
                 dev_fallbacks[version_key] = data
             else:

--- a/pg_atlas/crawlers/packagist.py
+++ b/pg_atlas/crawlers/packagist.py
@@ -157,7 +157,7 @@ class PackagistCrawler(RegistryCrawler):
             display_name=name,
             latest_version=latest_version,
             repo_url=repo_url,
-            downloads=monthly,
+            downloads_30d=monthly,
             stars=None,
             metadata=metadata,
             dependencies=dependencies,

--- a/pg_atlas/crawlers/pubdev.py
+++ b/pg_atlas/crawlers/pubdev.py
@@ -17,20 +17,26 @@ import logging
 from typing import Any
 
 import httpx
+from pydantic import TypeAdapter, ValidationError
 
 from pg_atlas.crawlers.base import CrawledDependency, CrawledDependent, CrawledPackage, RegistryCrawler
 
 logger = logging.getLogger(__name__)
 
 
+_DEPENDENCIES_ADAPTER: TypeAdapter[dict[str, object]] = TypeAdapter(dict[str, object])
+_WEEKLY_DOWNLOADS_ADAPTER: TypeAdapter[list[float]] = TypeAdapter(list[float])
+
+
 class PubDevCrawler(RegistryCrawler):
     """
     Crawler for pub.dev (Dart/Flutter package registry).
 
-    ``adoption_downloads`` is set to the 30-day download count from the
-    score endpoint, matching the spec definition (last 30 days).  Additional
-    download breakdowns are stored in metadata (``download_count_4w``,
-    ``download_count_12w``, ``download_count_52w``).
+    ``downloads_30d`` is captured on ``CrawledPackage`` from pub.dev metrics.
+    The base crawler persists that value under the source repo metadata PURL
+    map; scalar adoption downloads are reduced later during materialization.
+    Additional download breakdowns are stored in package metadata
+    (``download_count_4w``, ``download_count_12w``, ``download_count_52w``).
     """
 
     REGISTRY = "pub.dev"
@@ -112,14 +118,21 @@ class PubDevCrawler(RegistryCrawler):
         repo_url: str | None = homepage if isinstance(homepage, str) else None
 
         # Parse runtime dependencies only (not dev_dependencies or dependency_overrides)
-        raw_deps = pubspec.get("dependencies") or {}
+        raw_deps_obj = pubspec.get("dependencies")
+        try:
+            raw_deps = _DEPENDENCIES_ADAPTER.validate_python(raw_deps_obj)
+        except ValidationError:
+            raw_deps = {}
+
         dependencies: list[CrawledDependency] = []
         for dep_name, dep_constraint in raw_deps.items():
             if dep_name.lower() in self.FRAMEWORK_PACKAGES:
                 continue
+
             # SDK dependencies like {"sdk": "flutter"} are dicts, not version strings
             if isinstance(dep_constraint, dict):
                 continue
+
             version_range = dep_constraint if isinstance(dep_constraint, str) else None
             dependencies.append(
                 CrawledDependency(
@@ -142,9 +155,13 @@ class PubDevCrawler(RegistryCrawler):
         # Extract weekly download history from scorecard
         scorecard = metrics_data.get("scorecard", {})
         wvd = scorecard.get("weeklyVersionDownloads", {})
-        weekly_downloads = wvd.get("totalWeeklyDownloads")
-        is_valid = isinstance(weekly_downloads, list) and weekly_downloads
-        if is_valid and all(isinstance(x, (int, float)) for x in weekly_downloads):
+        weekly_downloads_obj = wvd.get("totalWeeklyDownloads")
+        try:
+            weekly_downloads = _WEEKLY_DOWNLOADS_ADAPTER.validate_python(weekly_downloads_obj)
+        except ValidationError:
+            weekly_downloads = []
+
+        if weekly_downloads:
             metadata["download_count_4w"] = sum(weekly_downloads[:4])
             metadata["download_count_12w"] = sum(weekly_downloads[:12])
             metadata["download_count_52w"] = sum(weekly_downloads[:52])

--- a/pg_atlas/crawlers/pubdev.py
+++ b/pg_atlas/crawlers/pubdev.py
@@ -17,9 +17,11 @@ import logging
 from typing import Any
 
 import httpx
+import msgspec
 from pydantic import TypeAdapter, ValidationError
 
-from pg_atlas.crawlers.base import CrawledDependency, CrawledDependent, CrawledPackage, RegistryCrawler
+from pg_atlas.crawlers.base import CrawledDependency, CrawledDependent, CrawledPackage, RegistryCrawler, as_str_key_dict
+from pg_atlas.db_models.release import Release
 
 logger = logging.getLogger(__name__)
 
@@ -88,10 +90,20 @@ class PubDevCrawler(RegistryCrawler):
         while url and pages_fetched < max_pages and len(dependents) < max_dependents:
             pages_fetched += 1
             resp = await self._request_with_retry(url)
-            data: dict[str, Any] = resp.json()
+            data = as_str_key_dict(resp.json())
 
-            for entry in data.get("packages", []):
-                name = entry.get("package", "")
+            packages_obj = data.get("packages")
+            packages: list[object] = []
+            if isinstance(packages_obj, list):
+                try:
+                    packages = msgspec.convert(packages_obj, type=list[object])
+                except msgspec.ValidationError:
+                    packages = []
+
+            for entry_obj in packages:
+                entry = as_str_key_dict(entry_obj)
+                name_obj = entry.get("package")
+                name = name_obj if isinstance(name_obj, str) else ""
                 if name:
                     dependents.append(
                         CrawledDependent(
@@ -100,7 +112,8 @@ class PubDevCrawler(RegistryCrawler):
                         )
                     )
 
-            url = data.get("next", "")
+            next_url = data.get("next")
+            url = next_url if isinstance(next_url, str) else ""
 
         if len(dependents) >= max_dependents:
             logger.warning(f"Truncated dependents for {package_name} at {max_dependents}")
@@ -109,10 +122,13 @@ class PubDevCrawler(RegistryCrawler):
 
     def _parse_package(self, pkg_data: dict[str, Any], metrics_data: dict[str, Any]) -> CrawledPackage:
         """Parse pub.dev API responses into a CrawledPackage."""
-        name = pkg_data.get("name", "")
-        latest = pkg_data.get("latest", {})
-        version = latest.get("version", "")
-        pubspec = latest.get("pubspec", {})
+        name_obj = pkg_data.get("name")
+        name = name_obj if isinstance(name_obj, str) else ""
+        package_purl = f"pkg:pub/{name.lower()}"
+        latest = as_str_key_dict(pkg_data.get("latest"))
+        version_obj = latest.get("version")
+        version = version_obj if isinstance(version_obj, str) else ""
+        pubspec = as_str_key_dict(latest.get("pubspec"))
 
         homepage = pubspec.get("homepage") or pubspec.get("repository")
         repo_url: str | None = homepage if isinstance(homepage, str) else None
@@ -143,7 +159,7 @@ class PubDevCrawler(RegistryCrawler):
             )
 
         # Extract score data (nested under "score" in metrics response)
-        score = metrics_data.get("score", {})
+        score = as_str_key_dict(metrics_data.get("score"))
         downloads_30d = score.get("downloadCount30Days")
         pub_points = score.get("grantedPoints")
         pub_points_max = score.get("maxPoints")
@@ -153,8 +169,8 @@ class PubDevCrawler(RegistryCrawler):
             metadata["download_count_30d"] = downloads_30d
 
         # Extract weekly download history from scorecard
-        scorecard = metrics_data.get("scorecard", {})
-        wvd = scorecard.get("weeklyVersionDownloads", {})
+        scorecard = as_str_key_dict(metrics_data.get("scorecard"))
+        wvd = as_str_key_dict(scorecard.get("weeklyVersionDownloads"))
         weekly_downloads_obj = wvd.get("totalWeeklyDownloads")
         try:
             weekly_downloads = _WEEKLY_DOWNLOADS_ADAPTER.validate_python(weekly_downloads_obj)
@@ -171,8 +187,30 @@ class PubDevCrawler(RegistryCrawler):
         if pub_points_max is not None:
             metadata["pub_points_max"] = pub_points_max
 
+        releases: list[Release] = []
+        versions_obj = pkg_data.get("versions")
+        if isinstance(versions_obj, list):
+            try:
+                versions: list[object] = msgspec.convert(versions_obj, type=list[object])
+            except msgspec.ValidationError:
+                versions = []
+
+            for version_payload_obj in versions:
+                if not isinstance(version_payload_obj, dict):
+                    continue
+
+                version_payload = as_str_key_dict(version_payload_obj)
+
+                version_value = version_payload.get("version")
+                if not isinstance(version_value, str) or not version_value:
+                    continue
+
+                published_value = version_payload.get("published")
+                release_date = published_value if isinstance(published_value, str) else ""
+                releases.append(Release(purl=package_purl, version=version_value, release_date=release_date))
+
         return CrawledPackage(
-            canonical_id=f"pkg:pub/{name.lower()}",
+            canonical_id=package_purl,
             display_name=name,
             latest_version=version,
             repo_url=repo_url,
@@ -180,4 +218,5 @@ class PubDevCrawler(RegistryCrawler):
             stars=None,
             metadata=metadata,
             dependencies=dependencies,
+            releases=releases,
         )

--- a/pg_atlas/crawlers/pubdev.py
+++ b/pg_atlas/crawlers/pubdev.py
@@ -159,7 +159,7 @@ class PubDevCrawler(RegistryCrawler):
             display_name=name,
             latest_version=version,
             repo_url=repo_url,
-            downloads=downloads_30d,
+            downloads_30d=downloads_30d,
             stars=None,
             metadata=metadata,
             dependencies=dependencies,

--- a/pg_atlas/db_models/base.py
+++ b/pg_atlas/db_models/base.py
@@ -18,11 +18,16 @@ SPDX-License-Identifier: MPL-2.0
 from __future__ import annotations
 
 import enum
-from typing import Annotated
+from typing import Annotated, Any
 
+import msgspec
 import sqlalchemy.types as types
 from sqlalchemy import Dialect, MetaData, String
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, MappedAsDataclass, mapped_column
+from sqlalchemy.types import TypeDecorator
+
+from pg_atlas.db_models.release import Release
 
 
 def enum_values(obj: type[enum.Enum]) -> list[str]:
@@ -40,7 +45,7 @@ def enum_values(obj: type[enum.Enum]) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# Custom column type: HexBinary
+# Custom column types
 # ---------------------------------------------------------------------------
 
 
@@ -76,6 +81,30 @@ class HexBinary(types.TypeDecorator[str]):
             # Can occur during outer joins or eager loading of nullable relations.
             return ""
         return value.hex()
+
+
+class ReleaseListJSONB(TypeDecorator[list[Release] | None]):
+    """
+    JSONB mapper that exposes release payloads as ``list[Release]`` in Python.
+    Values are stored as plain JSON dictionaries in PostgreSQL.
+    """
+
+    impl = JSONB
+    cache_ok = True
+
+    def process_bind_param(self, value: Any, dialect: Any) -> list[dict[str, str]] | None:
+        """Serialize ``Release`` structs into JSON-compatible dictionaries."""
+        if value is None:
+            return None
+
+        return msgspec.to_builtins(value)
+
+    def process_result_value(self, value: Any, dialect: Any) -> list[Release] | None:
+        """Deserialize JSON dictionaries into ``Release`` structs."""
+        if value is None:
+            return None
+
+        return msgspec.convert(value, list[Release])
 
 
 # ---------------------------------------------------------------------------

--- a/pg_atlas/db_models/base.py
+++ b/pg_atlas/db_models/base.py
@@ -97,14 +97,28 @@ class ReleaseListJSONB(TypeDecorator[list[Release] | None]):
         if value is None:
             return None
 
-        return msgspec.to_builtins(value)
+        payload = msgspec.to_builtins(value)
+
+        return msgspec.convert(payload, type=list[dict[str, str]])
 
     def process_result_value(self, value: Any, dialect: Any) -> list[Release] | None:
         """Deserialize JSON dictionaries into ``Release`` structs."""
         if value is None:
             return None
 
-        return msgspec.convert(value, list[Release])
+        normalized: list[Any] = []
+        for item in value:
+            if isinstance(item, dict):
+                row = msgspec.convert(item, type=dict[str, object])
+                if row.get("release_date") is None:
+                    row["release_date"] = ""
+
+                normalized.append(row)
+                continue
+
+            normalized.append(item)
+
+        return msgspec.convert(normalized, list[Release])
 
 
 # ---------------------------------------------------------------------------

--- a/pg_atlas/db_models/project.py
+++ b/pg_atlas/db_models/project.py
@@ -83,3 +83,5 @@ class Project(PgBase):
         init=False,
         repr=False,
     )
+
+    # TODO: write `async def has_published_packages()` for project_type check

--- a/pg_atlas/db_models/release.py
+++ b/pg_atlas/db_models/release.py
@@ -12,7 +12,7 @@ class Release(msgspec.Struct, frozen=True):
 
     purl: str
     version: str
-    release_date: str
+    release_date: str = ""  # if populated, the value MUST be `isoformat`
 
     @classmethod
     def __get_pydantic_core_schema__(cls, _source_type: Any, _handler: Any) -> core_schema.CoreSchema:

--- a/pg_atlas/db_models/release.py
+++ b/pg_atlas/db_models/release.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import msgspec
+from pydantic_core import core_schema
+
+
+class Release(msgspec.Struct, frozen=True):
+    """One normalized release record keyed by package PURL + version."""
+
+    purl: str
+    version: str
+    release_date: str
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, _source_type: Any, _handler: Any) -> core_schema.CoreSchema:
+        """Provide Pydantic v2 validation/serialization support for FastAPI models."""
+        return core_schema.with_info_plain_validator_function(
+            cls._pydantic_validate,
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                msgspec.to_builtins  # efficiently converts Struct -> dict/list
+            ),
+        )
+
+    @classmethod
+    def _pydantic_validate(cls, value: Any, _info: core_schema.ValidationInfo) -> Release:
+        try:
+            return msgspec.convert(value, cls)
+        except (msgspec.ValidationError, TypeError) as e:
+            raise ValueError(f"Invalid Release payload: {e}") from e
+
+    @classmethod
+    def __get_pydantic_json_schema__(cls, _core_schema: Any, _handler: Any) -> dict[str, Any]:
+        """Return the resolved object schema so OpenAPI generation does not depend on $defs references."""
+
+        schema_doc = msgspec.convert(msgspec.json.schema(cls), type=dict[str, Any])
+        # unwrap the valid JSON schema to return what is under `Release`
+        return next(iter(schema_doc["$defs"].values()))
+
+
+def merge_releases(existing: Sequence[object] | None, incoming: Sequence[object] | None) -> list[Release] | None:
+    """
+    Union-merge releases using (purl, version) as the identity key.
+
+    Existing order is preserved; new keys append at the end.
+    If the same key appears with an empty existing release_date and a non-empty
+    incoming release_date, the incoming value replaces the existing one.
+    """
+    norm_existing = msgspec.convert(existing, list[Release]) if existing is not None else []
+    norm_incoming = msgspec.convert(incoming, list[Release]) if incoming is not None else []
+
+    if not norm_existing and not norm_incoming:
+        return None
+
+    # dict comprehension for speed; incoming replaces existing if key matches
+    merged = {(r.purl, r.version): r for r in norm_existing}
+
+    for r in norm_incoming:
+        key = (r.purl, r.version)
+        current = merged.get(key)
+
+        # logic: update if new entry OR if current has no date and new one does
+        if not current or (not current.release_date and r.release_date):
+            merged[key] = r
+
+    return list(merged.values())

--- a/pg_atlas/db_models/release.py
+++ b/pg_atlas/db_models/release.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from typing import Any
 
 import msgspec
 from pydantic_core import core_schema
+
+_SEMVER_RE = re.compile(r"^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
+_COMMIT_HASH_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
 
 
 class Release(msgspec.Struct, frozen=True):
@@ -44,17 +48,20 @@ def merge_releases(existing: Sequence[object] | None, incoming: Sequence[object]
     """
     Union-merge releases using (purl, version) as the identity key.
 
-    Existing order is preserved; new keys append at the end.
+    Merge identity is ``(purl, version)`` and the output is sorted in reverse
+    chronological order by lexical compare of the datetime prefix
+    ``YYYY-MM-DDTHH:MM:SS``.
+
     If the same key appears with an empty existing release_date and a non-empty
     incoming release_date, the incoming value replaces the existing one.
     """
-    norm_existing = msgspec.convert(existing, list[Release]) if existing is not None else []
-    norm_incoming = msgspec.convert(incoming, list[Release]) if incoming is not None else []
+    norm_existing = _normalize_release_list(existing)
+    norm_incoming = _normalize_release_list(incoming)
 
     if not norm_existing and not norm_incoming:
         return None
 
-    # dict comprehension for speed; incoming replaces existing if key matches
+    # Dict comprehension for speed; incoming replaces existing if key matches.
     merged = {(r.purl, r.version): r for r in norm_existing}
 
     for r in norm_incoming:
@@ -65,4 +72,76 @@ def merge_releases(existing: Sequence[object] | None, incoming: Sequence[object]
         if not current or (not current.release_date and r.release_date):
             merged[key] = r
 
-    return list(merged.values())
+    return sorted_releases_desc([rel for rel in merged.values()])
+
+
+def sorted_releases_desc(releases: Sequence[Release]) -> list[Release]:
+    """Sort releases by lexical datetime prefix in reverse chronological order."""
+
+    return sorted(releases, key=lambda release: _release_datetime_prefix(release.release_date), reverse=True)
+
+
+def preferred_latest_version(releases: list[Release]) -> str:
+    """
+    Pick one latest-version candidate from the newest release window.
+
+    Preference order in ``releases[:9]``:
+    1. semver-like string
+    2. commit-hash-like string
+    3. first non-empty arbitrary string
+    """
+
+    newest_window = releases[:9]
+
+    for release in newest_window:
+        if _is_semver_like(release.version):
+            return release.version
+
+    for release in newest_window:
+        if _is_commit_hash(release.version):
+            return release.version
+
+    for release in newest_window:
+        if release.version:
+            return release.version
+
+    return ""
+
+
+def _normalize_release_list(values: Sequence[object] | None) -> list[Release]:
+    """Convert release-like payloads into ``Release`` structs, tolerating legacy null dates."""
+
+    if values is None:
+        return []
+
+    normalized_values: list[object] = []
+    for value in values:
+        if isinstance(value, dict):
+            normalized = msgspec.convert(value, type=dict[str, object])
+            if normalized.get("release_date") is None:
+                normalized["release_date"] = ""
+
+            normalized_values.append(normalized)
+            continue
+
+        normalized_values.append(value)
+
+    return msgspec.convert(normalized_values, list[Release])
+
+
+def _is_semver_like(version: str) -> bool:
+    """Return whether a version string resembles semver, optionally prefixed with ``v``."""
+
+    return bool(_SEMVER_RE.fullmatch(version))
+
+
+def _is_commit_hash(version: str) -> bool:
+    """Return whether a version string looks like a hex git commit hash."""
+
+    return bool(_COMMIT_HASH_RE.fullmatch(version))
+
+
+def _release_datetime_prefix(release_date: str) -> str:
+    """Return the stable datetime prefix used for lexical recency sorting."""
+
+    return release_date[:19]

--- a/pg_atlas/db_models/repo_vertex.py
+++ b/pg_atlas/db_models/repo_vertex.py
@@ -24,7 +24,8 @@ from sqlalchemy import DateTime, Enum, ForeignKey, Index, Integer, String, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from pg_atlas.db_models.base import PgBase, RepoVertexType, Visibility, canonical_id, enum_values, intpk
+from pg_atlas.db_models.base import PgBase, ReleaseListJSONB, RepoVertexType, Visibility, canonical_id, enum_values, intpk
+from pg_atlas.db_models.release import Release
 
 if TYPE_CHECKING:
     from pg_atlas.db_models.contributed_to import ContributedTo
@@ -121,7 +122,7 @@ class Repo(RepoVertex):
     adoption_forks: Mapped[int | None] = mapped_column(default=None)
 
     # --- flexible data ---
-    releases: Mapped[list[dict[str, Any]] | None] = mapped_column(JSONB, default=None)
+    releases: Mapped[list[Release] | None] = mapped_column(ReleaseListJSONB(), default=None)
     # NB: 'metadata' is reserved by SQLAlchemy DeclarativeBase; the Python attribute
     # is named 'repo_metadata' while the DB column is named 'metadata'.
     repo_metadata: Mapped[dict[str, Any] | None] = mapped_column("metadata", JSONB, default=None)
@@ -208,7 +209,7 @@ class ExternalRepo(RepoVertex):
     criticality_score: Mapped[int | None] = mapped_column(default=None)
 
     # --- flexible data ---
-    releases: Mapped[list[dict[str, Any]] | None] = mapped_column(JSONB, default=None)
+    releases: Mapped[list[Release] | None] = mapped_column(ReleaseListJSONB(), default=None)
 
     # --- audit ---
     updated_at: Mapped[dt.datetime] = mapped_column(

--- a/pg_atlas/db_models/session.py
+++ b/pg_atlas/db_models/session.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 
+import msgspec
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -54,10 +55,13 @@ def get_session_factory() -> async_sessionmaker[AsyncSession]:
             raise ValueError(
                 "PG_ATLAS_DATABASE_URL is not configured. Set it to a postgresql:// DSN before using database sessions."
             )
+
+        decoder = msgspec.json.Decoder()
         _engine = create_async_engine(
             settings.DATABASE_URL,
             echo=settings.LOG_LEVEL == "DEBUG",
             pool_pre_ping=True,
+            json_deserializer=decoder.decode,
         )
         _session_factory = async_sessionmaker(_engine, expire_on_commit=False)
     return _session_factory

--- a/pg_atlas/db_models/vertex_ops.py
+++ b/pg_atlas/db_models/vertex_ops.py
@@ -54,7 +54,7 @@ async def upsert_external_repo(
     the existing row is returned unchanged — ``ExternalRepo`` never overwrites
     a ``Repo``.
     FIXME: scrutinize this logic since Repo and ExternalRepo now use separate
-    canonical_id namespaces. We could be creating duplicate vertices here.
+    canonical_id namespaces. We could need fancier merging logic here.
 
     Calls ``session.flush()`` so the returned object has its ``id`` populated.
     """

--- a/pg_atlas/ingestion/persist.py
+++ b/pg_atlas/ingestion/persist.py
@@ -54,8 +54,7 @@ from pg_atlas.db_models.base import EdgeConfidence, SubmissionStatus, Visibility
 from pg_atlas.db_models.depends_on import DependsOn
 from pg_atlas.db_models.repo_vertex import Repo
 from pg_atlas.db_models.sbom_submission import SbomSubmission
-from pg_atlas.db_models.vertex_ops import get_vertex
-from pg_atlas.db_models.vertex_ops import upsert_external_repo as _upsert_external_repo
+from pg_atlas.db_models.vertex_ops import get_vertex, upsert_external_repo
 from pg_atlas.ingestion.queue import defer_sbom_processing
 from pg_atlas.ingestion.spdx import ParsedSbom, SpdxValidationError, parse_and_validate_spdx
 from pg_atlas.storage.artifacts import read_artifact, store_artifact
@@ -330,7 +329,7 @@ async def _upsert_sbom_vertices(
         display_name, version, repo_url = canonical_inputs[canonical_id]
 
         try:
-            dep_vertex = await _upsert_external_repo(
+            dep_vertex = await upsert_external_repo(
                 session,
                 canonical_id=canonical_id,
                 display_name=display_name,

--- a/pg_atlas/metrics/adoption.py
+++ b/pg_atlas/metrics/adoption.py
@@ -19,17 +19,21 @@ SPDX-License-Identifier: MPL-2.0
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
-from typing import TYPE_CHECKING
+from typing import Final
+
+from pydantic import StrictInt, TypeAdapter, ValidationError
 
 from pg_atlas.metrics.criticality import compute_percentile_ranks
 
-if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
-
-
 PERCENTILE_QUANTUM = Decimal("0.01")
+ADOPTION_DOWNLOADS_BY_PURL_KEY = "adoption_downloads_by_purl"
+_DOWNLOADS_BY_PURL_ADAPTER: Final[TypeAdapter[dict[str, int]]] = TypeAdapter(dict[str, StrictInt])
+
+logger = logging.getLogger(__name__)
 
 
 def _quantize_score(value: Decimal) -> Decimal:
@@ -51,6 +55,76 @@ class RepoAdoptionSignals:
     adoption_downloads: int | None = None
     adoption_stars: int | None = None
     adoption_forks: int | None = None
+
+
+def aggregate_repo_downloads(
+    adoption_downloads_by_purl: Mapping[str, int] | None,
+) -> int | None:
+    """
+    Resolve one repo's effective downloads from per-PURL metadata only.
+
+    Materialization persists this sum into ``Repo.adoption_downloads`` so
+    percentile ranking runs on reduced scalar values.
+    """
+
+    if not adoption_downloads_by_purl:
+        return None
+
+    return sum(adoption_downloads_by_purl.values())
+
+
+def downloads_by_purl_from_metadata(
+    repo_metadata: Mapping[str, object] | None,
+    *,
+    repo_canonical_id: str | None = None,
+) -> dict[str, int] | None:
+    """
+    Extract and validate the per-PURL downloads map from repo metadata.
+
+    Invalid shapes are skipped and logged instead of silently ignored.
+    """
+
+    if repo_metadata is None:
+        return None
+
+    raw_downloads_by_purl = repo_metadata.get(ADOPTION_DOWNLOADS_BY_PURL_KEY)
+    if raw_downloads_by_purl is None:
+        return None
+
+    try:
+        parsed_downloads_by_purl = _DOWNLOADS_BY_PURL_ADAPTER.validate_python(raw_downloads_by_purl)
+    except ValidationError as exc:
+        logger.warning(
+            "Invalid %s for repo %s: validation_errors=%d",
+            ADOPTION_DOWNLOADS_BY_PURL_KEY,
+            repo_canonical_id or "<unknown>",
+            exc.error_count(),
+        )
+        return None
+
+    return parsed_downloads_by_purl if parsed_downloads_by_purl else None
+
+
+def merge_download_into_repo_metadata(
+    repo_metadata: Mapping[str, object] | None,
+    package_purl: str,
+    downloads: int,
+    *,
+    repo_canonical_id: str | None = None,
+) -> dict[str, object]:
+    """
+    Upsert one package download count into repo metadata.
+
+    The ``adoption_downloads_by_purl`` map is the crawler write target; scalar
+    reduction happens later during adoption materialization.
+    """
+
+    metadata: dict[str, object] = dict(repo_metadata or {})
+    existing_by_purl = downloads_by_purl_from_metadata(metadata, repo_canonical_id=repo_canonical_id) or {}
+    existing_by_purl[package_purl] = downloads
+    metadata[ADOPTION_DOWNLOADS_BY_PURL_KEY] = existing_by_purl
+
+    return metadata
 
 
 def compute_repo_adoption_composites(repos: Sequence[RepoAdoptionSignals]) -> dict[str, Decimal]:

--- a/pg_atlas/metrics/adoption.py
+++ b/pg_atlas/metrics/adoption.py
@@ -81,7 +81,8 @@ def downloads_by_purl_from_metadata(
     """
     Extract and validate the per-PURL downloads map from repo metadata.
 
-    Invalid shapes are skipped and logged instead of silently ignored.
+    Validation is strict (string keys + integer values). Invalid shapes are
+    skipped and logged instead of silently ignored.
     """
 
     if repo_metadata is None:
@@ -94,12 +95,8 @@ def downloads_by_purl_from_metadata(
     try:
         parsed_downloads_by_purl = _DOWNLOADS_BY_PURL_ADAPTER.validate_python(raw_downloads_by_purl)
     except ValidationError as exc:
-        logger.warning(
-            "Invalid %s for repo %s: validation_errors=%d",
-            ADOPTION_DOWNLOADS_BY_PURL_KEY,
-            repo_canonical_id or "<unknown>",
-            exc.error_count(),
-        )
+        repo_id = repo_canonical_id or "<unknown>"
+        logger.error(f"Invalid {ADOPTION_DOWNLOADS_BY_PURL_KEY} for repo {repo_id}: validation_errors={exc.error_count()}")
         return None
 
     return parsed_downloads_by_purl if parsed_downloads_by_purl else None
@@ -117,6 +114,9 @@ def merge_download_into_repo_metadata(
 
     The ``adoption_downloads_by_purl`` map is the crawler write target; scalar
     reduction happens later during adoption materialization.
+
+    Existing metadata entries are preserved when valid. Invalid existing map
+    shapes are discarded with logging by ``downloads_by_purl_from_metadata``.
     """
 
     metadata: dict[str, object] = dict(repo_metadata or {})

--- a/pg_atlas/metrics/materialize_adoption.py
+++ b/pg_atlas/metrics/materialize_adoption.py
@@ -34,8 +34,10 @@ from pg_atlas.db_models.session import get_session_factory
 from pg_atlas.instruments.tee import run_with_tee
 from pg_atlas.metrics.adoption import (
     RepoAdoptionSignals,
+    aggregate_repo_downloads,
     compute_project_adoption_scores,
     compute_repo_adoption_composites,
+    downloads_by_purl_from_metadata,
 )
 
 logging.basicConfig(
@@ -70,16 +72,22 @@ async def materialize_adoption_scores(session: AsyncSession) -> AdoptionMaterial
     started_at = time.perf_counter()
 
     repos = (await session.execute(select(Repo).order_by(Repo.id))).scalars().all()
-    repo_snapshots = [
-        RepoAdoptionSignals(
-            canonical_id=repo.canonical_id,
-            project_id=repo.project_id,
-            adoption_downloads=repo.adoption_downloads,
-            adoption_stars=repo.adoption_stars,
-            adoption_forks=repo.adoption_forks,
+    repo_snapshots: list[RepoAdoptionSignals] = []
+    for repo in repos:
+        downloads_by_purl = downloads_by_purl_from_metadata(repo.repo_metadata, repo_canonical_id=repo.canonical_id)
+        aggregated_downloads = aggregate_repo_downloads(downloads_by_purl)
+        repo.adoption_downloads = aggregated_downloads
+
+        repo_snapshots.append(
+            RepoAdoptionSignals(
+                canonical_id=repo.canonical_id,
+                project_id=repo.project_id,
+                adoption_downloads=aggregated_downloads,
+                adoption_stars=repo.adoption_stars,
+                adoption_forks=repo.adoption_forks,
+            )
         )
-        for repo in repos
-    ]
+
     repo_composites = compute_repo_adoption_composites(repo_snapshots)
     project_scores = compute_project_adoption_scores(repo_snapshots, repo_composites)
 

--- a/pg_atlas/migrations/README.md
+++ b/pg_atlas/migrations/README.md
@@ -75,7 +75,8 @@ If you try to restore this dump into a blank database, that will fail. The
 hosted dump does not include everything needed to bootstrap the schema from
 scratch (notably PostgreSQL enum types), so the correct sequence is always:
 
-1. migrate the local database to `heads` (or the specified revision)
+1. clear Procrastinate tables that are not in the dump: `uv run alembic downgrade procrastinate@base`
+1. migrate the local database to `heads` (or the specified revision): `uv run alembic upgrade heads`
 1. restore the dump onto that migrated schema
 
 ## Generate a new revision

--- a/pg_atlas/procrastinate/depsdev.py
+++ b/pg_atlas/procrastinate/depsdev.py
@@ -106,7 +106,7 @@ class DepsDevPackageInfo:
     name: str
     purl: str
     default_version: str
-    versions: list[DepsDevVersionInfo] = field(default_factory=list)
+    versions: list[DepsDevVersionInfo] = field(default_factory=list[DepsDevVersionInfo])
 
 
 @dataclass
@@ -127,7 +127,7 @@ class DepsDevProjectInfo:
     forks_count: int
     license: str
     description: str
-    package_versions: list[ProjectPackageVersion] = field(default_factory=list)
+    package_versions: list[ProjectPackageVersion] = field(default_factory=list[ProjectPackageVersion])
 
 
 # ---------------------------------------------------------------------------

--- a/pg_atlas/procrastinate/depsdev.py
+++ b/pg_atlas/procrastinate/depsdev.py
@@ -43,6 +43,7 @@ from pg_atlas.deps_dev.lib.deps_dev.v3alpha import (
     System,
     VersionKey,
 )
+from pg_atlas.ingestion.persist import strip_purl_version
 
 logger = logging.getLogger(__name__)
 
@@ -112,10 +113,30 @@ class DepsDevProjectInfo:
     packages: list[ProjectPackage] = field(default_factory=list[ProjectPackage])
 
     async def populate_packages(self, stub: InsightsStub | None = None) -> None:
+        """
+        Populate ``packages`` with unique versionless package identities.
+
+        ``GetProjectPackageVersions`` returns one row per version, but
+        downstream crawl orchestration needs one package identity per
+        ``(system, name)`` pair. Version metadata is fetched later via
+        ``get_package`` when building release lists.
+        """
+
         package_versions = await _get_project_package_versions(self.project_id, stub=stub)
-        # TODO: deduplicate and sort by purl, uses `strip_purl_version`
-        # self.packages = deduped-versions
-        print(package_versions)  # I put this here only to satisfy ruff
+        deduped_packages: dict[tuple[str, str], ProjectPackage] = {}
+
+        for package_version in package_versions:
+            key = (package_version.system, package_version.name)
+            if key in deduped_packages:
+                continue
+
+            deduped_packages[key] = ProjectPackage(
+                system=package_version.system,
+                name=package_version.name,
+                purl=strip_purl_version(package_version.purl),
+            )
+
+        self.packages = sorted(deduped_packages.values(), key=lambda package: package.purl)
 
 
 @dataclass

--- a/pg_atlas/procrastinate/depsdev.py
+++ b/pg_atlas/procrastinate/depsdev.py
@@ -18,6 +18,7 @@ SPDX-License-Identifier: MPL-2.0
 from __future__ import annotations
 
 import logging
+from abc import ABC
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -79,43 +80,24 @@ class DepsDevError(Exception):
 
 
 @dataclass
-class DepsDevVersionInfo:
-    """A version entry returned by deps.dev GetPackage."""
-
-    version: str
-    purl: str
-    published_at: str | None
-    is_default: bool
+class _SystemNameBase(ABC):
+    system: str
+    name: str
 
 
 @dataclass
-class ProjectPackageVersion:
+class ProjectPackageVersion(_SystemNameBase):
     """A project package/version mapping returned by deps.dev."""
 
-    system: str
-    name: str
     version: str
     purl: str
 
 
 @dataclass
-class DepsDevPackageInfo:
-    """Info about a package from deps.dev GetPackage."""
+class ProjectPackage(_SystemNameBase):
+    """A distinct project package derived from ProjectPackageVersion."""
 
-    system: str
-    name: str
     purl: str
-    default_version: str
-    versions: list[DepsDevVersionInfo] = field(default_factory=list[DepsDevVersionInfo])
-
-
-@dataclass
-class DepsDevRequirement:
-    """A single unresolved requirement (dependency) from GetRequirements."""
-
-    system: str
-    name: str
-    version_constraint: str
 
 
 @dataclass
@@ -127,7 +109,39 @@ class DepsDevProjectInfo:
     forks_count: int
     license: str
     description: str
-    package_versions: list[ProjectPackageVersion] = field(default_factory=list[ProjectPackageVersion])
+    packages: list[ProjectPackage] = field(default_factory=list[ProjectPackage])
+
+    async def populate_packages(self, stub: InsightsStub | None = None) -> None:
+        package_versions = await _get_project_package_versions(self.project_id, stub=stub)
+        # TODO: deduplicate and sort by purl, uses `strip_purl_version`
+        # self.packages = deduped-versions
+        print(package_versions)  # I put this here only to satisfy ruff
+
+
+@dataclass
+class DepsDevVersionInfo:
+    """A version entry returned by deps.dev GetPackage."""
+
+    version: str
+    purl: str
+    published_at: str | None
+    is_default: bool
+
+
+@dataclass
+class DepsDevPackageInfo(_SystemNameBase):
+    """Info about a package from deps.dev GetPackage."""
+
+    purl: str
+    default_version: str
+    versions: list[DepsDevVersionInfo] = field(default_factory=list[DepsDevVersionInfo])
+
+
+@dataclass
+class DepsDevRequirement(_SystemNameBase):
+    """A single unresolved requirement (dependency) from GetRequirements."""
+
+    version_constraint: str
 
 
 # ---------------------------------------------------------------------------
@@ -412,7 +426,7 @@ async def _get_project_batch_page(
     return list(batch.responses), batch.next_page_token
 
 
-async def get_project_package_versions(project_id: str, *, stub: InsightsStub | None = None) -> list[ProjectPackageVersion]:
+async def _get_project_package_versions(project_id: str, *, stub: InsightsStub | None) -> list[ProjectPackageVersion]:
     """
     Fetch package-version mappings for one project.
 
@@ -500,7 +514,7 @@ async def get_project_batch(project_ids: list[str], *, stub: InsightsStub | None
                 forks_count=proj.forks_count,
                 license=proj.license,
                 description=proj.description,
-                package_versions=[],
+                packages=[],
             )
 
         if not next_token:

--- a/pg_atlas/procrastinate/github.py
+++ b/pg_atlas/procrastinate/github.py
@@ -425,6 +425,9 @@ def _run_dependency_graph_query(owner: str, repo_name: str, *, after: str | None
 def _is_skipped_manifest_path(path: str) -> bool:
     """
     Return whether one path falls under ignored test/example folders.
+
+    This is a quick and dirty "best-effort" check that excludes e.g. `contest/` and `latest/`.
+    We'd rather miss a couple of uncommon manifest paths than have to read a lot of junk.
     """
     normalized_path = path.lower()
     return any(substr in normalized_path for substr in _SKIPPED_PATH_SUBSTRINGS)

--- a/pg_atlas/procrastinate/github.py
+++ b/pg_atlas/procrastinate/github.py
@@ -19,8 +19,8 @@ from dataclasses import dataclass
 from threading import Lock
 from typing import Any
 
+import msgspec
 from github import Auth, Github, GithubException
-from pydantic import BaseModel, ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -43,53 +43,108 @@ _MANIFEST_FILE_NAMES = frozenset(
 _SKIPPED_PATH_SUBSTRINGS = frozenset({".github", "example", "test"})
 
 
-class _NpmManifest(BaseModel):
-    """
-    Typed subset of package.json fields used for package detection.
-    """
+class _NpmManifest(msgspec.Struct, omit_defaults=True):
+    """Typed subset of package.json fields used for package detection."""
 
     name: str | None = None
     private: bool | None = None
+    version: str | None = None
 
 
-class _ComposerManifest(BaseModel):
-    """
-    Typed subset of composer.json fields used for package detection.
-    """
-
-    name: str | None = None
-
-
-class _CargoPackageSection(BaseModel):
-    """
-    Typed subset of Cargo.toml [package] section.
-    """
+class _ComposerManifest(msgspec.Struct, omit_defaults=True):
+    """Typed subset of composer.json fields used for package detection."""
 
     name: str | None = None
 
 
-class _CargoManifest(BaseModel):
-    """
-    Typed subset of Cargo.toml used for package detection.
-    """
+class _CargoPackageSection(msgspec.Struct, omit_defaults=True):
+    """Typed subset of Cargo.toml [package] section."""
+
+    name: str | None = None
+
+
+class _CargoManifest(msgspec.Struct, omit_defaults=True):
+    """Typed subset of Cargo.toml used for package detection."""
 
     package: _CargoPackageSection | None = None
 
 
-class _PyProjectSection(BaseModel):
-    """
-    Typed subset of pyproject.toml [project] section.
-    """
+class _PyProjectSection(msgspec.Struct, omit_defaults=True):
+    """Typed subset of pyproject.toml [project] section."""
 
     name: str | None = None
 
 
-class _PyProjectManifest(BaseModel):
-    """
-    Typed subset of pyproject.toml used for package detection.
-    """
+class _PyProjectManifest(msgspec.Struct, omit_defaults=True):
+    """Typed subset of pyproject.toml used for package detection."""
 
     project: _PyProjectSection | None = None
+
+
+class _ManifestGraphNode(msgspec.Struct, omit_defaults=True):
+    """One manifest row returned by GitHub dependency graph GraphQL."""
+
+    filename: str
+    parseable: bool | None = None
+    exceedsMaxSize: bool | None = None
+
+
+class _PageInfo(msgspec.Struct, omit_defaults=True):
+    """Page info shape for GraphQL pagination."""
+
+    hasNextPage: bool
+    endCursor: str | None = None
+
+
+class _DependencyGraphManifestConnection(msgspec.Struct, omit_defaults=True):
+    """GraphQL connection payload for dependencyGraphManifests."""
+
+    nodes: list[_ManifestGraphNode] | None = None
+    pageInfo: _PageInfo | None = None
+
+
+class _RepositoryGraphPayload(msgspec.Struct, omit_defaults=True):
+    """GraphQL repository wrapper used by manifest discovery."""
+
+    dependencyGraphManifests: _DependencyGraphManifestConnection | None = None
+
+
+class _GraphQLData(msgspec.Struct, omit_defaults=True):
+    """GraphQL top-level data envelope."""
+
+    repository: _RepositoryGraphPayload | None = None
+
+
+class _GraphQLError(msgspec.Struct, omit_defaults=True):
+    """GraphQL error payload used for logging diagnostics."""
+
+    message: str
+
+
+class _GraphQLResponse(msgspec.Struct, omit_defaults=True):
+    """GraphQL response envelope."""
+
+    data: _GraphQLData | None = None
+    errors: list[_GraphQLError] | None = None
+
+
+_DEPENDENCY_GRAPH_QUERY = """
+query($owner: String!, $name: String!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    dependencyGraphManifests(first: 100, after: $after) {
+      nodes {
+        filename
+        parseable
+        exceedsMaxSize
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+""".strip()
 
 
 # Module-level singletons
@@ -240,11 +295,10 @@ def get_single_repo(owner: str, repo_name: str) -> list[GitHubRepoMetadata]:
 
 def detect_packages_from_repo(owner: str, repo_name: str) -> list[PackageReference]:
     """
-    Detect published packages by scanning manifests in the repository tree.
+    Detect published packages by scanning manifests from dependency graph GraphQL.
 
-    This scan is auth-independent and covers nested monorepo paths. It avoids
-    GitHub code-search query/parser failures by listing the Git tree directly
-    and parsing only manifest blobs.
+    This scan avoids GitHub code-search parser limitations by querying
+    ``dependencyGraphManifests`` and then parsing only those manifest blobs.
     """
     gh = get_github_client()
     repo_path = f"{owner}/{repo_name}"
@@ -258,7 +312,7 @@ def detect_packages_from_repo(owner: str, repo_name: str) -> list[PackageReferen
 
         return []
 
-    manifest_paths = _manifest_paths_from_repo_tree(repo, repo_path)
+    manifest_paths = _manifest_paths_from_graphql(owner, repo_name)
 
     for path in manifest_paths:
         system = _system_from_manifest_path(path)
@@ -295,39 +349,77 @@ def detect_packages_from_repo(owner: str, repo_name: str) -> list[PackageReferen
     return package_refs
 
 
-def _manifest_paths_from_repo_tree(repo: Any, repo_path: str) -> list[str]:
+def _manifest_paths_from_graphql(owner: str, repo_name: str) -> list[str]:
     """
-    Collect manifest blob paths from one repository tree.
+    Collect manifest paths from GitHub dependency graph manifests.
 
-    Skips common test/example folders to reduce noise.
+    Skips ignored paths and non-parseable/oversized manifest entries.
     """
+
+    repo_path = f"{owner}/{repo_name}"
+    manifest_paths: set[str] = set()
+    after: str | None = None
+
+    while True:
+        response = _run_dependency_graph_query(owner, repo_name, after=after)
+        if response is None:
+            return []
+
+        if response.errors:
+            joined_errors = "; ".join(error.message for error in response.errors)
+            logger.warning(f"GraphQL manifest query failed for {repo_path}: {joined_errors}")
+            return []
+
+        repository = response.data.repository if response.data is not None else None
+        manifests = repository.dependencyGraphManifests if repository is not None else None
+        if manifests is None:
+            return sorted(manifest_paths)
+
+        for node in manifests.nodes or []:
+            if node.parseable is False or node.exceedsMaxSize is True:
+                continue
+
+            path = node.filename
+            if not path or _is_skipped_manifest_path(path):
+                continue
+
+            basename = path.rsplit("/", 1)[-1].lower()
+            if basename in _MANIFEST_FILE_NAMES or basename.endswith(".gemspec"):
+                manifest_paths.add(path)
+
+        page_info = manifests.pageInfo
+        if page_info is None or not page_info.hasNextPage or not page_info.endCursor:
+            return sorted(manifest_paths)
+
+        after = page_info.endCursor
+
+
+def _run_dependency_graph_query(owner: str, repo_name: str, *, after: str | None) -> _GraphQLResponse | None:
+    """Run one dependencyGraphManifests GraphQL query through PyGithub's requester."""
+
+    gh = get_github_client()
+    requester = getattr(gh, "_Github__requester", None)
+    if requester is None:
+        logger.warning("PyGithub requester is unavailable for GraphQL manifest detection")
+        return None
+
+    variables: dict[str, str | None] = {
+        "owner": owner,
+        "name": repo_name,
+        "after": after,
+    }
 
     try:
-        default_branch = getattr(repo, "default_branch", None) or "main"
-        tree = repo.get_git_tree(default_branch, recursive=True)
+        _, response_payload = requester.graphql_query(_DEPENDENCY_GRAPH_QUERY, variables)
     except GithubException as exc:
-        logger.warning(f"Failed to list git tree for {repo_path}: {exc}")
-        return []
+        logger.warning(f"GraphQL manifest query failed for {owner}/{repo_name}: {exc}")
+        return None
 
-    if bool(getattr(tree, "truncated", False)):
-        logger.warning(f"Manifest scan tree was truncated for {repo_path}")
-
-    manifest_paths: set[str] = set()
-    for item in getattr(tree, "tree", []):
-        path_obj = getattr(item, "path", None)
-        item_type_obj = getattr(item, "type", None)
-        if item_type_obj != "blob":
-            continue
-
-        path = path_obj if isinstance(path_obj, str) else ""
-        if not path or _is_skipped_manifest_path(path):
-            continue
-
-        basename = path.rsplit("/", 1)[-1].lower()
-        if basename in _MANIFEST_FILE_NAMES or basename.endswith(".gemspec"):
-            manifest_paths.add(path)
-
-    return sorted(manifest_paths)
+    try:
+        return msgspec.convert(response_payload, type=_GraphQLResponse)
+    except msgspec.ValidationError as exc:
+        logger.warning(f"Invalid GraphQL manifest response for {owner}/{repo_name}: {exc}")
+        return None
 
 
 def _is_skipped_manifest_path(path: str) -> bool:
@@ -345,24 +437,25 @@ def _system_from_manifest_path(path: str) -> str | None:
 
     lowered = path.lower()
 
-    if lowered.endswith("cargo.toml"):
-        return "CARGO"
-    if lowered.endswith("package.json"):
-        return "NPM"
-    if lowered.endswith("pyproject.toml") or lowered.endswith("setup.py") or lowered.endswith("setup.cfg"):
-        return "PYPI"
-    if lowered.endswith("pom.xml"):
-        return "MAVEN"
-    if lowered.endswith("go.mod"):
-        return "GO"
-    if lowered.endswith("gemfile") or lowered.endswith(".gemspec"):
-        return "RUBYGEMS"
-    if lowered.endswith("pubspec.yaml"):
-        return "DART"
-    if lowered.endswith("composer.json"):
-        return "COMPOSER"
-
-    return None
+    match lowered:
+        case _ if lowered.endswith("cargo.toml"):
+            return "CARGO"
+        case _ if lowered.endswith("package.json"):
+            return "NPM"
+        case _ if lowered.endswith("pyproject.toml") or lowered.endswith("setup.py") or lowered.endswith("setup.cfg"):
+            return "PYPI"
+        case _ if lowered.endswith("pom.xml"):
+            return "MAVEN"
+        case _ if lowered.endswith("go.mod"):
+            return "GO"
+        case _ if lowered.endswith("gemfile") or lowered.endswith(".gemspec"):
+            return "RUBYGEMS"
+        case _ if lowered.endswith("pubspec.yaml"):
+            return "DART"
+        case _ if lowered.endswith("composer.json"):
+            return "COMPOSER"
+        case _:
+            return None
 
 
 def _read_manifest_text(repo: Any, path: str) -> str:
@@ -383,62 +476,84 @@ def _extract_package_name(system: str, path: str, manifest_text: str, owner: str
     Extract one package name from manifest content for a given ecosystem.
     """
 
-    if system == "NPM":
-        try:
-            npm_manifest = _NpmManifest.model_validate_json(manifest_text)
-        except ValidationError:
+    lowered_path = path.lower()
+
+    match system:
+        case "NPM":
+            compact_manifest = "".join(manifest_text.lower().split())
+            if '"private":true' in compact_manifest:
+                return None
+
+            try:
+                npm_manifest = msgspec.json.decode(manifest_text, type=_NpmManifest)
+            except msgspec.ValidationError:
+                return None
+
+            if npm_manifest.private is True:
+                return None
+
+            if not npm_manifest.version:
+                return None
+
+            return npm_manifest.name if npm_manifest.name else None
+
+        case "COMPOSER":
+            try:
+                composer_manifest = msgspec.json.decode(manifest_text, type=_ComposerManifest)
+            except msgspec.ValidationError:
+                return None
+
+            return composer_manifest.name if composer_manifest.name else None
+
+        case "DART":
+            name_match = re.search(r"^name\s*:\s*([A-Za-z0-9_.-]+)\s*$", manifest_text, flags=re.MULTILINE)
+            if name_match is not None:
+                return name_match.group(1)
+
             return repo_name
 
-        if npm_manifest.private is True:
-            return None
+        case "GO":
+            for line in manifest_text.splitlines():
+                stripped_line = line.strip()
+                if not stripped_line.startswith("module"):
+                    continue
 
-        return npm_manifest.name if npm_manifest.name else repo_name
+                module_expr = stripped_line.split("//", 1)[0].strip()
+                module_match = re.fullmatch(r'module\s+(?:"([^"]+)"|([^\s]+))', module_expr)
+                if module_match is None:
+                    continue
 
-    if system == "COMPOSER":
-        try:
-            composer_manifest = _ComposerManifest.model_validate_json(manifest_text)
-        except ValidationError:
-            return None
+                quoted_value = module_match.group(1)
+                bare_value = module_match.group(2)
+                module_path = quoted_value if quoted_value is not None else bare_value
+                if module_path:
+                    return module_path
 
-        return composer_manifest.name if composer_manifest.name else None
+            return f"github.com/{owner}/{repo_name}"
 
-    if system == "DART":
-        match = re.search(r"^name\s*:\s*([A-Za-z0-9_.-]+)\s*$", manifest_text, flags=re.MULTILINE)
-        if match is not None:
-            return match.group(1)
+        case "CARGO":
+            if "[package]" not in manifest_text:
+                return None
 
-        return repo_name
+            try:
+                cargo_manifest = msgspec.convert(tomllib.loads(manifest_text), type=_CargoManifest)
+            except tomllib.TOMLDecodeError, msgspec.ValidationError:
+                return repo_name
 
-    if system == "GO":
-        match = re.search(r"^module\s+(.+)$", manifest_text, flags=re.MULTILINE)
-        if match is not None:
-            return match.group(1).strip()
+            package_name = cargo_manifest.package.name if cargo_manifest.package is not None else None
+            return package_name if package_name else repo_name
 
-        return f"github.com/{owner}/{repo_name}"
+        case "PYPI" if lowered_path.endswith("pyproject.toml"):
+            try:
+                pyproject_manifest = msgspec.convert(tomllib.loads(manifest_text), type=_PyProjectManifest)
+            except tomllib.TOMLDecodeError, msgspec.ValidationError:
+                return repo_name
 
-    if system == "CARGO":
-        try:
-            cargo_manifest = _CargoManifest.model_validate(tomllib.loads(manifest_text))
-        except tomllib.TOMLDecodeError, ValidationError:
+            project_name = pyproject_manifest.project.name if pyproject_manifest.project is not None else None
+            return project_name if project_name else repo_name
+
+        case _:
             return repo_name
-
-        if cargo_manifest.package is not None and cargo_manifest.package.name:
-            return cargo_manifest.package.name
-
-        return repo_name
-
-    if system == "PYPI" and path.endswith("pyproject.toml"):
-        try:
-            pyproject_manifest = _PyProjectManifest.model_validate(tomllib.loads(manifest_text))
-        except tomllib.TOMLDecodeError, ValidationError:
-            return repo_name
-
-        if pyproject_manifest.project is not None and pyproject_manifest.project.name:
-            return pyproject_manifest.project.name
-
-        return repo_name
-
-    return repo_name
 
 
 def latest_version_from_repo(owner: str, repo_name: str) -> str:

--- a/pg_atlas/procrastinate/github.py
+++ b/pg_atlas/procrastinate/github.py
@@ -173,7 +173,6 @@ class PackageReference:
 
     system: str
     name: str
-    version: str = ""
     purl: str = ""
 
     @classmethod
@@ -183,7 +182,6 @@ class PackageReference:
         return cls(
             system=payload.get("system", ""),
             name=payload.get("name", ""),
-            version=payload.get("version", ""),
             purl=payload.get("purl", ""),
         )
 

--- a/pg_atlas/procrastinate/github.py
+++ b/pg_atlas/procrastinate/github.py
@@ -13,13 +13,81 @@ from __future__ import annotations
 import datetime as dt
 import logging
 import os
+import re
+import tomllib
 from dataclasses import dataclass
 from threading import Lock
+from typing import Any
 
-import msgspec
 from github import Auth, Github, GithubException
+from pydantic import BaseModel, ValidationError
 
 logger = logging.getLogger(__name__)
+
+
+_MANIFEST_SEARCH_TERMS = [
+    "path:Cargo.toml",
+    "path:package.json",
+    "path:pyproject.toml",
+    "path:setup.py",
+    "path:setup.cfg",
+    "path:pom.xml",
+    "path:go.mod",
+    "path:Gemfile",
+    "path:pubspec.yaml",
+    "path:composer.json",
+    "path:.gemspec",
+]
+
+
+class _NpmManifest(BaseModel):
+    """
+    Typed subset of package.json fields used for package detection.
+    """
+
+    name: str | None = None
+    private: bool | None = None
+
+
+class _ComposerManifest(BaseModel):
+    """
+    Typed subset of composer.json fields used for package detection.
+    """
+
+    name: str | None = None
+
+
+class _CargoPackageSection(BaseModel):
+    """
+    Typed subset of Cargo.toml [package] section.
+    """
+
+    name: str | None = None
+
+
+class _CargoManifest(BaseModel):
+    """
+    Typed subset of Cargo.toml used for package detection.
+    """
+
+    package: _CargoPackageSection | None = None
+
+
+class _PyProjectSection(BaseModel):
+    """
+    Typed subset of pyproject.toml [project] section.
+    """
+
+    name: str | None = None
+
+
+class _PyProjectManifest(BaseModel):
+    """
+    Typed subset of pyproject.toml used for package detection.
+    """
+
+    project: _PyProjectSection | None = None
+
 
 # Module-level singletons
 _gh_client: Github | None = None
@@ -169,55 +237,178 @@ def get_single_repo(owner: str, repo_name: str) -> list[GitHubRepoMetadata]:
 
 def detect_packages_from_repo(owner: str, repo_name: str) -> list[PackageReference]:
     """
-    Detect published packages by inspecting repo root for manifest files.
+    Detect published packages by searching for manifests in the repository.
 
-    Returns a list of ``{system, name}`` dicts.
+    Uses GitHub code search so monorepo manifests in nested directories are
+    detected.
     """
     gh = get_github_client()
-    packages: list[PackageReference] = []
+    repo_path = f"{owner}/{repo_name}"
+    package_refs: list[PackageReference] = []
+    seen_keys: set[tuple[str, str]] = set()
 
     try:
-        repo = gh.get_repo(f"{owner}/{repo_name}")
-        contents = repo.get_contents("")
+        repo = gh.get_repo(repo_path)
+    except GithubException as exc:
+        logger.warning(f"Failed to access repo for package detection {repo_path}: {exc}")
 
-        if not isinstance(contents, list):
-            contents = [contents]
+        return []
 
-        filenames = {c.name for c in contents}
+    search_terms = " OR ".join(_MANIFEST_SEARCH_TERMS)
+    query = f"repo:{repo_path} ({search_terms}) -path:test -path:tests -path:example -path:examples"
 
-        if "Cargo.toml" in filenames:
-            packages.append(PackageReference(system="CARGO", name=repo_name))
+    try:
+        search_results = gh.search_code(query=query)
+        for index, result in enumerate(search_results):
+            # Guard against unexpectedly-large repositories.
+            if index >= 200:
+                break
 
-        if "package.json" in filenames:
-            # Try to read the actual package name from package.json.
+            path_obj = getattr(result, "path", None)
+            path = path_obj if isinstance(path_obj, str) else ""
+            if not path:
+                continue
+
+            system = _system_from_manifest_path(path)
+            if system is None:
+                continue
+
             try:
-                pj = repo.get_contents("package.json")
-                pkg_data = msgspec.json.decode(pj.decoded_content, type=dict[str, object])  # type: ignore[union-attr]
-                npm_name_obj = pkg_data.get("name")
-                npm_name = npm_name_obj if isinstance(npm_name_obj, str) else repo_name
-                packages.append(PackageReference(system="NPM", name=npm_name))
+                manifest_text = _read_manifest_text(repo, path)
+            except GithubException as exc:
+                logger.warning(f"Failed to read manifest {path} in {repo_path}: {exc}")
+                continue
 
-            except GithubException, msgspec.DecodeError, msgspec.ValidationError, AttributeError, TypeError:
-                packages.append(PackageReference(system="NPM", name=repo_name))
+            package_name = _extract_package_name(system, path, manifest_text, owner, repo_name)
 
-        if "pyproject.toml" in filenames or "setup.py" in filenames or "setup.cfg" in filenames:
-            packages.append(PackageReference(system="PYPI", name=repo_name))
+            if package_name is None:
+                continue
 
-        if "pom.xml" in filenames:
-            packages.append(PackageReference(system="MAVEN", name=repo_name))
+            key = (system, package_name)
+            if key in seen_keys:
+                continue
 
-        if "go.mod" in filenames:
-            packages.append(PackageReference(system="GO", name=f"github.com/{owner}/{repo_name}"))
-
-        if f"{repo_name}.gemspec" in filenames or "Gemfile" in filenames:
-            packages.append(PackageReference(system="RUBYGEMS", name=repo_name))
+            seen_keys.add(key)
+            package_refs.append(PackageReference(system=system, name=package_name))
 
     except GithubException as exc:
-        logger.warning(f"Failed to detect packages in {owner}/{repo_name}: {exc}")
+        logger.warning(f"GitHub code search unavailable for {repo_path}: {exc}")
+        return []
 
-    # Keep the same shape produced by get_project_package_versions():
-    # {"system": "...", "name": "..."} plus optional keys.
-    return packages
+    if not package_refs:
+        logger.info(f"detect_packages_from_repo: {repo_path} packages={{}}")
+        return []
+
+    counts_by_system: dict[str, int] = {}
+    for package_ref in package_refs:
+        counts_by_system[package_ref.system] = counts_by_system.get(package_ref.system, 0) + 1
+
+    logger.info(f"detect_packages_from_repo: {repo_path} packages={counts_by_system}")
+
+    return package_refs
+
+
+def _system_from_manifest_path(path: str) -> str | None:
+    """
+    Resolve a package system from one manifest path.
+    """
+
+    lowered = path.lower()
+
+    if lowered.endswith("cargo.toml"):
+        return "CARGO"
+    if lowered.endswith("package.json"):
+        return "NPM"
+    if lowered.endswith("pyproject.toml") or lowered.endswith("setup.py") or lowered.endswith("setup.cfg"):
+        return "PYPI"
+    if lowered.endswith("pom.xml"):
+        return "MAVEN"
+    if lowered.endswith("go.mod"):
+        return "GO"
+    if lowered.endswith("gemfile") or lowered.endswith(".gemspec"):
+        return "RUBYGEMS"
+    if lowered.endswith("pubspec.yaml"):
+        return "DART"
+    if lowered.endswith("composer.json"):
+        return "COMPOSER"
+
+    return None
+
+
+def _read_manifest_text(repo: Any, path: str) -> str:
+    """
+    Read one manifest file from GitHub and decode it to UTF-8 text.
+    """
+
+    content = repo.get_contents(path)
+    raw = getattr(content, "decoded_content", b"")
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", errors="replace")
+
+    return ""
+
+
+def _extract_package_name(system: str, path: str, manifest_text: str, owner: str, repo_name: str) -> str | None:
+    """
+    Extract one package name from manifest content for a given ecosystem.
+    """
+
+    if system == "NPM":
+        try:
+            npm_manifest = _NpmManifest.model_validate_json(manifest_text)
+        except ValidationError:
+            return repo_name
+
+        if npm_manifest.private is True:
+            return None
+
+        return npm_manifest.name if npm_manifest.name else repo_name
+
+    if system == "COMPOSER":
+        try:
+            composer_manifest = _ComposerManifest.model_validate_json(manifest_text)
+        except ValidationError:
+            return None
+
+        return composer_manifest.name if composer_manifest.name else None
+
+    if system == "DART":
+        match = re.search(r"^name\s*:\s*([A-Za-z0-9_.-]+)\s*$", manifest_text, flags=re.MULTILINE)
+        if match is not None:
+            return match.group(1)
+
+        return repo_name
+
+    if system == "GO":
+        match = re.search(r"^module\s+(.+)$", manifest_text, flags=re.MULTILINE)
+        if match is not None:
+            return match.group(1).strip()
+
+        return f"github.com/{owner}/{repo_name}"
+
+    if system == "CARGO":
+        try:
+            cargo_manifest = _CargoManifest.model_validate(tomllib.loads(manifest_text))
+        except tomllib.TOMLDecodeError, ValidationError:
+            return repo_name
+
+        if cargo_manifest.package is not None and cargo_manifest.package.name:
+            return cargo_manifest.package.name
+
+        return repo_name
+
+    if system == "PYPI" and path.endswith("pyproject.toml"):
+        try:
+            pyproject_manifest = _PyProjectManifest.model_validate(tomllib.loads(manifest_text))
+        except tomllib.TOMLDecodeError, ValidationError:
+            return repo_name
+
+        if pyproject_manifest.project is not None and pyproject_manifest.project.name:
+            return pyproject_manifest.project.name
+
+        return repo_name
+
+    return repo_name
 
 
 def latest_version_from_repo(owner: str, repo_name: str) -> str:

--- a/pg_atlas/procrastinate/github.py
+++ b/pg_atlas/procrastinate/github.py
@@ -25,19 +25,22 @@ from pydantic import BaseModel, ValidationError
 logger = logging.getLogger(__name__)
 
 
-_MANIFEST_SEARCH_TERMS = [
-    "path:Cargo.toml",
-    "path:package.json",
-    "path:pyproject.toml",
-    "path:setup.py",
-    "path:setup.cfg",
-    "path:pom.xml",
-    "path:go.mod",
-    "path:Gemfile",
-    "path:pubspec.yaml",
-    "path:composer.json",
-    "path:.gemspec",
-]
+_MANIFEST_FILE_NAMES = frozenset(
+    {
+        "cargo.toml",
+        "package.json",
+        "pyproject.toml",
+        "setup.py",
+        "setup.cfg",
+        "pom.xml",
+        "go.mod",
+        "gemfile",
+        "pubspec.yaml",
+        "composer.json",
+    }
+)
+
+_SKIPPED_PATH_SUBSTRINGS = frozenset({".github", "example", "test"})
 
 
 class _NpmManifest(BaseModel):
@@ -237,10 +240,11 @@ def get_single_repo(owner: str, repo_name: str) -> list[GitHubRepoMetadata]:
 
 def detect_packages_from_repo(owner: str, repo_name: str) -> list[PackageReference]:
     """
-    Detect published packages by searching for manifests in the repository.
+    Detect published packages by scanning manifests in the repository tree.
 
-    Uses GitHub code search so monorepo manifests in nested directories are
-    detected.
+    This scan is auth-independent and covers nested monorepo paths. It avoids
+    GitHub code-search query/parser failures by listing the Git tree directly
+    and parsing only manifest blobs.
     """
     gh = get_github_client()
     repo_path = f"{owner}/{repo_name}"
@@ -254,46 +258,29 @@ def detect_packages_from_repo(owner: str, repo_name: str) -> list[PackageReferen
 
         return []
 
-    search_terms = " OR ".join(_MANIFEST_SEARCH_TERMS)
-    query = f"repo:{repo_path} ({search_terms}) -path:test -path:tests -path:example -path:examples"
+    manifest_paths = _manifest_paths_from_repo_tree(repo, repo_path)
 
-    try:
-        search_results = gh.search_code(query=query)
-        for index, result in enumerate(search_results):
-            # Guard against unexpectedly-large repositories.
-            if index >= 200:
-                break
+    for path in manifest_paths:
+        system = _system_from_manifest_path(path)
+        if system is None:
+            continue
 
-            path_obj = getattr(result, "path", None)
-            path = path_obj if isinstance(path_obj, str) else ""
-            if not path:
-                continue
+        try:
+            manifest_text = _read_manifest_text(repo, path)
+        except GithubException as exc:
+            logger.warning(f"Failed to read manifest {path} in {repo_path}: {exc}")
+            continue
 
-            system = _system_from_manifest_path(path)
-            if system is None:
-                continue
+        package_name = _extract_package_name(system, path, manifest_text, owner, repo_name)
+        if package_name is None:
+            continue
 
-            try:
-                manifest_text = _read_manifest_text(repo, path)
-            except GithubException as exc:
-                logger.warning(f"Failed to read manifest {path} in {repo_path}: {exc}")
-                continue
+        key = (system, package_name)
+        if key in seen_keys:
+            continue
 
-            package_name = _extract_package_name(system, path, manifest_text, owner, repo_name)
-
-            if package_name is None:
-                continue
-
-            key = (system, package_name)
-            if key in seen_keys:
-                continue
-
-            seen_keys.add(key)
-            package_refs.append(PackageReference(system=system, name=package_name))
-
-    except GithubException as exc:
-        logger.warning(f"GitHub code search unavailable for {repo_path}: {exc}")
-        return []
+        seen_keys.add(key)
+        package_refs.append(PackageReference(system=system, name=package_name))
 
     if not package_refs:
         logger.info(f"detect_packages_from_repo: {repo_path} packages={{}}")
@@ -306,6 +293,49 @@ def detect_packages_from_repo(owner: str, repo_name: str) -> list[PackageReferen
     logger.info(f"detect_packages_from_repo: {repo_path} packages={counts_by_system}")
 
     return package_refs
+
+
+def _manifest_paths_from_repo_tree(repo: Any, repo_path: str) -> list[str]:
+    """
+    Collect manifest blob paths from one repository tree.
+
+    Skips common test/example folders to reduce noise.
+    """
+
+    try:
+        default_branch = getattr(repo, "default_branch", None) or "main"
+        tree = repo.get_git_tree(default_branch, recursive=True)
+    except GithubException as exc:
+        logger.warning(f"Failed to list git tree for {repo_path}: {exc}")
+        return []
+
+    if bool(getattr(tree, "truncated", False)):
+        logger.warning(f"Manifest scan tree was truncated for {repo_path}")
+
+    manifest_paths: set[str] = set()
+    for item in getattr(tree, "tree", []):
+        path_obj = getattr(item, "path", None)
+        item_type_obj = getattr(item, "type", None)
+        if item_type_obj != "blob":
+            continue
+
+        path = path_obj if isinstance(path_obj, str) else ""
+        if not path or _is_skipped_manifest_path(path):
+            continue
+
+        basename = path.rsplit("/", 1)[-1].lower()
+        if basename in _MANIFEST_FILE_NAMES or basename.endswith(".gemspec"):
+            manifest_paths.add(path)
+
+    return sorted(manifest_paths)
+
+
+def _is_skipped_manifest_path(path: str) -> bool:
+    """
+    Return whether one path falls under ignored test/example folders.
+    """
+    normalized_path = path.lower()
+    return any(substr in normalized_path for substr in _SKIPPED_PATH_SUBSTRINGS)
 
 
 def _system_from_manifest_path(path: str) -> str | None:

--- a/pg_atlas/procrastinate/tasks.py
+++ b/pg_atlas/procrastinate/tasks.py
@@ -543,7 +543,6 @@ async def crawl_github_repo(
             queueing_lock=f"registry:{repo_canonical_id}:{system}",
             system=system,
             package_names=sorted(package_names),
-            source_repo_canonical_id=repo_canonical_id,
         )
         if enqueued:
             deferred_registry_tasks += 1
@@ -568,7 +567,6 @@ async def crawl_github_repo(
 async def crawl_package_registry(
     system: str,
     package_names: list[str],
-    source_repo_canonical_id: str,
 ) -> None:
     """
     Crawl direct registry signals and persist package-level download metadata.
@@ -603,10 +601,7 @@ async def crawl_package_registry(
 
             return
 
-        result = await crawler.crawl_and_persist(
-            package_names=package_names,
-            source_repo_canonical_id=source_repo_canonical_id,
-        )
+        result = await crawler.crawl_and_persist(package_names=package_names)
 
     logger.info(
         f"crawl_package_registry: system={normalized_system} packages={len(package_names)} "
@@ -681,54 +676,59 @@ async def crawl_package_deps(
 
         source_vertex_id: int = row[0]
 
-    finally:
-        await session.close()
+        # ----- Process each requirement -----
+        for req in reqs:
+            dep_purl_type = _purl_type_for_system(req.system)
+            dep_canonical_id = f"pkg:{dep_purl_type}/{req.name}" if dep_purl_type else req.name.lower()
 
-    # ----- Process each requirement -----
-    for req in reqs:
-        dep_purl_type = _purl_type_for_system(req.system)
-        dep_canonical_id = f"pkg:{dep_purl_type}/{req.name}" if dep_purl_type else req.name.lower()
+            if dep_canonical_id == source_repo_canonical_id:
+                logger.debug(f"Skipping self-recursive dependency {dep_canonical_id}")
 
-        if dep_canonical_id == source_repo_canonical_id:
-            logger.debug(f"Skipping self-recursive dependency {dep_canonical_id}")
+                continue
 
-            continue
+            # Look up the dependency's package PURL in existing Repos' releases.
+            repo_match = await find_repo_by_release_purl(dep_canonical_id)
 
-        # Look up the dependency's package PURL in existing Repos' releases.
-        repo_match = await find_repo_by_release_purl(dep_canonical_id)
+            if repo_match is not None:
+                dep_vertex_id, repo_canonical_id, project_id = repo_match
 
-        if repo_match is not None:
-            dep_vertex_id, repo_canonical_id, project_id = repo_match
-
-            await upsert_depends_on(
-                in_vertex_id=source_vertex_id,
-                out_vertex_id=dep_vertex_id,
-                version_range=req.version_constraint,
-            )
-
-            # Recurse only if the Repo belongs to a tracked Project.
-            if project_id is not None:
-                await _defer_with_lock(
-                    crawl_package_deps,
-                    queueing_lock=f"{req.system}:{req.name}",
-                    system=req.system,
-                    package_name=req.name,
-                    source_repo_canonical_id=repo_canonical_id,
+                await upsert_depends_on(
+                    session=session,
+                    in_vertex_id=source_vertex_id,
+                    out_vertex_id=dep_vertex_id,
+                    version_range=req.version_constraint,
                 )
 
-        else:
-            # External dependency — upsert ExternalRepo, no recursion.
-            dep_vertex_id = await upsert_external_repo(
-                canonical_id=dep_canonical_id,
-                display_name=req.name,
-                latest_version=req.version_constraint,
-            )
+                # Recurse only if the Repo belongs to a tracked Project.
+                if project_id is not None:
+                    await _defer_with_lock(
+                        crawl_package_deps,
+                        queueing_lock=f"{req.system}:{req.name}",
+                        system=req.system,
+                        package_name=req.name,
+                        source_repo_canonical_id=repo_canonical_id,
+                    )
 
-            await upsert_depends_on(
-                in_vertex_id=source_vertex_id,
-                out_vertex_id=dep_vertex_id,
-                version_range=req.version_constraint,
-            )
+            else:
+                # External dependency — upsert ExternalRepo, no recursion.
+                dep_vertex_id = await upsert_external_repo(
+                    session=session,
+                    canonical_id=dep_canonical_id,
+                    display_name=req.name,
+                    latest_version=req.version_constraint,
+                )
+
+                await upsert_depends_on(
+                    session=session,
+                    in_vertex_id=source_vertex_id,
+                    out_vertex_id=dep_vertex_id,
+                    version_range=req.version_constraint,
+                )
+
+        await session.commit()
+
+    finally:
+        await session.close()
 
     logger.info(f"crawl_package_deps: {system}/{package_name}@{version} - {len(reqs)} deps processed")
 

--- a/pg_atlas/procrastinate/tasks.py
+++ b/pg_atlas/procrastinate/tasks.py
@@ -36,6 +36,7 @@ from sqlalchemy import select
 from pg_atlas.config import settings
 from pg_atlas.crawlers.factory import build_registry_crawler, normalize_registry_system
 from pg_atlas.db_models.base import ActivityStatus, ProjectType, SubmissionStatus
+from pg_atlas.db_models.release import Release
 from pg_atlas.db_models.repo_vertex import RepoVertex
 from pg_atlas.db_models.sbom_submission import SbomSubmission
 from pg_atlas.db_models.session import get_session_factory
@@ -441,7 +442,7 @@ async def crawl_github_repo(
     packages_to_process = list(unique_packages.values())
 
     # ----- Build releases from package info -----
-    releases: list[dict[str, Any]] = []
+    releases: list[Release] = []
     async with depsdev_session() as stub:
         for pkg in packages_to_process:
             system = pkg.system
@@ -451,11 +452,11 @@ async def crawl_github_repo(
                 pkg_info = await get_package(system, name, stub=stub)
                 for v in pkg_info.versions:
                     releases.append(
-                        {
-                            "version": v.version,
-                            "release_date": v.published_at,
-                            "purl": strip_purl_version(v.purl),
-                        }
+                        Release(
+                            version=v.version,
+                            release_date=v.published_at or "",
+                            purl=strip_purl_version(v.purl),
+                        )
                     )
 
             except DepsDevError:
@@ -468,7 +469,7 @@ async def crawl_github_repo(
     # ----- Determine latest_version -----
     if releases:
         # Use the latest version from package releases.
-        latest_version = releases[-1].get("version", "")
+        latest_version = releases[-1].version
     else:
         latest_version = latest_version_from_repo(owner, repo)
 

--- a/pg_atlas/procrastinate/tasks.py
+++ b/pg_atlas/procrastinate/tasks.py
@@ -10,12 +10,12 @@ Task hierarchy (queue names in brackets)::
     sync_opengrants  [opengrants]
       └─ process_project  [opengrants]
            └─ crawl_github_repo  [opengrants]
-                └─ crawl_package_deps  [package-deps]
+                 ├─ crawl_package_deps  [package-deps]
+                 └─ crawl_package_registry  [registry-crawl]
 
-The bootstrap workers are invoked sequentially per queue so that all
-``crawl_github_repo`` tasks are complete before ``crawl_package_deps`` begins.
-This guarantees that ``Repo`` vertices and their ``Project`` associations
-exist by the time the dependency crawl needs to check them.
+The bootstrap workers run ``package-deps`` and ``registry-crawl`` after
+``opengrants`` has drained so that all ``Repo`` vertices and ``Project``
+associations exist by the time downstream crawls execute.
 
 SPDX-FileCopyrightText: 2026 PG Atlas contributors
 SPDX-License-Identifier: MPL-2.0
@@ -33,6 +33,8 @@ import yaml
 from procrastinate.exceptions import AlreadyEnqueued
 from sqlalchemy import select
 
+from pg_atlas.config import settings
+from pg_atlas.crawlers.factory import build_registry_crawler, normalize_registry_system
 from pg_atlas.db_models.base import ActivityStatus, ProjectType, SubmissionStatus
 from pg_atlas.db_models.repo_vertex import RepoVertex
 from pg_atlas.db_models.sbom_submission import SbomSubmission
@@ -70,6 +72,9 @@ from pg_atlas.procrastinate.upserts import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+REGISTRY_CRAWL_SYSTEMS = frozenset({"DART", "COMPOSER"})
 
 
 # ---------------------------------------------------------------------------
@@ -516,9 +521,96 @@ async def crawl_github_repo(
             source_repo_canonical_id=repo_canonical_id,
         )
 
+    registry_packages_by_system: dict[str, set[str]] = {}
+    unsupported_registry_purls: dict[str, set[str]] = {}
+
+    for pkg in packages_to_process:
+        normalized_system = normalize_registry_system(pkg.system)
+        if normalized_system is None:
+            purl = _purl_for_package(pkg.system, pkg.name)
+            unsupported_registry_purls.setdefault(pkg.system.upper(), set()).add(purl)
+            continue
+
+        registry_packages_by_system.setdefault(normalized_system, set()).add(pkg.name)
+
+    deferred_registry_tasks = 0
+    for system, package_names in registry_packages_by_system.items():
+        if system not in REGISTRY_CRAWL_SYSTEMS:
+            continue
+
+        enqueued = await _defer_with_lock(
+            crawl_package_registry,
+            queueing_lock=f"registry:{repo_canonical_id}:{system}",
+            system=system,
+            package_names=sorted(package_names),
+            source_repo_canonical_id=repo_canonical_id,
+        )
+        if enqueued:
+            deferred_registry_tasks += 1
+
+    for system, purls in sorted(unsupported_registry_purls.items()):
+        joined_purls = " ".join(sorted(purls))
+        logger.warning(f"registry-crawl unsupported ecosystem: system={system} purls={joined_purls}")
+
     logger.info(
         f"crawl_github_repo: {owner}/{repo} - {len(packages_to_process)} packages, "
-        f"deferred {len(packages_to_process)} crawl_package_deps tasks"
+        f"deferred {len(packages_to_process)} crawl_package_deps tasks, "
+        f"deferred {deferred_registry_tasks} crawl_package_registry tasks"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task: crawl_package_registry
+# ---------------------------------------------------------------------------
+
+
+@app.task(queue="registry-crawl")
+async def crawl_package_registry(
+    system: str,
+    package_names: list[str],
+    source_repo_canonical_id: str,
+) -> None:
+    """
+    Crawl direct registry signals and persist package-level download metadata.
+
+    This task is intentionally separate from deps.dev dependency crawling.
+    It fetches package signals from source registries and records per-package
+    download counts under the source repo metadata map.
+    """
+
+    normalized_system = normalize_registry_system(system)
+    if normalized_system is None:
+        logger.warning(f"crawl_package_registry: unsupported system={system}")
+
+        return
+
+    session_factory = get_session_factory()
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(settings.CRAWLER_TIMEOUT, connect=10.0),
+        follow_redirects=True,
+        headers={"User-Agent": "pg-atlas-crawler/0.1"},
+    ) as client:
+        crawler = build_registry_crawler(
+            normalized_system,
+            client=client,
+            session_factory=session_factory,
+            rate_limit=settings.CRAWLER_RATE_LIMIT,
+            max_retries=settings.CRAWLER_MAX_RETRIES,
+        )
+
+        if crawler is None:
+            logger.warning(f"crawl_package_registry: no crawler available for system={normalized_system}")
+
+            return
+
+        result = await crawler.crawl_and_persist(
+            package_names=package_names,
+            source_repo_canonical_id=source_repo_canonical_id,
+        )
+
+    logger.info(
+        f"crawl_package_registry: system={normalized_system} packages={len(package_names)} "
+        f"processed={result.packages_processed} errors={len(result.errors)}"
     )
 
 
@@ -663,6 +755,20 @@ def _purl_type_for_system(system: str) -> str | None:
         "GO": "golang",
         "RUBYGEMS": "gem",
         "NUGET": "nuget",
+        "DART": "pub",
+        "COMPOSER": "composer",
     }
 
     return _map.get(system.upper())
+
+
+def _purl_for_package(system: str, name: str) -> str:
+    """
+    Build a best-effort PURL for one system/package pair.
+    """
+
+    purl_type = _purl_type_for_system(system)
+    if purl_type is None:
+        return name
+
+    return f"pkg:{purl_type}/{name}"

--- a/pg_atlas/procrastinate/tasks.py
+++ b/pg_atlas/procrastinate/tasks.py
@@ -53,18 +53,10 @@ from pg_atlas.procrastinate.depsdev import (
 from pg_atlas.procrastinate.github import (
     GitHubRepoMetadata,
     PackageReference,
-)
-from pg_atlas.procrastinate.github import (
-    detect_packages_from_repo as _detect_packages_from_repo,
-)
-from pg_atlas.procrastinate.github import (
-    get_single_repo as _get_single_repo,
-)
-from pg_atlas.procrastinate.github import (
-    latest_version_from_repo as _latest_version_from_repo,
-)
-from pg_atlas.procrastinate.github import (
-    list_org_repos as _list_org_repos,
+    detect_packages_from_repo,
+    get_single_repo,
+    latest_version_from_repo,
+    list_org_repos,
 )
 from pg_atlas.procrastinate.opengrants import fetch_scf_projects
 from pg_atlas.procrastinate.upserts import (
@@ -302,10 +294,10 @@ async def process_project(
     repos_to_crawl: list[GitHubRepoMetadata] = []
     if owner:
         if extended_universe or not git_repo_url:
-            repos_to_crawl = _list_org_repos(owner)
+            repos_to_crawl = list_org_repos(owner)
         else:
             repo_name = git_repo_url.rstrip("/").rsplit("/", 1)[-1]
-            repos_to_crawl = _get_single_repo(owner, repo_name)
+            repos_to_crawl = get_single_repo(owner, repo_name)
             logger.info(f"Restricting {git_owner_url} crawl to {repo_name} only.")
 
     # ----- deps.dev GetProjectBatch -----
@@ -417,7 +409,7 @@ async def crawl_github_repo(
 
     package_refs = [PackageReference.from_payload(pkg) for pkg in packages]
     if not package_refs:
-        package_refs = _detect_packages_from_repo(owner, repo)
+        package_refs = detect_packages_from_repo(owner, repo)
         logger.info(f"Detected {len(package_refs)} packages in {owner}/{repo}")
 
     # Deps.dev project package versions can include many entries per package
@@ -463,7 +455,7 @@ async def crawl_github_repo(
         # Use the latest version from package releases.
         latest_version = releases[-1].get("version", "")
     else:
-        latest_version = _latest_version_from_repo(owner, repo)
+        latest_version = latest_version_from_repo(owner, repo)
 
     # ----- Upsert the Repo vertex (pkg:github/owner/repo) -----
     repo_canonical_id = f"pkg:github/{owner}/{repo}"

--- a/pg_atlas/procrastinate/tasks.py
+++ b/pg_atlas/procrastinate/tasks.py
@@ -38,7 +38,7 @@ from pg_atlas.config import settings
 from pg_atlas.crawlers.base import AllPackagesFailed
 from pg_atlas.crawlers.factory import build_registry_crawler, normalize_registry_system
 from pg_atlas.db_models.base import ActivityStatus, ProjectType, SubmissionStatus
-from pg_atlas.db_models.release import Release
+from pg_atlas.db_models.release import Release, preferred_latest_version, sorted_releases_desc
 from pg_atlas.db_models.repo_vertex import RepoVertex
 from pg_atlas.db_models.sbom_submission import SbomSubmission
 from pg_atlas.db_models.session import get_session_factory
@@ -75,8 +75,9 @@ from pg_atlas.procrastinate.upserts import (
 
 logger = logging.getLogger(__name__)
 
-
+# TODO: refactor into single source of truth; should live in crawlers and depsdev.
 REGISTRY_CRAWL_SYSTEMS = frozenset({"DART", "COMPOSER"})
+DEPSDEV_SUPPORTED_SYSTEMS = frozenset({"PYPI", "NPM", "CARGO", "MAVEN", "GO", "RUBYGEMS", "NUGET"})
 
 
 # ---------------------------------------------------------------------------
@@ -89,27 +90,7 @@ _MAPPING_PATH = Path(__file__).parent / "project-git-mapping.yml"
 _MAX_RELEASE_ENTRIES = 555
 
 
-# ---------------------------------------------------------------------------
-# Mapping file helpers
-# ---------------------------------------------------------------------------
-
-
-def _load_git_mapping() -> dict[str, dict[str, str]]:
-    """
-    Load the project → git URL mapping YAML file.
-
-    Returns a dict mapping ``projectId`` → ``{git_owner_url, git_repo_url}``.
-    """
-    if not _MAPPING_PATH.exists():
-        return {}
-
-    with _MAPPING_PATH.open() as f:
-        data: dict[str, dict[str, str]] = yaml.safe_load(f) or {}
-
-    return data
-
-
-async def _defer_with_lock(task: Any, queueing_lock: str, **kwargs: Any) -> bool:
+async def defer_with_lock(task: Any, queueing_lock: str, **kwargs: Any) -> bool:
     """
     Defer a Procrastinate task and suppress expected duplicate-lock noise.
 
@@ -124,9 +105,6 @@ async def _defer_with_lock(task: Any, queueing_lock: str, **kwargs: Any) -> bool
         logger.warning(str(exc))
 
         return False
-
-
-defer_with_lock = _defer_with_lock
 
 
 # ---------------------------------------------------------------------------
@@ -270,9 +248,13 @@ async def process_project(
     2. If category is "Education & Community", skip GitHub/deps.dev crawling.
     3. Otherwise, list GitHub repos, call deps.dev, and defer ``crawl_github_repo``.
 
-    ``crawl_github_repo`` receives both deps.dev package payloads and repo
-    metadata so package detection can still run when deps.dev has no package
-    coverage for a repository.
+    ``crawl_github_repo`` receives versionless package identities so it can:
+    - reuse known package keys from deps.dev project mapping, and
+    - still detect packages from repository manifests when deps.dev has no
+        package coverage for a repository.
+
+    Later in ``crawl_github_repo``, ``get_package`` is used to fetch default
+    version and release metadata for these package identities.
     """
     logger.info(f"process_project: {display_name} ({project_canonical_id})")
 
@@ -403,8 +385,8 @@ async def crawl_github_repo(
     2. For each package, check if it exists as ``ExternalRepo``; if so,
        promote it to ``Repo`` and link it to the project.
     3. Ensure a ``Repo`` vertex ``pkg:github/owner/repo`` exists.
-    4. Defer ``crawl_package_deps`` for each package.
-    5. Group detected packages by registry system and defer one
+    4. Defer ``crawl_package_deps`` for deps.dev-supported packages.
+    5. Group registry-crawl packages by registry system and defer one
         ``crawl_package_registry`` task per supported system.
 
     Supported direct-registry crawl systems are intentionally limited to
@@ -415,31 +397,18 @@ async def crawl_github_repo(
 
     # ----- Proceed with Deps.dev packages, or detect published packages from repo manifests -----
     package_refs = [PackageReference.from_payload(pkg) for pkg in packages]
-    # the above comes from DepsDev and only includes systems it supports
+    received_depsdev_payload = bool(package_refs)
     if not package_refs:
-        # TODO: it would be helpful to track that we are now creating a MIXED list
         package_refs = detect_packages_from_repo(owner, repo)
         logger.info(f"Detected {len(package_refs)} packages in {owner}/{repo}")
 
-    # TODO: remove after dedup in `process_project`
-    # Deps.dev project package versions can include many entries per package
-    # (one row per version). Collapse to unique package keys before crawling.
-    unique_packages: dict[tuple[str, str], PackageReference] = {}
-    for pkg in package_refs:
-        system = pkg.system
-        name = pkg.name
-        if not system or not name:
-            continue
+    depsdev_packages, registry_packages, misc_packages = _partition_package_refs(package_refs)
+    mixed_package_list = bool(depsdev_packages) and bool(registry_packages or misc_packages)
 
-        unique_packages[(system, name)] = pkg
-
-    packages_to_process = list(unique_packages.values())
-
-    # ----- Build releases from package info -----
-    # FIXME: must not try to get packages for systems that DepsDev does not support
+    # ----- Build releases from deps.dev-supported package info -----
     releases: list[Release] = []
     async with depsdev_session() as stub:
-        for pkg in packages_to_process:
+        for pkg in depsdev_packages:
             system = pkg.system
             name = pkg.name
 
@@ -457,14 +426,15 @@ async def crawl_github_repo(
             except DepsDevError:
                 logger.debug(f"Package not found on deps.dev: {system}/{name}")
 
+    releases = sorted_releases_desc(releases)
+
     if len(releases) > _MAX_RELEASE_ENTRIES:
         logger.warning(f"Truncating releases for {owner}/{repo} from {len(releases)} to {_MAX_RELEASE_ENTRIES} entries")
-        releases = releases[-_MAX_RELEASE_ENTRIES:]
+        releases = releases[:_MAX_RELEASE_ENTRIES]
 
     # ----- Determine latest_version -----
     if releases:
-        # Use the latest version from package releases.
-        latest_version = releases[-1].version
+        latest_version = preferred_latest_version(releases)
     else:
         latest_version = latest_version_from_repo(owner, repo)
 
@@ -493,13 +463,13 @@ async def crawl_github_repo(
 
     # ----- For each package: absorb ExternalRepo if one exists -----
     # must happen for all packages regardless of system
-    for pkg in packages_to_process:
+    for pkg in package_refs:
         system = pkg.system
         name = pkg.name
 
         # Build the canonical_id this package would have as a vertex.
-        # TODO: simplify when purl is provided in the PackageReference
-        # preferred solution: ensure and enforce that the purl is present on every PackageReference.
+        # Package references from repository detection may not carry a purl.
+        # FIXME: ensure and enforce that the purl is present on every PackageReference
         purl_type = _purl_type_for_system(system)
         if purl_type:
             pkg_canonical_id = f"pkg:{purl_type}/{name}"
@@ -517,13 +487,12 @@ async def crawl_github_repo(
     # ----- Associate the github repo vertex with the project -----
     await associate_repo_with_project(repo_canonical_id, project_id)
 
-    # ----- Defer crawl_package_deps for each package -----
-    # FIXME: must be filtered for DepsDev supported systems
-    for pkg in packages_to_process:
+    # ----- Defer crawl_package_deps for deps.dev-supported packages -----
+    for pkg in depsdev_packages:
         system = pkg.system
         name = pkg.name
 
-        await _defer_with_lock(
+        await defer_with_lock(
             crawl_package_deps,
             queueing_lock=f"{system}:{name}",
             system=system,
@@ -531,15 +500,11 @@ async def crawl_github_repo(
             source_repo_canonical_id=repo_canonical_id,
         )
 
+    # ----- Defer crawl_package_registry for crawler-supported packages -----
     registry_packages_by_system: dict[str, set[str]] = {}
-    unsupported_registry_purls: dict[str, set[str]] = {}
-
-    # FIXME: this is a mess, clean up in refactor
-    for pkg in packages_to_process:
+    for pkg in registry_packages:
         normalized_system = normalize_registry_system(pkg.system)
         if normalized_system is None:
-            purl = _purl_for_package(pkg.system, pkg.name)
-            unsupported_registry_purls.setdefault(pkg.system.upper(), set()).add(purl)
             continue
 
         registry_packages_by_system.setdefault(normalized_system, set()).add(pkg.name)
@@ -549,7 +514,7 @@ async def crawl_github_repo(
         if system not in REGISTRY_CRAWL_SYSTEMS:
             continue
 
-        enqueued = await _defer_with_lock(
+        enqueued = await defer_with_lock(
             crawl_package_registry,
             queueing_lock=f"registry:{repo_canonical_id}:{system}",
             system=system,
@@ -558,14 +523,21 @@ async def crawl_github_repo(
         if enqueued:
             deferred_registry_tasks += 1
 
-    # FIXME: only warn for unsupported packages that have come from `detect_packages_from_repo`
+    warning_packages = list(misc_packages)
+    if mixed_package_list:
+        warning_packages.extend(depsdev_packages)
+
+    if received_depsdev_payload and not mixed_package_list:
+        warning_packages = list(misc_packages)
+
+    unsupported_registry_purls = _build_registry_warning_purls(warning_packages)
     for system, purls in sorted(unsupported_registry_purls.items()):
         joined_purls = " ".join(sorted(purls))
         logger.warning(f"registry-crawl unsupported ecosystem: system={system} purls={joined_purls}")
 
     logger.info(
-        f"crawl_github_repo: {owner}/{repo} - {len(packages_to_process)} packages, "
-        f"deferred {len(packages_to_process)} crawl_package_deps tasks, "
+        f"crawl_github_repo: {owner}/{repo} - {len(package_refs)} packages, "
+        f"deferred {len(depsdev_packages)} crawl_package_deps tasks, "
         f"deferred {deferred_registry_tasks} crawl_package_registry tasks"
     )
 
@@ -719,7 +691,7 @@ async def crawl_package_deps(
 
                 # Recurse only if the Repo belongs to a tracked Project.
                 if project_id is not None:
-                    await _defer_with_lock(
+                    await defer_with_lock(
                         crawl_package_deps,
                         queueing_lock=f"{req.system}:{req.name}",
                         system=req.system,
@@ -754,6 +726,7 @@ async def crawl_package_deps(
 # ---------------------------------------------------------------------------
 # PURL type mapping (system → PURL type component)
 # ---------------------------------------------------------------------------
+# FIXME: duplication with DEPSDEV_SUPPORTED_SYSTEMS and REGISTRY_CRAWL_SYSTEMS
 
 
 def _purl_type_for_system(system: str) -> str | None:
@@ -790,3 +763,63 @@ def _purl_for_package(system: str, name: str) -> str:
         return name
 
     return f"pkg:{purl_type}/{name}"
+
+
+def _partition_package_refs(
+    package_refs: list[PackageReference],
+) -> tuple[list[PackageReference], list[PackageReference], list[PackageReference]]:
+    """
+    Split package references by processing path.
+
+    Returns ``(depsdev_packages, registry_packages, misc_packages)``.
+    """
+
+    depsdev_packages: list[PackageReference] = []
+    registry_packages: list[PackageReference] = []
+    misc_packages: list[PackageReference] = []
+
+    for package_ref in package_refs:
+        system = package_ref.system.upper()
+        if system in DEPSDEV_SUPPORTED_SYSTEMS:
+            depsdev_packages.append(package_ref)
+            continue
+
+        normalized_registry_system = normalize_registry_system(system)
+        if normalized_registry_system in REGISTRY_CRAWL_SYSTEMS:
+            registry_packages.append(package_ref)
+            continue
+
+        misc_packages.append(package_ref)
+
+    return depsdev_packages, registry_packages, misc_packages
+
+
+def _build_registry_warning_purls(package_refs: list[PackageReference]) -> dict[str, set[str]]:
+    """Build grouped warning payload for registry-unsupported package references."""
+
+    grouped_purls: dict[str, set[str]] = {}
+    for package_ref in package_refs:
+        purl = package_ref.purl or _purl_for_package(package_ref.system, package_ref.name)
+        grouped_purls.setdefault(package_ref.system.upper(), set()).add(purl)
+
+    return grouped_purls
+
+
+# ---------------------------------------------------------------------------
+# Mapping file helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_git_mapping() -> dict[str, dict[str, str]]:
+    """
+    Load the project → git URL mapping YAML file.
+
+    Returns a dict mapping ``projectId`` → ``{git_owner_url, git_repo_url}``.
+    """
+    if not _MAPPING_PATH.exists():
+        return {}
+
+    with _MAPPING_PATH.open() as f:
+        data: dict[str, dict[str, str]] = yaml.safe_load(f) or {}
+
+    return data

--- a/pg_atlas/procrastinate/tasks.py
+++ b/pg_atlas/procrastinate/tasks.py
@@ -267,6 +267,10 @@ async def process_project(
     1. Upsert a ``Project`` row.
     2. If category is "Education & Community", skip GitHub/deps.dev crawling.
     3. Otherwise, list GitHub repos, call deps.dev, and defer ``crawl_github_repo``.
+
+    ``crawl_github_repo`` receives both deps.dev package payloads and repo
+    metadata so package detection can still run when deps.dev has no package
+    coverage for a repository.
     """
     logger.info(f"process_project: {display_name} ({project_canonical_id})")
 
@@ -409,6 +413,12 @@ async def crawl_github_repo(
        promote it to ``Repo`` and link it to the project.
     3. Ensure a ``Repo`` vertex ``pkg:github/owner/repo`` exists.
     4. Defer ``crawl_package_deps`` for each package.
+    5. Group detected packages by registry system and defer one
+        ``crawl_package_registry`` task per supported system.
+
+    Supported direct-registry crawl systems are intentionally limited to
+    ``DART`` and ``COMPOSER``. Other ecosystems are logged as unsupported for
+    observability.
     """
     logger.info(f"crawl_github_repo: {owner}/{repo} (project_id={project_id})")
 
@@ -573,7 +583,11 @@ async def crawl_package_registry(
 
     This task is intentionally separate from deps.dev dependency crawling.
     It fetches package signals from source registries and records per-package
-    download counts under the source repo metadata map.
+    download counts under the source repo metadata map
+    (``adoption_downloads_by_purl``).
+
+    It does not write scalar ``Repo.adoption_downloads`` directly; scalar
+    reduction is performed by adoption materialization.
     """
 
     normalized_system = normalize_registry_system(system)

--- a/pg_atlas/procrastinate/tasks.py
+++ b/pg_atlas/procrastinate/tasks.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +35,7 @@ from procrastinate.exceptions import AlreadyEnqueued
 from sqlalchemy import select
 
 from pg_atlas.config import settings
+from pg_atlas.crawlers.base import AllPackagesFailed
 from pg_atlas.crawlers.factory import build_registry_crawler, normalize_registry_system
 from pg_atlas.db_models.base import ActivityStatus, ProjectType, SubmissionStatus
 from pg_atlas.db_models.release import Release
@@ -46,11 +48,10 @@ from pg_atlas.procrastinate.app import app
 from pg_atlas.procrastinate.depsdev import (
     DepsDevError,
     DepsDevProjectInfo,
-    ProjectPackageVersion,
+    ProjectPackage,
     depsdev_session,
     get_package,
     get_project_batch,
-    get_project_package_versions,
     get_requirements,
 )
 from pg_atlas.procrastinate.github import (
@@ -277,15 +278,12 @@ async def process_project(
 
     status = ActivityStatus(activity_status)
 
-    # ----- Determine project type (preliminary; may be refined after deps.dev) -----
-    project_type = ProjectType.scf_project
-
     # ----- Education & Community: upsert project row only, skip crawling -----
     if category == "Education & Community":
         await upsert_project(
             canonical_id=project_canonical_id,
             display_name=display_name,
-            project_type=project_type,
+            project_type=ProjectType.scf_project,
             activity_status=status,
             git_owner_url=git_owner_url,
             category=category,
@@ -325,7 +323,7 @@ async def process_project(
 
                 for project_key, proj_info in depsdev_projects.items():
                     try:
-                        proj_info.package_versions = await get_project_package_versions(project_key, stub=stub)
+                        await proj_info.populate_packages(stub=stub)
                     except DepsDevError as exc:
                         logger.warning(f"GetProjectPackageVersions failed for {project_key}: {exc}")
 
@@ -333,7 +331,7 @@ async def process_project(
             logger.warning(f"GetProjectBatch failed for {project_canonical_id}: {exc}")
 
     # ----- Determine project type -----
-    has_packages = any(info.package_versions for info in depsdev_projects.values()) if depsdev_projects else False
+    has_packages = any(info.packages for info in depsdev_projects.values()) if depsdev_projects else False
     project_type = ProjectType.public_good if has_packages else ProjectType.scf_project
 
     # ----- Upsert Project row -----
@@ -353,7 +351,7 @@ async def process_project(
         depsdev_key = f"github.com/{repo_full}".lower()
         depsdev_info = depsdev_projects.get(depsdev_key)
 
-        packages: list[ProjectPackageVersion] = []
+        packages: list[ProjectPackage] = []
         adoption_stars = repo_info.stars
         adoption_forks = repo_info.forks
         # normalize datetime to UTC before DB persistence
@@ -362,7 +360,7 @@ async def process_project(
             pushed_at_utc = repo_info.pushed_at.astimezone(dt.UTC)
 
         if depsdev_info:
-            packages = depsdev_info.package_versions
+            packages = depsdev_info.packages
             adoption_stars = max(adoption_stars, depsdev_info.stars_count)
             adoption_forks = max(adoption_forks, depsdev_info.forks_count)
 
@@ -374,15 +372,7 @@ async def process_project(
             owner=repo_owner,
             repo=repo_name,
             project_id=project_id,
-            packages=[
-                {
-                    "system": pkg.system,
-                    "name": pkg.name,
-                    "version": pkg.version,
-                    "purl": pkg.purl,
-                }
-                for pkg in packages
-            ],
+            packages=[asdict(pkg) for pkg in packages],
             pushed_at_isodt=pushed_at_utc.isoformat() if pushed_at_utc is not None else None,
             adoption_stars=adoption_stars,
             adoption_forks=adoption_forks,
@@ -423,11 +413,15 @@ async def crawl_github_repo(
     """
     logger.info(f"crawl_github_repo: {owner}/{repo} (project_id={project_id})")
 
+    # ----- Proceed with Deps.dev packages, or detect published packages from repo manifests -----
     package_refs = [PackageReference.from_payload(pkg) for pkg in packages]
+    # the above comes from DepsDev and only includes systems it supports
     if not package_refs:
+        # TODO: it would be helpful to track that we are now creating a MIXED list
         package_refs = detect_packages_from_repo(owner, repo)
         logger.info(f"Detected {len(package_refs)} packages in {owner}/{repo}")
 
+    # TODO: remove after dedup in `process_project`
     # Deps.dev project package versions can include many entries per package
     # (one row per version). Collapse to unique package keys before crawling.
     unique_packages: dict[tuple[str, str], PackageReference] = {}
@@ -442,6 +436,7 @@ async def crawl_github_repo(
     packages_to_process = list(unique_packages.values())
 
     # ----- Build releases from package info -----
+    # FIXME: must not try to get packages for systems that DepsDev does not support
     releases: list[Release] = []
     async with depsdev_session() as stub:
         for pkg in packages_to_process:
@@ -497,11 +492,14 @@ async def crawl_github_repo(
     )
 
     # ----- For each package: absorb ExternalRepo if one exists -----
+    # must happen for all packages regardless of system
     for pkg in packages_to_process:
         system = pkg.system
         name = pkg.name
 
         # Build the canonical_id this package would have as a vertex.
+        # TODO: simplify when purl is provided in the PackageReference
+        # preferred solution: ensure and enforce that the purl is present on every PackageReference.
         purl_type = _purl_type_for_system(system)
         if purl_type:
             pkg_canonical_id = f"pkg:{purl_type}/{name}"
@@ -520,6 +518,7 @@ async def crawl_github_repo(
     await associate_repo_with_project(repo_canonical_id, project_id)
 
     # ----- Defer crawl_package_deps for each package -----
+    # FIXME: must be filtered for DepsDev supported systems
     for pkg in packages_to_process:
         system = pkg.system
         name = pkg.name
@@ -535,6 +534,7 @@ async def crawl_github_repo(
     registry_packages_by_system: dict[str, set[str]] = {}
     unsupported_registry_purls: dict[str, set[str]] = {}
 
+    # FIXME: this is a mess, clean up in refactor
     for pkg in packages_to_process:
         normalized_system = normalize_registry_system(pkg.system)
         if normalized_system is None:
@@ -558,6 +558,7 @@ async def crawl_github_repo(
         if enqueued:
             deferred_registry_tasks += 1
 
+    # FIXME: only warn for unsupported packages that have come from `detect_packages_from_repo`
     for system, purls in sorted(unsupported_registry_purls.items()):
         joined_purls = " ".join(sorted(purls))
         logger.warning(f"registry-crawl unsupported ecosystem: system={system} purls={joined_purls}")
@@ -622,6 +623,8 @@ async def crawl_package_registry(
         f"crawl_package_registry: system={normalized_system} packages={len(package_names)} "
         f"processed={result.packages_processed} errors={len(result.errors)}"
     )
+    if result.packages_processed == 0:
+        raise AllPackagesFailed(package_names)
 
 
 # ---------------------------------------------------------------------------

--- a/pg_atlas/procrastinate/upserts.py
+++ b/pg_atlas/procrastinate/upserts.py
@@ -34,6 +34,7 @@ from pg_atlas.db_models.base import (
 )
 from pg_atlas.db_models.depends_on import DependsOn
 from pg_atlas.db_models.project import Project
+from pg_atlas.db_models.release import Release, merge_releases
 from pg_atlas.db_models.repo_vertex import ExternalRepo, Repo, RepoVertex
 from pg_atlas.db_models.session import get_session_factory
 from pg_atlas.db_models.vertex_ops import get_vertex
@@ -140,7 +141,7 @@ async def upsert_repo(
     latest_commit_date: dt.datetime | None = None,
     adoption_stars: int | None = None,
     adoption_forks: int | None = None,
-    releases: list[dict[str, Any]] | None = None,
+    releases: list[Release] | None = None,
     repo_metadata: dict[str, Any] | None = None,
 ) -> int:
     """
@@ -161,6 +162,8 @@ async def upsert_repo(
         vertex = await get_vertex(session, canonical_id)
 
         if vertex is not None and isinstance(vertex, ExternalRepo):
+            merged_releases = merge_releases(vertex.releases, releases)
+
             repo_id = await _promote_external_to_repo(
                 session,
                 vertex_id=vertex.id,
@@ -171,7 +174,7 @@ async def upsert_repo(
                 latest_commit_date=latest_commit_date,
                 adoption_stars=adoption_stars,
                 adoption_forks=adoption_forks,
-                releases=releases,
+                releases=merged_releases,
                 repo_metadata=repo_metadata,
             )
             await session.commit()
@@ -197,9 +200,7 @@ async def upsert_repo(
             if adoption_forks is not None:
                 vertex.adoption_forks = adoption_forks
             if releases is not None:
-                # FIXME: there can be existing releases we must not overwrite
-                # we want the union of unique releases to be stored
-                vertex.releases = releases
+                vertex.releases = merge_releases(vertex.releases, releases)
             if repo_metadata is not None:
                 vertex.repo_metadata = repo_metadata
 
@@ -293,7 +294,7 @@ async def _promote_external_to_repo(
     latest_commit_date: dt.datetime | None,
     adoption_stars: int | None,
     adoption_forks: int | None,
-    releases: list[dict[str, Any]] | None,
+    releases: list[Release] | None,
     repo_metadata: dict[str, Any] | None,
 ) -> int:
     """

--- a/pg_atlas/procrastinate/upserts.py
+++ b/pg_atlas/procrastinate/upserts.py
@@ -23,7 +23,8 @@ import json
 import logging
 from typing import Any
 
-from sqlalchemy import delete, select, update
+from sqlalchemy import and_, case, delete, or_, select, update
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from pg_atlas.db_models.base import (
@@ -34,7 +35,7 @@ from pg_atlas.db_models.base import (
 )
 from pg_atlas.db_models.depends_on import DependsOn
 from pg_atlas.db_models.project import Project
-from pg_atlas.db_models.release import Release, merge_releases
+from pg_atlas.db_models.release import Release, merge_releases, sorted_releases_desc
 from pg_atlas.db_models.repo_vertex import ExternalRepo, Repo, RepoVertex
 from pg_atlas.db_models.session import get_session_factory
 from pg_atlas.db_models.vertex_ops import get_vertex
@@ -212,6 +213,7 @@ async def upsert_repo(
             return repo_id
 
         # New vertex — insert.
+        sorted_releases = sorted_releases_desc(releases or [])
         repo = Repo(
             canonical_id=canonical_id,
             display_name=display_name,
@@ -222,7 +224,7 @@ async def upsert_repo(
             latest_commit_date=latest_commit_date,
             adoption_stars=adoption_stars,
             adoption_forks=adoption_forks,
-            releases=releases,
+            releases=sorted_releases,
             repo_metadata=repo_metadata,
         )
         session.add(repo)
@@ -524,37 +526,39 @@ async def upsert_depends_on(
     confidence: EdgeConfidence = EdgeConfidence.inferred_shadow,
 ) -> bool:
     """
-    Insert a ``DependsOn`` edge if it does not already exist.
+    Insert a ``DependsOn`` edge atomically.
 
-    Only the ``version_range`` is updated on existing edges.
-    Returns ``True`` if an edge was inserted or updated.
+    On conflict, updates mutable fields while preserving stronger confidence.
+    Returns ``True`` when a row is inserted or updated, ``False`` for no-op.
     """
-    result = await session.execute(
-        select(DependsOn).where(
-            DependsOn.in_vertex_id == in_vertex_id,
-            DependsOn.out_vertex_id == out_vertex_id,
-        )
-    )
-    existing = result.scalar_one_or_none()
-
-    if existing is not None:
-        if existing.version_range != version_range:
-            existing.version_range = version_range
-            await session.flush()
-            return True
-
-        return False
-
-    edge = DependsOn(
+    stmt = insert(DependsOn).values(
         in_vertex_id=in_vertex_id,
         out_vertex_id=out_vertex_id,
         version_range=version_range,
         confidence=confidence,
     )
-    session.add(edge)
-    await session.flush()
+    upsert_stmt = stmt.on_conflict_do_update(
+        index_elements=[DependsOn.in_vertex_id, DependsOn.out_vertex_id],
+        set_={
+            "version_range": stmt.excluded.version_range,
+            "confidence": case(
+                (DependsOn.confidence == EdgeConfidence.verified_sbom, DependsOn.confidence),
+                else_=stmt.excluded.confidence,
+            ),
+        },
+        where=or_(
+            DependsOn.version_range.is_distinct_from(stmt.excluded.version_range),
+            and_(
+                DependsOn.confidence != EdgeConfidence.verified_sbom,
+                DependsOn.confidence != stmt.excluded.confidence,
+            ),
+        ),
+    )
+    result = await session.execute(upsert_stmt)
+    rowcount_obj = getattr(result, "rowcount", 0)
+    rowcount = rowcount_obj if isinstance(rowcount_obj, int) else 0
 
-    return True
+    return rowcount > 0
 
 
 # ---------------------------------------------------------------------------

--- a/pg_atlas/procrastinate/upserts.py
+++ b/pg_atlas/procrastinate/upserts.py
@@ -100,6 +100,7 @@ async def upsert_project(
             session.add(project)
         else:
             project.display_name = display_name
+            # TODO: determine project_type based on `Project.has_published_packages()`
             project.project_type = project_type
             project.activity_status = activity_status
             if git_owner_url is not None:

--- a/pg_atlas/procrastinate/upserts.py
+++ b/pg_atlas/procrastinate/upserts.py
@@ -198,7 +198,7 @@ async def upsert_repo(
                 vertex.adoption_forks = adoption_forks
             if releases is not None:
                 # FIXME: there can be existing releases we must not overwrite
-                # we want the union of unique
+                # we want the union of unique releases to be stored
                 vertex.releases = releases
             if repo_metadata is not None:
                 vertex.repo_metadata = repo_metadata

--- a/pg_atlas/procrastinate/upserts.py
+++ b/pg_atlas/procrastinate/upserts.py
@@ -197,6 +197,8 @@ async def upsert_repo(
             if adoption_forks is not None:
                 vertex.adoption_forks = adoption_forks
             if releases is not None:
+                # FIXME: there can be existing releases we must not overwrite
+                # we want the union of unique
                 vertex.releases = releases
             if repo_metadata is not None:
                 vertex.repo_metadata = repo_metadata
@@ -245,6 +247,7 @@ async def upsert_repo(
 
 
 async def upsert_external_repo(
+    session: AsyncSession,
     *,
     canonical_id: str,
     display_name: str,
@@ -258,8 +261,6 @@ async def upsert_external_repo(
     (i.e. it was promoted earlier), the existing ``Repo`` id is returned
     without modification.
     """
-    session = await _session()
-
     try:
         vertex = await _upsert_ext(
             session,
@@ -269,17 +270,11 @@ async def upsert_external_repo(
             repo_url=repo_url,
         )
         vertex_id: int = vertex.id
-        await session.commit()
-
         return vertex_id
 
-    except Exception:
-        await session.rollback()
-
+    except ValueError as exc:
+        logger.warning(exc)
         raise
-
-    finally:
-        await session.close()
 
 
 # ---------------------------------------------------------------------------
@@ -519,51 +514,45 @@ async def find_repo_by_release_purl(purl: str) -> tuple[int, str, int | None] | 
 
 
 async def upsert_depends_on(
+    session: AsyncSession,
     *,
     in_vertex_id: int,
     out_vertex_id: int,
     version_range: str | None = None,
     confidence: EdgeConfidence = EdgeConfidence.inferred_shadow,
-) -> None:
+) -> bool:
     """
     Insert a ``DependsOn`` edge if it does not already exist.
 
-    Existing edges are left unchanged (no update on conflict) because the
-    ``(in_vertex_id, out_vertex_id)`` composite PK already enforces
-    uniqueness.
+    Only the ``version_range`` is updated on existing edges.
+    Returns ``True`` if an edge was inserted or updated.
     """
-    session = await _session()
-
-    try:
-        result = await session.execute(
-            select(DependsOn).where(
-                DependsOn.in_vertex_id == in_vertex_id,
-                DependsOn.out_vertex_id == out_vertex_id,
-            )
+    result = await session.execute(
+        select(DependsOn).where(
+            DependsOn.in_vertex_id == in_vertex_id,
+            DependsOn.out_vertex_id == out_vertex_id,
         )
-        existing = result.scalar_one_or_none()
+    )
+    existing = result.scalar_one_or_none()
 
-        if existing is not None:
-            await session.close()
+    if existing is not None:
+        if existing.version_range != version_range:
+            existing.version_range = version_range
+            await session.flush()
+            return True
 
-            return
+        return False
 
-        edge = DependsOn(
-            in_vertex_id=in_vertex_id,
-            out_vertex_id=out_vertex_id,
-            version_range=version_range,
-            confidence=confidence,
-        )
-        session.add(edge)
-        await session.commit()
+    edge = DependsOn(
+        in_vertex_id=in_vertex_id,
+        out_vertex_id=out_vertex_id,
+        version_range=version_range,
+        confidence=confidence,
+    )
+    session.add(edge)
+    await session.flush()
 
-    except Exception:
-        await session.rollback()
-
-        raise
-
-    finally:
-        await session.close()
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/pg_atlas/routers/models.py
+++ b/pg_atlas/routers/models.py
@@ -24,6 +24,7 @@ from pg_atlas.db_models.base import (
     SubmissionStatus,
     Visibility,
 )
+from pg_atlas.db_models.release import Release
 
 T = TypeVar("T")
 
@@ -202,7 +203,7 @@ class RepoDetailResponse(RepoSummary):
     and active contributor stats.
     """
 
-    releases: list[dict[str, Any]] | None
+    releases: list[Release] | None
     parent_project: ProjectSummary | None
     contributors: list[ContributorSummary]
     outgoing_dep_counts: DepCounts

--- a/tests/bootstrap/test_depsdev.py
+++ b/tests/bootstrap/test_depsdev.py
@@ -20,11 +20,12 @@ from pg_atlas.procrastinate.depsdev import (
     DepsDevError,
     DepsDevPackageInfo,
     DepsDevProjectInfo,
+    ProjectPackage,
     ProjectPackageVersion,
     _extract_requirements,
+    _get_project_package_versions,
     get_package,
     get_project_batch,
-    get_project_package_versions,
     get_requirements,
     system_for_purl,
 )
@@ -56,7 +57,7 @@ def test_extract_requirements_runtime_only() -> None:
         rubygems=None,
     )
 
-    result = _extract_requirements("CARGO", reqs)
+    result = _extract_requirements("CARGO", reqs)  # pyright: ignore[reportArgumentType]
 
     assert len(result) == 1
     assert result[0].name == "serde"
@@ -136,11 +137,54 @@ async def test_get_project_package_versions_success(mocker: Any) -> None:
     response = _ns(versions=[_ns(version_key=version_key)])
     mocker.patch("pg_atlas.procrastinate.depsdev._run_with_stub", new=mocker.AsyncMock(return_value=response))
 
-    versions = await get_project_package_versions("github.com/stellarcn/py-stellar-base")
+    versions = await _get_project_package_versions("github.com/stellarcn/py-stellar-base", stub=None)
 
     assert isinstance(versions[0], ProjectPackageVersion)
     assert versions[0].system == "PYPI"
     assert versions[0].name == "stellar-sdk"
+
+
+async def test_populate_packages_deduplicates_version_rows(mocker: Any) -> None:
+    mocker.patch(
+        "pg_atlas.procrastinate.depsdev._get_project_package_versions",
+        new=mocker.AsyncMock(
+            return_value=[
+                ProjectPackageVersion(
+                    system="PYPI",
+                    name="stellar-sdk",
+                    version="11.0.0",
+                    purl="pkg:pypi/stellar-sdk@11.0.0",
+                ),
+                ProjectPackageVersion(
+                    system="PYPI",
+                    name="stellar-sdk",
+                    version="11.1.0",
+                    purl="pkg:pypi/stellar-sdk@11.1.0",
+                ),
+                ProjectPackageVersion(
+                    system="NPM",
+                    name="stellar-base",
+                    version="2.0.0",
+                    purl="pkg:npm/stellar-base@2.0.0",
+                ),
+            ]
+        ),
+    )
+
+    info = DepsDevProjectInfo(
+        project_id="github.com/org/repo",
+        stars_count=10,
+        forks_count=2,
+        license="Apache-2.0",
+        description="repo",
+    )
+
+    await info.populate_packages()
+
+    assert info.packages == [
+        ProjectPackage(system="NPM", name="stellar-base", purl="pkg:npm/stellar-base"),
+        ProjectPackage(system="PYPI", name="stellar-sdk", purl="pkg:pypi/stellar-sdk"),
+    ]
 
 
 async def test_get_requirements_not_found_grpclib(mocker: Any) -> None:

--- a/tests/bootstrap/test_github.py
+++ b/tests/bootstrap/test_github.py
@@ -1,0 +1,121 @@
+"""
+Unit tests for ``pg_atlas.procrastinate.github`` helper functions.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from pg_atlas.procrastinate import github as gh
+
+
+def _graphql_response(
+    *,
+    nodes: list[gh._ManifestGraphNode],
+    has_next_page: bool = False,
+    end_cursor: str | None = None,
+) -> gh._GraphQLResponse:
+    """Build a typed GraphQL response object for manifest discovery tests."""
+
+    page_info = gh._PageInfo(hasNextPage=has_next_page, endCursor=end_cursor)
+    manifests = gh._DependencyGraphManifestConnection(nodes=nodes, pageInfo=page_info)
+    repository = gh._RepositoryGraphPayload(dependencyGraphManifests=manifests)
+
+    return gh._GraphQLResponse(data=gh._GraphQLData(repository=repository), errors=None)
+
+
+def test_manifest_paths_from_graphql_filters_non_parseable_and_ignored_paths(monkeypatch: Any) -> None:
+    """Manifest listing should keep only parseable, non-ignored manifest files."""
+
+    response = _graphql_response(
+        nodes=[
+            gh._ManifestGraphNode(filename="apps/sdk/package.json", parseable=True, exceedsMaxSize=False),
+            gh._ManifestGraphNode(filename="apps/example/package.json", parseable=True, exceedsMaxSize=False),
+            gh._ManifestGraphNode(filename="apps/invalid/composer.json", parseable=False, exceedsMaxSize=False),
+            gh._ManifestGraphNode(filename="apps/too-big/pubspec.yaml", parseable=True, exceedsMaxSize=True),
+        ]
+    )
+
+    def _mock_graph_query(owner: str, repo_name: str, after: str | None) -> gh._GraphQLResponse:
+        del owner, repo_name, after
+        return response
+
+    monkeypatch.setattr(gh, "_run_dependency_graph_query", _mock_graph_query)
+
+    paths = gh._manifest_paths_from_graphql("test-org", "test-repo")
+
+    assert paths == ["apps/sdk/package.json"]
+
+
+def test_detect_packages_from_repo_uses_graphql_manifest_paths(monkeypatch: Any) -> None:
+    """Package detection should read manifests listed by GraphQL and parse package names."""
+
+    class _FakeGitHubClient:
+        def get_repo(self, repo_path: str) -> SimpleNamespace:
+            return SimpleNamespace(repo_path=repo_path)
+
+    monkeypatch.setattr(gh, "get_github_client", lambda: _FakeGitHubClient())
+
+    def _mock_manifest_paths(owner: str, repo_name: str) -> list[str]:
+        del owner, repo_name
+        return ["package.json"]
+
+    def _mock_read_manifest_text(repo: Any, path: str) -> str:
+        del repo, path
+        return '{"name":"pkg-name","version":"1.0.0"}'
+
+    monkeypatch.setattr(gh, "_manifest_paths_from_graphql", _mock_manifest_paths)
+    monkeypatch.setattr(gh, "_read_manifest_text", _mock_read_manifest_text)
+
+    package_refs = gh.detect_packages_from_repo("test-org", "test-repo")
+
+    assert len(package_refs) == 1
+    assert package_refs[0].system == "NPM"
+    assert package_refs[0].name == "pkg-name"
+
+
+def test_extract_package_name_npm_private_fast_path_skips_even_if_json_is_invalid() -> None:
+    """NPM manifest should be skipped quickly when private=true appears in raw JSON text."""
+
+    manifest_text = '{"name": "private-pkg", "private": true, "version": '
+
+    assert gh._extract_package_name("NPM", "package.json", manifest_text, "org", "repo") is None
+
+
+def test_extract_package_name_npm_requires_version_field() -> None:
+    """NPM package should be treated as non-published when version is absent."""
+
+    manifest_text = '{"name": "example-no-version"}'
+
+    assert gh._extract_package_name("NPM", "package.json", manifest_text, "org", "repo") is None
+
+
+def test_extract_package_name_go_handles_quotes_and_comments() -> None:
+    """Go module parser should ignore trailing comments and optional quotes."""
+
+    quoted = 'module "github.com/org/repo" // comment\n'
+    bare = "module github.com/org/repo-bare // comment\n"
+
+    assert gh._extract_package_name("GO", "go.mod", quoted, "org", "fallback") == "github.com/org/repo"
+    assert gh._extract_package_name("GO", "go.mod", bare, "org", "fallback") == "github.com/org/repo-bare"
+
+
+def test_extract_package_name_cargo_requires_package_section() -> None:
+    """Cargo parser should skip manifests missing a [package] section."""
+
+    manifest_text = "[workspace]\nmembers = ['a']\n"
+
+    assert gh._extract_package_name("CARGO", "Cargo.toml", manifest_text, "org", "repo") is None
+
+
+def test_system_from_manifest_path() -> None:
+    """Manifest system resolution should classify known manifest names."""
+
+    assert gh._system_from_manifest_path("a/b/Cargo.toml") == "CARGO"
+    assert gh._system_from_manifest_path("a/b/package.json") == "NPM"
+    assert gh._system_from_manifest_path("a/b/pubspec.yaml") == "DART"
+    assert gh._system_from_manifest_path("a/b/unknown.txt") is None

--- a/tests/bootstrap/test_tasks.py
+++ b/tests/bootstrap/test_tasks.py
@@ -31,11 +31,13 @@ from pg_atlas.procrastinate.opengrants import ScfProject
 try:
     from pg_atlas.procrastinate.tasks import (
         GitHubRepoMetadata,
+        PackageReference,
         _defer_with_lock,
         _load_git_mapping,
         _purl_type_for_system,
         crawl_github_repo,
         crawl_package_deps,
+        crawl_package_registry,
         process_gitlog_batch,
         process_project,
         sync_opengrants,
@@ -121,7 +123,7 @@ async def test_process_gitlog_batch_calls_runtime(mocker: Any) -> None:
 
 async def test_process_project_enriches_packages_from_depsdev(mocker: Any) -> None:
     mocker.patch(
-        "pg_atlas.procrastinate.tasks._list_org_repos",
+        "pg_atlas.procrastinate.tasks.list_org_repos",
         return_value=[
             GitHubRepoMetadata(
                 name="repo",
@@ -355,7 +357,7 @@ async def test_crawl_package_deps_skips_self_recursive_dep(mocker: Any) -> None:
 
 async def test_process_project_edu_community_skips_crawl(mocker: Any) -> None:
     upsert_mock = mocker.patch("pg_atlas.procrastinate.tasks.upsert_project", new=mocker.AsyncMock(return_value=42))
-    list_repos_mock = mocker.patch("pg_atlas.procrastinate.tasks._list_org_repos")
+    list_repos_mock = mocker.patch("pg_atlas.procrastinate.tasks.list_org_repos")
     crawl_mock = mocker.patch.object(crawl_github_repo, "defer_async", new=mocker.AsyncMock())
 
     await process_project(
@@ -372,3 +374,103 @@ async def test_process_project_edu_community_skips_crawl(mocker: Any) -> None:
     assert upsert_mock.call_args.kwargs["category"] == "Education & Community"
     list_repos_mock.assert_not_called()
     crawl_mock.assert_not_called()
+
+
+async def test_crawl_github_repo_defers_and_runs_registry_crawl_for_flutter(mocker: Any) -> None:
+    """Ensure Flutter package detection defers and executes DART registry crawl."""
+
+    mocker.patch(
+        "pg_atlas.procrastinate.tasks.detect_packages_from_repo",
+        return_value=[PackageReference(system="DART", name="stellar_flutter_sdk")],
+    )
+    mocker.patch("pg_atlas.procrastinate.tasks.get_package", new=mocker.AsyncMock(side_effect=DepsDevError("missing")))
+    mocker.patch("pg_atlas.procrastinate.tasks.upsert_repo", new=mocker.AsyncMock(return_value=10))
+    mocker.patch("pg_atlas.procrastinate.tasks.absorb_external_repo", new=mocker.AsyncMock(return_value=False))
+    mocker.patch("pg_atlas.procrastinate.tasks.associate_repo_with_project", new=mocker.AsyncMock())
+    mocker.patch("pg_atlas.procrastinate.tasks.get_session_factory", return_value=mocker.Mock())
+
+    fake_result = mocker.Mock(packages_processed=1, errors=[])
+    fake_crawler = mocker.Mock()
+    fake_crawler.crawl_and_persist = mocker.AsyncMock(return_value=fake_result)
+    build_crawler_mock = mocker.patch("pg_atlas.procrastinate.tasks.build_registry_crawler", return_value=fake_crawler)
+
+    async def _defer_side_effect(task: Any, queueing_lock: str, **kwargs: Any) -> bool:
+        if task is crawl_package_registry:
+            await crawl_package_registry(**kwargs)
+
+        return True
+
+    defer_mock = mocker.patch(
+        "pg_atlas.procrastinate.tasks._defer_with_lock",
+        new=mocker.AsyncMock(side_effect=_defer_side_effect),
+    )
+
+    await crawl_github_repo(
+        owner="Soneso",
+        repo="stellar_flutter_sdk",
+        project_id=1,
+        packages=[],
+        adoption_stars=123,
+        adoption_forks=44,
+    )
+
+    registry_defer_calls = [call for call in defer_mock.call_args_list if call.args[0] is crawl_package_registry]
+    assert len(registry_defer_calls) == 1
+    assert registry_defer_calls[0].kwargs["system"] == "DART"
+    assert registry_defer_calls[0].kwargs["package_names"] == ["stellar_flutter_sdk"]
+
+    build_crawler_mock.assert_called_once()
+    fake_crawler.crawl_and_persist.assert_awaited_once_with(
+        package_names=["stellar_flutter_sdk"],
+        source_repo_canonical_id="pkg:github/Soneso/stellar_flutter_sdk",
+    )
+
+
+async def test_crawl_github_repo_defers_and_runs_registry_crawl_for_php(mocker: Any) -> None:
+    """Ensure Composer package detection defers and executes COMPOSER registry crawl."""
+
+    mocker.patch(
+        "pg_atlas.procrastinate.tasks.detect_packages_from_repo",
+        return_value=[PackageReference(system="COMPOSER", name="soneso/stellar-php-sdk")],
+    )
+    mocker.patch("pg_atlas.procrastinate.tasks.get_package", new=mocker.AsyncMock(side_effect=DepsDevError("missing")))
+    mocker.patch("pg_atlas.procrastinate.tasks.upsert_repo", new=mocker.AsyncMock(return_value=10))
+    mocker.patch("pg_atlas.procrastinate.tasks.absorb_external_repo", new=mocker.AsyncMock(return_value=False))
+    mocker.patch("pg_atlas.procrastinate.tasks.associate_repo_with_project", new=mocker.AsyncMock())
+    mocker.patch("pg_atlas.procrastinate.tasks.get_session_factory", return_value=mocker.Mock())
+
+    fake_result = mocker.Mock(packages_processed=1, errors=[])
+    fake_crawler = mocker.Mock()
+    fake_crawler.crawl_and_persist = mocker.AsyncMock(return_value=fake_result)
+    build_crawler_mock = mocker.patch("pg_atlas.procrastinate.tasks.build_registry_crawler", return_value=fake_crawler)
+
+    async def _defer_side_effect(task: Any, queueing_lock: str, **kwargs: Any) -> bool:
+        if task is crawl_package_registry:
+            await crawl_package_registry(**kwargs)
+
+        return True
+
+    defer_mock = mocker.patch(
+        "pg_atlas.procrastinate.tasks._defer_with_lock",
+        new=mocker.AsyncMock(side_effect=_defer_side_effect),
+    )
+
+    await crawl_github_repo(
+        owner="Soneso",
+        repo="stellar-php-sdk",
+        project_id=1,
+        packages=[],
+        adoption_stars=123,
+        adoption_forks=44,
+    )
+
+    registry_defer_calls = [call for call in defer_mock.call_args_list if call.args[0] is crawl_package_registry]
+    assert len(registry_defer_calls) == 1
+    assert registry_defer_calls[0].kwargs["system"] == "COMPOSER"
+    assert registry_defer_calls[0].kwargs["package_names"] == ["soneso/stellar-php-sdk"]
+
+    build_crawler_mock.assert_called_once()
+    fake_crawler.crawl_and_persist.assert_awaited_once_with(
+        package_names=["soneso/stellar-php-sdk"],
+        source_repo_canonical_id="pkg:github/Soneso/stellar-php-sdk",
+    )

--- a/tests/bootstrap/test_tasks.py
+++ b/tests/bootstrap/test_tasks.py
@@ -1,5 +1,4 @@
 """
-
 Unit tests for ``pg_atlas.procrastinate.tasks``.
 
 These tests avoid network/database I/O via pytest-native mocking
@@ -12,6 +11,7 @@ SPDX-License-Identifier: MPL-2.0
 from __future__ import annotations
 
 import datetime as dt
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -20,11 +20,8 @@ from procrastinate.exceptions import AlreadyEnqueued
 from pg_atlas.db_models.base import ActivityStatus, ProjectType
 from pg_atlas.procrastinate.depsdev import (
     DepsDevError,
-    DepsDevPackageInfo,
-    DepsDevProjectInfo,
     DepsDevRequirement,
-    DepsDevVersionInfo,
-    ProjectPackageVersion,
+    ProjectPackage,
 )
 from pg_atlas.procrastinate.opengrants import ScfProject
 
@@ -32,12 +29,12 @@ try:
     from pg_atlas.procrastinate.tasks import (
         GitHubRepoMetadata,
         PackageReference,
-        _defer_with_lock,
         _load_git_mapping,
         _purl_type_for_system,
         crawl_github_repo,
         crawl_package_deps,
         crawl_package_registry,
+        defer_with_lock,
         process_gitlog_batch,
         process_project,
         sync_opengrants,
@@ -49,6 +46,18 @@ except ValueError:
 class _FakeConfiguredTask:
     def __init__(self, mocker: Any) -> None:
         self.defer_async = mocker.AsyncMock()
+
+
+def _depsdev_package_info(default_version: str, versions: list[SimpleNamespace]) -> SimpleNamespace:
+    """Build a minimal deps.dev package info stub for task tests."""
+
+    return SimpleNamespace(
+        system="PYPI",
+        name="stellar-sdk",
+        purl="pkg:pypi/stellar-sdk",
+        default_version=default_version,
+        versions=versions,
+    )
 
 
 def test_purl_type_for_system() -> None:
@@ -68,7 +77,7 @@ async def test_defer_with_lock_handles_already_enqueued(mocker: Any) -> None:
     configured.defer_async.side_effect = AlreadyEnqueued("Job cannot be enqueued")
     task.configure.return_value = configured
 
-    ok = await _defer_with_lock(task, queueing_lock="PYPI:foo", system="PYPI", package_name="foo")
+    ok = await defer_with_lock(task, queueing_lock="PYPI:foo", system="PYPI", package_name="foo")
 
     assert ok is False
 
@@ -122,6 +131,15 @@ async def test_process_gitlog_batch_calls_runtime(mocker: Any) -> None:
 
 
 async def test_process_project_enriches_packages_from_depsdev(mocker: Any) -> None:
+    depsdev_info = SimpleNamespace(
+        project_id="github.com/org/repo",
+        stars_count=10,
+        forks_count=3,
+        license="Apache-2.0",
+        description="repo",
+        packages=[ProjectPackage(system="PYPI", name="stellar-sdk", purl="pkg:pypi/stellar-sdk")],
+    )
+    depsdev_info.populate_packages = mocker.AsyncMock()
     mocker.patch(
         "pg_atlas.procrastinate.tasks.list_org_repos",
         return_value=[
@@ -142,28 +160,8 @@ async def test_process_project_enriches_packages_from_depsdev(mocker: Any) -> No
         "pg_atlas.procrastinate.tasks.get_project_batch",
         new=mocker.AsyncMock(
             return_value={
-                "github.com/org/repo": DepsDevProjectInfo(
-                    project_id="github.com/org/repo",
-                    stars_count=10,
-                    forks_count=3,
-                    license="Apache-2.0",
-                    description="repo",
-                    package_versions=[],
-                )
+                "github.com/org/repo": depsdev_info,
             }
-        ),
-    )
-    mocker.patch(
-        "pg_atlas.procrastinate.tasks.get_project_package_versions",
-        new=mocker.AsyncMock(
-            return_value=[
-                ProjectPackageVersion(
-                    system="PYPI",
-                    name="stellar-sdk",
-                    version="11.1.0",
-                    purl="pkg:pypi/stellar-sdk@11.1.0",
-                )
-            ]
         ),
     )
     upsert_project_mock = mocker.patch("pg_atlas.procrastinate.tasks.upsert_project", new=mocker.AsyncMock(return_value=101))
@@ -185,8 +183,7 @@ async def test_process_project_enriches_packages_from_depsdev(mocker: Any) -> No
         {
             "system": "PYPI",
             "name": "stellar-sdk",
-            "version": "11.1.0",
-            "purl": "pkg:pypi/stellar-sdk@11.1.0",
+            "purl": "pkg:pypi/stellar-sdk",
         }
     ]
 
@@ -195,17 +192,13 @@ async def test_crawl_github_repo_defers_package_deps(mocker: Any) -> None:
     mocker.patch(
         "pg_atlas.procrastinate.tasks.get_package",
         new=mocker.AsyncMock(
-            return_value=DepsDevPackageInfo(
-                system="PYPI",
-                name="stellar-sdk",
-                purl="pkg:pypi/stellar-sdk",
-                default_version="11.1.0",
+            return_value=_depsdev_package_info(
+                "11.1.0",
                 versions=[
-                    DepsDevVersionInfo(
+                    SimpleNamespace(
                         version="11.1.0",
                         purl="pkg:pypi/stellar-sdk@11.1.0",
                         published_at=None,
-                        is_default=True,
                     )
                 ],
             )
@@ -214,7 +207,7 @@ async def test_crawl_github_repo_defers_package_deps(mocker: Any) -> None:
     mocker.patch("pg_atlas.procrastinate.tasks.upsert_repo", new=mocker.AsyncMock(return_value=10))
     mocker.patch("pg_atlas.procrastinate.tasks.absorb_external_repo", new=mocker.AsyncMock(return_value=False))
     mocker.patch("pg_atlas.procrastinate.tasks.associate_repo_with_project", new=mocker.AsyncMock())
-    defer_mock = mocker.patch("pg_atlas.procrastinate.tasks._defer_with_lock", new=mocker.AsyncMock(return_value=True))
+    defer_mock = mocker.patch("pg_atlas.procrastinate.tasks.defer_with_lock", new=mocker.AsyncMock(return_value=True))
 
     await crawl_github_repo(
         owner="StellarCN",
@@ -228,31 +221,23 @@ async def test_crawl_github_repo_defers_package_deps(mocker: Any) -> None:
     assert defer_mock.call_count == 1
 
 
-async def test_crawl_github_repo_deduplicates_same_package(mocker: Any) -> None:
+async def test_crawl_github_repo_processes_all_depsdev_package_refs(mocker: Any) -> None:
     mocker.patch(
         "pg_atlas.procrastinate.tasks.get_package",
-        new=mocker.AsyncMock(
-            return_value=DepsDevPackageInfo(
-                system="PYPI",
-                name="stellar-sdk",
-                purl="pkg:pypi/stellar-sdk",
-                default_version="11.1.0",
-                versions=[],
-            )
-        ),
+        new=mocker.AsyncMock(return_value=_depsdev_package_info("11.1.0", versions=[])),
     )
     upsert_repo_mock = mocker.patch("pg_atlas.procrastinate.tasks.upsert_repo", new=mocker.AsyncMock(return_value=10))
     absorb_mock = mocker.patch("pg_atlas.procrastinate.tasks.absorb_external_repo", new=mocker.AsyncMock(return_value=False))
     mocker.patch("pg_atlas.procrastinate.tasks.associate_repo_with_project", new=mocker.AsyncMock())
-    defer_mock = mocker.patch("pg_atlas.procrastinate.tasks._defer_with_lock", new=mocker.AsyncMock(return_value=True))
+    defer_mock = mocker.patch("pg_atlas.procrastinate.tasks.defer_with_lock", new=mocker.AsyncMock(return_value=True))
 
     await crawl_github_repo(
         owner="StellarCN",
         repo="py-stellar-base",
         project_id=1,
         packages=[
-            {"system": "PYPI", "name": "stellar-sdk", "version": "1.0.0"},
-            {"system": "PYPI", "name": "stellar-sdk", "version": "1.1.0"},
+            {"system": "PYPI", "name": "stellar-sdk", "purl": "pkg:pypi/stellar-sdk"},
+            {"system": "PYPI", "name": "stellar-sdk", "purl": "pkg:pypi/stellar-sdk"},
         ],
         adoption_stars=123,
         adoption_forks=44,
@@ -260,22 +245,14 @@ async def test_crawl_github_repo_deduplicates_same_package(mocker: Any) -> None:
 
     # 1 upsert for github repo; per-package loop calls absorb, not upsert_repo.
     assert upsert_repo_mock.call_count == 1
-    assert absorb_mock.call_count == 1
-    assert defer_mock.call_count == 1
+    assert absorb_mock.call_count == 2
+    assert defer_mock.call_count == 2
 
 
 async def test_crawl_package_deps_uses_source_repo_canonical_id(mocker: Any) -> None:
     mocker.patch(
         "pg_atlas.procrastinate.tasks.get_package",
-        new=mocker.AsyncMock(
-            return_value=DepsDevPackageInfo(
-                system="PYPI",
-                name="stellar-sdk",
-                purl="pkg:pypi/stellar-sdk",
-                default_version="1.0.0",
-                versions=[],
-            )
-        ),
+        new=mocker.AsyncMock(return_value=_depsdev_package_info("1.0.0", versions=[])),
     )
     mocker.patch(
         "pg_atlas.procrastinate.tasks.get_requirements",
@@ -316,7 +293,7 @@ async def test_crawl_package_deps_skips_self_recursive_dep(mocker: Any) -> None:
     mocker.patch(
         "pg_atlas.procrastinate.tasks.get_package",
         new=mocker.AsyncMock(
-            return_value=DepsDevPackageInfo(
+            return_value=SimpleNamespace(
                 system="PYPI",
                 name="py-evm",
                 purl="pkg:pypi/py-evm",
@@ -335,7 +312,7 @@ async def test_crawl_package_deps_skips_self_recursive_dep(mocker: Any) -> None:
     )
     upsert_ext_mock = mocker.patch("pg_atlas.procrastinate.tasks.upsert_external_repo", new=mocker.AsyncMock(return_value=200))
     edge_mock = mocker.patch("pg_atlas.procrastinate.tasks.upsert_depends_on", new=mocker.AsyncMock())
-    defer_mock = mocker.patch("pg_atlas.procrastinate.tasks._defer_with_lock", new=mocker.AsyncMock(return_value=True))
+    defer_mock = mocker.patch("pg_atlas.procrastinate.tasks.defer_with_lock", new=mocker.AsyncMock(return_value=True))
 
     session = mocker.AsyncMock()
     execute_result = mocker.Mock()
@@ -401,7 +378,7 @@ async def test_crawl_github_repo_defers_and_runs_registry_crawl_for_flutter(mock
         return True
 
     defer_mock = mocker.patch(
-        "pg_atlas.procrastinate.tasks._defer_with_lock",
+        "pg_atlas.procrastinate.tasks.defer_with_lock",
         new=mocker.AsyncMock(side_effect=_defer_side_effect),
     )
 
@@ -448,7 +425,7 @@ async def test_crawl_github_repo_defers_and_runs_registry_crawl_for_php(mocker: 
         return True
 
     defer_mock = mocker.patch(
-        "pg_atlas.procrastinate.tasks._defer_with_lock",
+        "pg_atlas.procrastinate.tasks.defer_with_lock",
         new=mocker.AsyncMock(side_effect=_defer_side_effect),
     )
 

--- a/tests/bootstrap/test_tasks.py
+++ b/tests/bootstrap/test_tasks.py
@@ -420,10 +420,7 @@ async def test_crawl_github_repo_defers_and_runs_registry_crawl_for_flutter(mock
     assert registry_defer_calls[0].kwargs["package_names"] == ["stellar_flutter_sdk"]
 
     build_crawler_mock.assert_called_once()
-    fake_crawler.crawl_and_persist.assert_awaited_once_with(
-        package_names=["stellar_flutter_sdk"],
-        source_repo_canonical_id="pkg:github/Soneso/stellar_flutter_sdk",
-    )
+    fake_crawler.crawl_and_persist.assert_awaited_once_with(package_names=["stellar_flutter_sdk"])
 
 
 async def test_crawl_github_repo_defers_and_runs_registry_crawl_for_php(mocker: Any) -> None:
@@ -470,7 +467,4 @@ async def test_crawl_github_repo_defers_and_runs_registry_crawl_for_php(mocker: 
     assert registry_defer_calls[0].kwargs["package_names"] == ["soneso/stellar-php-sdk"]
 
     build_crawler_mock.assert_called_once()
-    fake_crawler.crawl_and_persist.assert_awaited_once_with(
-        package_names=["soneso/stellar-php-sdk"],
-        source_repo_canonical_id="pkg:github/Soneso/stellar-php-sdk",
-    )
+    fake_crawler.crawl_and_persist.assert_awaited_once_with(package_names=["soneso/stellar-php-sdk"])

--- a/tests/bootstrap/test_upserts.py
+++ b/tests/bootstrap/test_upserts.py
@@ -22,7 +22,7 @@ from pg_atlas.db_models.base import EdgeConfidence, Visibility
 from pg_atlas.db_models.depends_on import DependsOn
 from pg_atlas.db_models.release import Release
 from pg_atlas.db_models.repo_vertex import ExternalRepo, Repo, RepoVertex
-from pg_atlas.procrastinate.upserts import absorb_external_repo, find_repo_by_release_purl
+from pg_atlas.procrastinate.upserts import absorb_external_repo, find_repo_by_release_purl, upsert_depends_on
 from tests.conftest import get_test_database_url
 from tests.db_cleanup import SBOM_DB_TABLE_SPECS, capture_snapshot, cleanup_created_rows
 
@@ -279,7 +279,121 @@ async def test_upsert_repo_union_merges_releases(
     await session.reset()
     repo = (await session.execute(select(Repo).where(Repo.id == repo_id))).scalar_one()
     assert repo.releases is not None
-    assert {(release.purl, release.version) for release in repo.releases} == {
-        ("pkg:pub/release-merge", "1.0.0"),
-        ("pkg:pub/release-merge", "1.1.0"),
-    }
+    assert [release.version for release in repo.releases] == ["1.1.0", "1.0.0"]
+
+
+@pytest.mark.skipif(not _DB_AVAILABLE, reason="No database configured")
+async def test_upsert_depends_on_insert_update_and_noop(
+    upsert_test_env: tuple[async_sessionmaker[AsyncSession], AsyncSession],
+) -> None:
+    factory, session = upsert_test_env
+    del factory
+
+    source = ExternalRepo(
+        canonical_id="pkg:npm/upsert-source",
+        display_name="source",
+        latest_version="1.0.0",
+    )
+    target = ExternalRepo(
+        canonical_id="pkg:npm/upsert-target",
+        display_name="target",
+        latest_version="1.0.0",
+    )
+    session.add_all([source, target])
+    await session.flush()
+
+    inserted = await upsert_depends_on(
+        session=session,
+        in_vertex_id=source.id,
+        out_vertex_id=target.id,
+        version_range="^1.0",
+        confidence=EdgeConfidence.inferred_shadow,
+    )
+    await session.flush()
+
+    updated = await upsert_depends_on(
+        session=session,
+        in_vertex_id=source.id,
+        out_vertex_id=target.id,
+        version_range="^2.0",
+        confidence=EdgeConfidence.inferred_shadow,
+    )
+    await session.flush()
+
+    noop = await upsert_depends_on(
+        session=session,
+        in_vertex_id=source.id,
+        out_vertex_id=target.id,
+        version_range="^2.0",
+        confidence=EdgeConfidence.inferred_shadow,
+    )
+
+    await session.commit()
+    await session.refresh(source)
+    await session.refresh(target)
+
+    edge = (
+        await session.execute(
+            select(DependsOn).where(
+                DependsOn.in_vertex_id == source.id,
+                DependsOn.out_vertex_id == target.id,
+            )
+        )
+    ).scalar_one()
+
+    assert inserted is True
+    assert updated is True
+    assert noop is False
+    assert edge.version_range == "^2.0"
+
+
+@pytest.mark.skipif(not _DB_AVAILABLE, reason="No database configured")
+async def test_upsert_depends_on_preserves_verified_confidence(
+    upsert_test_env: tuple[async_sessionmaker[AsyncSession], AsyncSession],
+) -> None:
+    factory, session = upsert_test_env
+    del factory
+
+    source = ExternalRepo(
+        canonical_id="pkg:npm/upsert-source-verified",
+        display_name="source",
+        latest_version="1.0.0",
+    )
+    target = ExternalRepo(
+        canonical_id="pkg:npm/upsert-target-verified",
+        display_name="target",
+        latest_version="1.0.0",
+    )
+    session.add_all([source, target])
+    await session.flush()
+
+    await upsert_depends_on(
+        session=session,
+        in_vertex_id=source.id,
+        out_vertex_id=target.id,
+        version_range="^1.0",
+        confidence=EdgeConfidence.verified_sbom,
+    )
+    await session.flush()
+
+    changed = await upsert_depends_on(
+        session=session,
+        in_vertex_id=source.id,
+        out_vertex_id=target.id,
+        version_range="^2.0",
+        confidence=EdgeConfidence.inferred_shadow,
+    )
+    await session.commit()
+
+    edge = (
+        await session.execute(
+            select(DependsOn).where(
+                DependsOn.in_vertex_id == source.id,
+                DependsOn.out_vertex_id == target.id,
+            )
+        )
+    ).scalar_one()
+
+    assert changed is True
+    assert edge.version_range == "^2.0"
+    assert edge.confidence == EdgeConfidence.verified_sbom

--- a/tests/bootstrap/test_upserts.py
+++ b/tests/bootstrap/test_upserts.py
@@ -20,6 +20,7 @@ from sqlalchemy.pool import NullPool
 
 from pg_atlas.db_models.base import EdgeConfidence, Visibility
 from pg_atlas.db_models.depends_on import DependsOn
+from pg_atlas.db_models.release import Release
 from pg_atlas.db_models.repo_vertex import ExternalRepo, Repo, RepoVertex
 from pg_atlas.procrastinate.upserts import absorb_external_repo, find_repo_by_release_purl
 from tests.conftest import get_test_database_url
@@ -219,8 +220,8 @@ async def test_find_repo_by_release_purl_found(
         visibility=Visibility.public,
         latest_version="1.0.0",
         releases=[
-            {"version": "1.0.0", "purl": "pkg:cargo/test-find-pkg-unique"},
-            {"version": "0.9.0", "purl": "pkg:cargo/test-find-pkg-unique"},
+            Release(version="1.0.0", release_date="", purl="pkg:cargo/test-find-pkg-unique"),
+            Release(version="0.9.0", release_date="", purl="pkg:cargo/test-find-pkg-unique"),
         ],
     )
     session.add(repo)
@@ -248,3 +249,37 @@ async def test_find_repo_by_release_purl_not_found(
         result = await find_repo_by_release_purl("pkg:npm/nonexistent-ever-zz")
 
     assert result is None
+
+
+@pytest.mark.skipif(not _DB_AVAILABLE, reason="No database configured")
+async def test_upsert_repo_union_merges_releases(
+    upsert_test_env: tuple[async_sessionmaker[AsyncSession], AsyncSession],
+) -> None:
+    """upsert_repo must union-merge releases instead of overwriting existing rows."""
+
+    from pg_atlas.procrastinate.upserts import upsert_repo
+
+    factory, session = upsert_test_env
+
+    with patch("pg_atlas.procrastinate.upserts.get_session_factory", return_value=factory):
+        repo_id = await upsert_repo(
+            canonical_id="pkg:github/test-org/release-merge",
+            display_name="release-merge",
+            latest_version="1.0.0",
+            releases=[Release(version="1.0.0", release_date="2025-01-01T00:00:00Z", purl="pkg:pub/release-merge")],
+        )
+
+        await upsert_repo(
+            canonical_id="pkg:github/test-org/release-merge",
+            display_name="release-merge",
+            latest_version="1.1.0",
+            releases=[Release(version="1.1.0", release_date="2025-02-01T00:00:00Z", purl="pkg:pub/release-merge")],
+        )
+
+    await session.reset()
+    repo = (await session.execute(select(Repo).where(Repo.id == repo_id))).scalar_one()
+    assert repo.releases is not None
+    assert {(release.purl, release.version) for release in repo.releases} == {
+        ("pkg:pub/release-merge", "1.0.0"),
+        ("pkg:pub/release-merge", "1.1.0"),
+    }

--- a/tests/crawlers/test_db_integration.py
+++ b/tests/crawlers/test_db_integration.py
@@ -121,7 +121,7 @@ def _make_package(
         display_name=display_name,
         latest_version=latest_version,
         repo_url=repo_url,
-        downloads=downloads,
+        downloads_30d=downloads,
         stars=stars,
         metadata={},
         dependencies=dependencies or [],

--- a/tests/crawlers/test_db_integration.py
+++ b/tests/crawlers/test_db_integration.py
@@ -137,6 +137,7 @@ def _make_package(
         stars=None,
         metadata={},
         dependencies=dependencies or [],
+        releases=[],
     )
 
 
@@ -189,6 +190,8 @@ async def test_crawl_writes_downloads_to_source_repo_metadata(
         metadata = repo.repo_metadata or {}
         downloads_by_purl = metadata.get("adoption_downloads_by_purl")
         assert downloads_by_purl == {package_canonical_id: 500}
+        assert repo.releases is not None
+        assert {(release.purl, release.version) for release in repo.releases} == {(package_canonical_id, "1.0.0")}
 
 
 async def test_crawl_creates_forward_dependency_edges_from_source_repo(

--- a/tests/crawlers/test_db_integration.py
+++ b/tests/crawlers/test_db_integration.py
@@ -1,12 +1,15 @@
 """
 Database integration tests for the registry crawler write path.
 
-Tests the critical DB logic: vertex upsert, edge confidence preservation,
-adoption column gating on Repo vs ExternalRepo, idempotency, and edge direction.
+These tests validate the refactored crawler contract:
+- package crawls resolve to an existing source Repo
+- dependency edges are anchored on that source Repo
+- download counts are written only to repo metadata
+  (adoption_downloads_by_purl), not scalar adoption columns
 
 These tests require a running PostgreSQL instance configured via
 ``PG_ATLAS_DATABASE_URL``. They are skipped automatically when the variable
-is not set (e.g. in CI without a database service).
+is not set.
 
 SPDX-FileCopyrightText: 2026 PG Atlas contributors
 SPDX-License-Identifier: MPL-2.0
@@ -36,24 +39,16 @@ from pg_atlas.db_models.repo_vertex import ExternalRepo, Repo, RepoVertex
 from tests.conftest import get_test_database_url
 from tests.db_cleanup import SBOM_DB_TABLE_SPECS, capture_snapshot, cleanup_created_rows
 
-# ---------------------------------------------------------------------------
-# Skip when no DB configured
-# ---------------------------------------------------------------------------
-
 pytestmark = pytest.mark.skipif(
     not get_test_database_url(),
     reason="PG_ATLAS_DATABASE_URL / PG_ATLAS_TEST_DATABASE_URL not set; skipping database integration tests",
 )
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture
 async def db_engine() -> AsyncGenerator[Any, None]:
     """Create a fresh async engine with NullPool for test isolation."""
+
     database_url = get_test_database_url()
     assert database_url is not None
     engine = create_async_engine(database_url, poolclass=NullPool)
@@ -64,14 +59,14 @@ async def db_engine() -> AsyncGenerator[Any, None]:
 @pytest.fixture
 async def db_session_factory(db_engine: Any) -> async_sessionmaker[AsyncSession]:
     """Session factory for crawler tests."""
+
     return async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
 
 
 @pytest.fixture(autouse=True)
 async def clean_tables(db_session_factory: async_sessionmaker[AsyncSession]) -> AsyncGenerator[None, None]:
-    """
-    Remove only rows created by each crawler DB integration test.
-    """
+    """Remove only rows created by each crawler DB integration test."""
+
     async with db_session_factory() as session:
         snapshot = await capture_snapshot(session, SBOM_DB_TABLE_SPECS)
 
@@ -81,13 +76,8 @@ async def clean_tables(db_session_factory: async_sessionmaker[AsyncSession]) -> 
         await cleanup_created_rows(session, SBOM_DB_TABLE_SPECS, snapshot)
 
 
-# ---------------------------------------------------------------------------
-# Stub crawler for integration tests
-# ---------------------------------------------------------------------------
-
-
 class IntegrationStubCrawler(RegistryCrawler):
-    """Concrete crawler that returns pre-configured data for integration tests."""
+    """Concrete crawler returning pre-configured data for integration tests."""
 
     def __init__(
         self,
@@ -107,378 +97,383 @@ class IntegrationStubCrawler(RegistryCrawler):
         return self._dependents.get(package_name, [])
 
 
+async def _seed_source_repo(
+    session: AsyncSession,
+    *,
+    canonical_id: str,
+    repo_url: str,
+    display_name: str,
+) -> Repo:
+    """Create one source Repo row used as crawl anchor."""
+
+    repo = Repo(
+        canonical_id=canonical_id,
+        display_name=display_name,
+        visibility=Visibility.public,
+        latest_version="1.0.0",
+        repo_url=repo_url,
+    )
+    session.add(repo)
+    await session.flush()
+
+    return repo
+
+
 def _make_package(
-    canonical_id: str = "pkg:pub/test_pkg",
-    display_name: str = "test_pkg",
-    latest_version: str = "1.0.0",
-    repo_url: str | None = None,
-    downloads: int | None = 100,
-    stars: int | None = 5,
+    canonical_id: str,
+    display_name: str,
+    repo_url: str,
+    downloads_30d: int | None = 100,
     dependencies: list[CrawledDependency] | None = None,
 ) -> CrawledPackage:
+    """Build a CrawledPackage for DB integration tests."""
+
     return CrawledPackage(
         canonical_id=canonical_id,
         display_name=display_name,
-        latest_version=latest_version,
+        latest_version="1.0.0",
         repo_url=repo_url,
-        downloads_30d=downloads,
-        stars=stars,
+        downloads_30d=downloads_30d,
+        stars=None,
         metadata={},
         dependencies=dependencies or [],
     )
 
 
 def _unique_suffix() -> str:
-    """Return a short unique suffix to avoid collisions with pre-existing DB rows."""
+    """Return a short unique suffix to avoid collisions with pre-existing rows."""
 
     return uuid.uuid4().hex[:8]
 
 
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
-
-
-async def test_crawl_creates_external_repo_vertex(
+async def test_crawl_writes_downloads_to_source_repo_metadata(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """Crawling a new package creates an ExternalRepo vertex."""
-    pkg = _make_package(canonical_id="pkg:pub/new_pkg", display_name="new_pkg")
-    crawler = IntegrationStubCrawler(
-        session_factory=db_session_factory,
-        packages={"new_pkg": pkg},
-    )
-    result = await crawler.crawl_and_persist(["new_pkg"])
+    """Crawler should write download counts into source repo metadata map only."""
 
-    assert result.packages_processed == 1
-    assert result.vertices_upserted >= 1
+    suffix = _unique_suffix()
+    source_repo_url = f"https://github.com/test-org/source-repo-{suffix}"
+    source_repo_canonical_id = f"pkg:github/test-org/source-repo-{suffix}"
+    package_canonical_id = f"pkg:pub/my-sdk-{suffix}"
 
     async with db_session_factory() as session:
-        vertex = (
-            await session.execute(select(ExternalRepo).where(ExternalRepo.canonical_id == "pkg:pub/new_pkg"))
-        ).scalar_one()
-        assert vertex.display_name == "new_pkg"
-
-
-async def test_crawl_updates_existing_repo_adoption(
-    db_session_factory: async_sessionmaker[AsyncSession],
-) -> None:
-    """Adoption columns are updated when vertex is a Repo (not ExternalRepo)."""
-    # Pre-create a Repo (as SBOM ingestion would)
-    async with db_session_factory() as session:
-        repo = Repo(
-            canonical_id="pkg:pub/my_sdk",
-            display_name="my_sdk",
-            visibility=Visibility.public,
-            latest_version="1.0.0",
+        await _seed_source_repo(
+            session,
+            canonical_id=source_repo_canonical_id,
+            repo_url=source_repo_url,
+            display_name=f"source-repo-{suffix}",
         )
-        session.add(repo)
         await session.commit()
 
-    pkg = _make_package(
-        canonical_id="pkg:pub/my_sdk",
-        display_name="my_sdk",
-        downloads=500,
-        stars=20,
-    )
     crawler = IntegrationStubCrawler(
         session_factory=db_session_factory,
-        packages={"my_sdk": pkg},
+        packages={
+            "my_sdk": _make_package(
+                canonical_id=package_canonical_id,
+                display_name=f"my_sdk_{suffix}",
+                repo_url=f"{source_repo_url}.git",
+                downloads_30d=500,
+            )
+        },
     )
-    await crawler.crawl_and_persist(["my_sdk"])
+
+    result = await crawler.crawl_and_persist(["my_sdk"])
+
+    assert result.packages_processed == 1
+    assert result.errors == []
 
     async with db_session_factory() as session:
-        repo = (await session.execute(select(Repo).where(Repo.canonical_id == "pkg:pub/my_sdk"))).scalar_one()
-        assert repo.adoption_downloads == 500
-        assert repo.adoption_stars == 20
+        repo = (await session.execute(select(Repo).where(Repo.canonical_id == source_repo_canonical_id))).scalar_one()
+        assert repo.adoption_downloads is None
+        assert isinstance(repo.repo_metadata, dict)
+        metadata = repo.repo_metadata or {}
+        downloads_by_purl = metadata.get("adoption_downloads_by_purl")
+        assert downloads_by_purl == {package_canonical_id: 500}
 
 
-async def test_crawl_skips_adoption_on_external_repo(
+async def test_crawl_creates_forward_dependency_edges_from_source_repo(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """No AttributeError when crawling produces an ExternalRepo (no adoption columns)."""
-    pkg = _make_package(canonical_id="pkg:pub/ext_pkg", display_name="ext_pkg", downloads=100, stars=5)
+    """Forward dependencies should create edges from source Repo to dependency vertices."""
+
+    suffix = _unique_suffix()
+    source_repo_url = f"https://github.com/test-org/forward-repo-{suffix}"
+    source_repo_canonical_id = f"pkg:github/test-org/forward-repo-{suffix}"
+    dep_canonical_id = f"pkg:pub/dep-a-{suffix}"
+
+    async with db_session_factory() as session:
+        source_repo = await _seed_source_repo(
+            session,
+            canonical_id=source_repo_canonical_id,
+            repo_url=source_repo_url,
+            display_name=f"forward-repo-{suffix}",
+        )
+        await session.commit()
+
+    dep = CrawledDependency(canonical_id=dep_canonical_id, display_name=f"dep_a_{suffix}", version_range="^1.0")
     crawler = IntegrationStubCrawler(
         session_factory=db_session_factory,
-        packages={"ext_pkg": pkg},
+        packages={
+            "main_pkg": _make_package(
+                canonical_id=f"pkg:pub/main-pkg-{suffix}",
+                display_name=f"main_pkg_{suffix}",
+                repo_url=source_repo_url,
+                dependencies=[dep],
+            )
+        },
     )
-    # This should NOT raise AttributeError
-    result = await crawler.crawl_and_persist(["ext_pkg"])
-    assert result.packages_processed == 1
 
-
-async def test_crawl_creates_depends_on_edges(
-    db_session_factory: async_sessionmaker[AsyncSession],
-) -> None:
-    """Forward dependency edges are created with correct direction."""
-    dep = CrawledDependency(canonical_id="pkg:pub/dep_a", display_name="dep_a", version_range="^1.0")
-    pkg = _make_package(
-        canonical_id="pkg:pub/main_pkg",
-        display_name="main_pkg",
-        dependencies=[dep],
-    )
-    crawler = IntegrationStubCrawler(
-        session_factory=db_session_factory,
-        packages={"main_pkg": pkg},
-    )
     result = await crawler.crawl_and_persist(["main_pkg"])
 
-    assert result.edges_created >= 1
+    assert result.packages_processed == 1
+    assert result.edges_created == 1
 
     async with db_session_factory() as session:
-        main_v = (await session.execute(select(RepoVertex).where(RepoVertex.canonical_id == "pkg:pub/main_pkg"))).scalar_one()
-        dep_v = (await session.execute(select(RepoVertex).where(RepoVertex.canonical_id == "pkg:pub/dep_a"))).scalar_one()
-
+        dep_vertex = (
+            await session.execute(select(RepoVertex).where(RepoVertex.canonical_id == dep_canonical_id))
+        ).scalar_one()
         edge = (
             await session.execute(
-                select(DependsOn).where(DependsOn.in_vertex_id == main_v.id, DependsOn.out_vertex_id == dep_v.id)
+                select(DependsOn).where(
+                    DependsOn.in_vertex_id == source_repo.id,
+                    DependsOn.out_vertex_id == dep_vertex.id,
+                )
             )
         ).scalar_one()
         assert edge.confidence == EdgeConfidence.inferred_shadow
         assert edge.version_range == "^1.0"
 
 
-async def test_crawl_preserves_verified_sbom_edges(
+async def test_crawl_creates_reverse_dependent_edges_to_source_repo(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """Existing verified_sbom edge is NOT overwritten by inferred_shadow."""
-    # Pre-create vertices and a verified_sbom edge
+    """Reverse dependents should create edges from dependent vertices to source Repo."""
+
+    suffix = _unique_suffix()
+    source_repo_url = f"https://github.com/test-org/reverse-repo-{suffix}"
+    source_repo_canonical_id = f"pkg:github/test-org/reverse-repo-{suffix}"
+    dependent_canonical_id = f"pkg:pub/rev-a-{suffix}"
+
     async with db_session_factory() as session:
-        repo = Repo(
-            canonical_id="pkg:pub/sbom_pkg",
-            display_name="sbom_pkg",
-            visibility=Visibility.public,
-            latest_version="1.0.0",
+        source_repo = await _seed_source_repo(
+            session,
+            canonical_id=source_repo_canonical_id,
+            repo_url=source_repo_url,
+            display_name=f"reverse-repo-{suffix}",
+        )
+        await session.commit()
+
+    crawler = IntegrationStubCrawler(
+        session_factory=db_session_factory,
+        packages={
+            "main_pkg": _make_package(
+                canonical_id=f"pkg:pub/main-pkg-{suffix}",
+                display_name=f"main_pkg_{suffix}",
+                repo_url=source_repo_url,
+                dependencies=[],
+            )
+        },
+        dependents={
+            "main_pkg": [
+                CrawledDependent(canonical_id=dependent_canonical_id, display_name=f"rev_a_{suffix}"),
+            ]
+        },
+    )
+
+    result = await crawler.crawl_and_persist(["main_pkg"])
+
+    assert result.packages_processed == 1
+    assert result.edges_created == 1
+
+    async with db_session_factory() as session:
+        dependent_vertex = (
+            await session.execute(select(RepoVertex).where(RepoVertex.canonical_id == dependent_canonical_id))
+        ).scalar_one()
+        edge = (
+            await session.execute(
+                select(DependsOn).where(
+                    DependsOn.in_vertex_id == dependent_vertex.id,
+                    DependsOn.out_vertex_id == source_repo.id,
+                )
+            )
+        ).scalar_one()
+        assert edge.confidence == EdgeConfidence.inferred_shadow
+        assert edge.version_range is None
+
+
+async def test_crawl_updates_existing_edge_version_without_changing_confidence(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Existing edge confidence is preserved while version_range is refreshed."""
+
+    suffix = _unique_suffix()
+    source_repo_url = f"https://github.com/test-org/version-repo-{suffix}"
+    source_repo_canonical_id = f"pkg:github/test-org/version-repo-{suffix}"
+    dep_canonical_id = f"pkg:pub/versioned-dep-{suffix}"
+
+    async with db_session_factory() as session:
+        source_repo = await _seed_source_repo(
+            session,
+            canonical_id=source_repo_canonical_id,
+            repo_url=source_repo_url,
+            display_name=f"version-repo-{suffix}",
         )
         dep_ext = ExternalRepo(
-            canonical_id="pkg:pub/sbom_dep",
-            display_name="sbom_dep",
-            latest_version="2.0.0",
+            canonical_id=dep_canonical_id,
+            display_name=f"versioned_dep_{suffix}",
+            latest_version="1.0.0",
         )
-        session.add_all([repo, dep_ext])
+        session.add(dep_ext)
         await session.flush()
         edge = DependsOn(
-            in_vertex_id=repo.id,
+            in_vertex_id=source_repo.id,
             out_vertex_id=dep_ext.id,
-            version_range="=2.0.0",
+            version_range="^1.0",
             confidence=EdgeConfidence.verified_sbom,
         )
         session.add(edge)
         await session.commit()
 
-    # Crawl with the same edge but inferred_shadow
-    dep = CrawledDependency(canonical_id="pkg:pub/sbom_dep", display_name="sbom_dep", version_range="^2.0")
-    pkg = _make_package(
-        canonical_id="pkg:pub/sbom_pkg",
-        display_name="sbom_pkg",
-        dependencies=[dep],
-    )
+    dep = CrawledDependency(canonical_id=dep_canonical_id, display_name=f"versioned_dep_{suffix}", version_range="^2.0")
     crawler = IntegrationStubCrawler(
         session_factory=db_session_factory,
-        packages={"sbom_pkg": pkg},
+        packages={
+            "main_pkg": _make_package(
+                canonical_id=f"pkg:pub/main-pkg-{suffix}",
+                display_name=f"main_pkg_{suffix}",
+                repo_url=source_repo_url,
+                dependencies=[dep],
+            )
+        },
     )
-    result = await crawler.crawl_and_persist(["sbom_pkg"])
 
-    assert result.edges_skipped >= 1
+    result = await crawler.crawl_and_persist(["main_pkg"])
 
-    # Verify the edge still has verified_sbom confidence and original version_range
+    assert result.packages_processed == 1
+
     async with db_session_factory() as session:
-        repo = (await session.execute(select(Repo).where(Repo.canonical_id == "pkg:pub/sbom_pkg"))).scalar_one()
-        dep_v = (await session.execute(select(RepoVertex).where(RepoVertex.canonical_id == "pkg:pub/sbom_dep"))).scalar_one()
         edge = (
             await session.execute(
-                select(DependsOn).where(DependsOn.in_vertex_id == repo.id, DependsOn.out_vertex_id == dep_v.id)
+                select(DependsOn).where(
+                    DependsOn.in_vertex_id == source_repo.id,
+                    DependsOn.out_vertex_id == dep_ext.id,
+                )
             )
         ).scalar_one()
         assert edge.confidence == EdgeConfidence.verified_sbom
-        assert edge.version_range == "=2.0.0"
+        assert edge.version_range == "^2.0"
 
 
-async def test_crawl_updates_inferred_shadow_edges(
+async def test_crawl_is_idempotent_for_vertices_and_edges(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """Existing inferred_shadow edge has its version_range updated."""
-    # Pre-create vertices and an inferred_shadow edge
+    """Running the same crawl twice should not create duplicate vertices or edges."""
+
+    suffix = _unique_suffix()
+    source_repo_url = f"https://github.com/test-org/idempotent-{suffix}"
+    source_repo_canonical_id = f"pkg:github/test-org/idempotent-{suffix}"
+    dep_canonical_id = f"pkg:pub/idempotent-dep-{suffix}"
+
     async with db_session_factory() as session:
-        ext1 = ExternalRepo(canonical_id="pkg:pub/inf_pkg", display_name="inf_pkg", latest_version="1.0.0")
-        ext2 = ExternalRepo(canonical_id="pkg:pub/inf_dep", display_name="inf_dep", latest_version="1.0.0")
-        session.add_all([ext1, ext2])
-        await session.flush()
-        edge = DependsOn(
-            in_vertex_id=ext1.id,
-            out_vertex_id=ext2.id,
-            version_range="^1.0",
-            confidence=EdgeConfidence.inferred_shadow,
+        await _seed_source_repo(
+            session,
+            canonical_id=source_repo_canonical_id,
+            repo_url=source_repo_url,
+            display_name=f"idempotent-{suffix}",
         )
-        session.add(edge)
         await session.commit()
 
-    # Crawl with updated version range
-    dep = CrawledDependency(canonical_id="pkg:pub/inf_dep", display_name="inf_dep", version_range="^2.0")
-    pkg = _make_package(
-        canonical_id="pkg:pub/inf_pkg",
-        display_name="inf_pkg",
-        dependencies=[dep],
-    )
+    dep = CrawledDependency(canonical_id=dep_canonical_id, display_name="idempotent_dep", version_range="^1.0")
     crawler = IntegrationStubCrawler(
         session_factory=db_session_factory,
-        packages={"inf_pkg": pkg},
-    )
-    await crawler.crawl_and_persist(["inf_pkg"])
-
-    async with db_session_factory() as session:
-        ext1 = (await session.execute(select(RepoVertex).where(RepoVertex.canonical_id == "pkg:pub/inf_pkg"))).scalar_one()
-        ext2 = (await session.execute(select(RepoVertex).where(RepoVertex.canonical_id == "pkg:pub/inf_dep"))).scalar_one()
-        edge = (
-            await session.execute(
-                select(DependsOn).where(DependsOn.in_vertex_id == ext1.id, DependsOn.out_vertex_id == ext2.id)
+        packages={
+            "main_pkg": _make_package(
+                canonical_id=f"pkg:pub/idempotent-main-{suffix}",
+                display_name="idempotent_main",
+                repo_url=source_repo_url,
+                dependencies=[dep],
+                downloads_30d=42,
             )
-        ).scalar_one()
-        assert edge.version_range == "^2.0"
-        assert edge.confidence == EdgeConfidence.inferred_shadow
-
-
-async def test_crawl_idempotent(
-    db_session_factory: async_sessionmaker[AsyncSession],
-) -> None:
-    """Running the same crawl twice produces the same DB state."""
-    suffix = _unique_suffix()
-    package_cid = f"pkg:pub/idemp_pkg_{suffix}"
-    dep_cid = f"pkg:pub/idemp_dep_{suffix}"
-    dep = CrawledDependency(canonical_id=dep_cid, display_name=f"idemp_dep_{suffix}", version_range="^1.0")
-    pkg = _make_package(
-        canonical_id=package_cid,
-        display_name=f"idemp_pkg_{suffix}",
-        dependencies=[dep],
-    )
-    crawler = IntegrationStubCrawler(
-        session_factory=db_session_factory,
-        packages={f"idemp_pkg_{suffix}": pkg},
+        },
     )
 
-    result1 = await crawler.crawl_and_persist([f"idemp_pkg_{suffix}"])
-    result2 = await crawler.crawl_and_persist([f"idemp_pkg_{suffix}"])
+    result1 = await crawler.crawl_and_persist(["main_pkg"])
+    result2 = await crawler.crawl_and_persist(["main_pkg"])
 
     assert result1.packages_processed == 1
     assert result2.packages_processed == 1
 
-    # Assert idempotency only for rows created by this test run.
     async with db_session_factory() as session:
-        vertices = (
-            (await session.execute(select(RepoVertex).where(RepoVertex.canonical_id.in_([package_cid, dep_cid]))))
+        source_repo = (await session.execute(select(Repo).where(Repo.canonical_id == source_repo_canonical_id))).scalar_one()
+        dep_vertex = (
+            await session.execute(select(RepoVertex).where(RepoVertex.canonical_id == dep_canonical_id))
+        ).scalar_one()
+
+        edges = (
+            (
+                await session.execute(
+                    select(DependsOn).where(
+                        DependsOn.in_vertex_id == source_repo.id,
+                        DependsOn.out_vertex_id == dep_vertex.id,
+                    )
+                )
+            )
             .scalars()
             .all()
         )
-        assert len(vertices) == 2
+        assert len(edges) == 1
 
-        package_vertex = next(v for v in vertices if v.canonical_id == package_cid)
-        dependency_vertex = next(v for v in vertices if v.canonical_id == dep_cid)
-        edge = (
-            await session.execute(
-                select(DependsOn).where(
-                    DependsOn.in_vertex_id == package_vertex.id,
-                    DependsOn.out_vertex_id == dependency_vertex.id,
-                )
-            )
-        ).scalar_one_or_none()
-        assert edge is not None
+        assert isinstance(source_repo.repo_metadata, dict)
+        metadata = source_repo.repo_metadata or {}
+        downloads_by_purl = metadata.get("adoption_downloads_by_purl")
+        assert downloads_by_purl == {f"pkg:pub/idempotent-main-{suffix}": 42}
 
 
-async def test_crawl_does_not_downgrade_repo_to_external(
+async def test_crawl_result_counts_include_dependency_and_dependent_vertices(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """Existing Repo is NOT replaced by ExternalRepo when crawled."""
-    # Pre-create a Repo
+    """CrawlResult counts should reflect dependency/dependent vertex and edge writes."""
+
+    suffix = _unique_suffix()
+    source_repo_url = f"https://github.com/test-org/count-repo-{suffix}"
+    source_repo_canonical_id = f"pkg:github/test-org/count-repo-{suffix}"
+    main_package_canonical_id = f"pkg:pub/counted-{suffix}"
+    dep_x_canonical_id = f"pkg:pub/dep-x-{suffix}"
+    dep_y_canonical_id = f"pkg:pub/dep-y-{suffix}"
+    rev_z_canonical_id = f"pkg:pub/rev-z-{suffix}"
+
     async with db_session_factory() as session:
-        repo = Repo(
-            canonical_id="pkg:pub/keep_repo",
-            display_name="keep_repo",
-            visibility=Visibility.public,
-            latest_version="1.0.0",
+        await _seed_source_repo(
+            session,
+            canonical_id=source_repo_canonical_id,
+            repo_url=source_repo_url,
+            display_name=f"count-repo-{suffix}",
         )
-        session.add(repo)
         await session.commit()
 
-    pkg = _make_package(canonical_id="pkg:pub/keep_repo", display_name="keep_repo")
-    crawler = IntegrationStubCrawler(
-        session_factory=db_session_factory,
-        packages={"keep_repo": pkg},
-    )
-    await crawler.crawl_and_persist(["keep_repo"])
-
-    async with db_session_factory() as session:
-        vertex = (await session.execute(select(RepoVertex).where(RepoVertex.canonical_id == "pkg:pub/keep_repo"))).scalar_one()
-        assert isinstance(vertex, Repo)
-
-
-async def test_crawl_empty_dependency_list(
-    db_session_factory: async_sessionmaker[AsyncSession],
-) -> None:
-    """Package with zero deps creates only the package vertex, no edges."""
-    suffix = _unique_suffix()
-    package_cid = f"pkg:pub/no_deps_{suffix}"
-    pkg = _make_package(canonical_id=package_cid, display_name=f"no_deps_{suffix}", dependencies=[])
-    crawler = IntegrationStubCrawler(
-        session_factory=db_session_factory,
-        packages={f"no_deps_{suffix}": pkg},
-    )
-    result = await crawler.crawl_and_persist([f"no_deps_{suffix}"])
-
-    assert result.edges_created == 0
-    async with db_session_factory() as session:
-        package_vertex = (await session.execute(select(RepoVertex).where(RepoVertex.canonical_id == package_cid))).scalar_one()
-        edge = (
-            await session.execute(select(DependsOn).where(DependsOn.in_vertex_id == package_vertex.id))
-        ).scalar_one_or_none()
-        assert edge is None
-
-
-async def test_crawl_empty_dependents_list(
-    db_session_factory: async_sessionmaker[AsyncSession],
-) -> None:
-    """Package with zero dependents creates no reverse edges."""
-    suffix = _unique_suffix()
-    package_cid = f"pkg:pub/no_rev_{suffix}"
-    pkg = _make_package(canonical_id=package_cid, display_name=f"no_rev_{suffix}")
-    crawler = IntegrationStubCrawler(
-        session_factory=db_session_factory,
-        packages={f"no_rev_{suffix}": pkg},
-        dependents={f"no_rev_{suffix}": []},
-    )
-    result = await crawler.crawl_and_persist([f"no_rev_{suffix}"])
-
-    assert result.packages_processed == 1
-    async with db_session_factory() as session:
-        package_vertex = (await session.execute(select(RepoVertex).where(RepoVertex.canonical_id == package_cid))).scalar_one()
-        edge = (
-            await session.execute(select(DependsOn).where(DependsOn.out_vertex_id == package_vertex.id))
-        ).scalar_one_or_none()
-        assert edge is None
-
-
-async def test_crawl_result_counts(
-    db_session_factory: async_sessionmaker[AsyncSession],
-) -> None:
-    """CrawlResult numbers are accurate."""
     deps = [
-        CrawledDependency(canonical_id="pkg:pub/dep_x", display_name="dep_x", version_range="^1.0"),
-        CrawledDependency(canonical_id="pkg:pub/dep_y", display_name="dep_y", version_range=None),
+        CrawledDependency(canonical_id=dep_x_canonical_id, display_name=f"dep_x_{suffix}", version_range="^1.0"),
+        CrawledDependency(canonical_id=dep_y_canonical_id, display_name=f"dep_y_{suffix}", version_range=None),
     ]
     dependents = [
-        CrawledDependent(canonical_id="pkg:pub/rev_z", display_name="rev_z"),
+        CrawledDependent(canonical_id=rev_z_canonical_id, display_name=f"rev_z_{suffix}"),
     ]
-    pkg = _make_package(canonical_id="pkg:pub/counted", display_name="counted", dependencies=deps)
     crawler = IntegrationStubCrawler(
         session_factory=db_session_factory,
-        packages={"counted": pkg},
+        packages={
+            "counted": _make_package(
+                canonical_id=main_package_canonical_id,
+                display_name=f"counted_{suffix}",
+                repo_url=source_repo_url,
+                dependencies=deps,
+            )
+        },
         dependents={"counted": dependents},
     )
+
     result = await crawler.crawl_and_persist(["counted"])
 
     assert result.packages_processed == 1
-    # 1 (main pkg) + 2 (deps) + 1 (reverse dep) = 4 vertices
-    assert result.vertices_upserted == 4
-    # 2 forward edges + 1 reverse edge = 3
+    assert result.vertices_upserted == 3
     assert result.edges_created == 3
-    assert result.edges_skipped == 0
     assert result.errors == []

--- a/tests/crawlers/test_live_apis.py
+++ b/tests/crawlers/test_live_apis.py
@@ -66,9 +66,9 @@ async def test_pubdev_live_metrics(live_client: httpx.AsyncClient) -> None:
     crawler = PubDevCrawler(client=live_client, session_factory=_dummy_session_factory(), rate_limit=0.0)
     pkg = await crawler.fetch_package("stellar_flutter_sdk")
 
-    if pkg.downloads is not None:
-        assert isinstance(pkg.downloads, int)
-        assert pkg.downloads >= 0
+    if pkg.downloads_30d is not None:
+        assert isinstance(pkg.downloads_30d, int)
+        assert pkg.downloads_30d >= 0
 
     # Weekly aggregations should be present from scorecard
     assert isinstance(pkg.metadata.get("download_count_4w"), int)
@@ -109,9 +109,9 @@ async def test_packagist_live_downloads(live_client: httpx.AsyncClient) -> None:
     pkg = await crawler.fetch_package("soneso/stellar-php-sdk")
 
     # downloads may be None if downloads endpoint fails, but should be int if present
-    if pkg.downloads is not None:
-        assert isinstance(pkg.downloads, int)
-        assert pkg.downloads >= 0
+    if pkg.downloads_30d is not None:
+        assert isinstance(pkg.downloads_30d, int)
+        assert pkg.downloads_30d >= 0
 
 
 async def test_packagist_live_dependents(live_client: httpx.AsyncClient) -> None:

--- a/tests/crawlers/test_packagist.py
+++ b/tests/crawlers/test_packagist.py
@@ -104,7 +104,7 @@ async def test_fetch_package_parses_stats(
     crawler = _make_crawler(mock_http_client)
     pkg = await crawler.fetch_package("soneso/stellar-php-sdk")
 
-    assert pkg.downloads == 1970  # monthly (last 30 days per spec)
+    assert pkg.downloads_30d == 1970  # monthly (last 30 days per spec)
     assert pkg.stars is None  # reserved for GitHub
     assert pkg.metadata["downloads_total"] == 46925
     assert pkg.metadata["download_count_30d"] == 1970
@@ -126,7 +126,7 @@ async def test_fetch_package_handles_missing_downloads(
     pkg = await crawler.fetch_package("soneso/stellar-php-sdk")
 
     assert pkg.canonical_id == "pkg:composer/soneso/stellar-php-sdk"
-    assert pkg.downloads is None
+    assert pkg.downloads_30d is None
 
 
 async def test_fetch_package_handles_malformed_downloads(
@@ -139,7 +139,7 @@ async def test_fetch_package_handles_malformed_downloads(
     pkg = await crawler.fetch_package("soneso/stellar-php-sdk")
 
     assert pkg.canonical_id == "pkg:composer/soneso/stellar-php-sdk"
-    assert pkg.downloads is None
+    assert pkg.downloads_30d is None
     assert "download_count_30d" not in pkg.metadata
     assert "downloads_daily" not in pkg.metadata
 

--- a/tests/crawlers/test_packagist.py
+++ b/tests/crawlers/test_packagist.py
@@ -68,6 +68,9 @@ async def test_fetch_package_parses_metadata(
     assert pkg.display_name == "soneso/stellar-php-sdk"
     assert pkg.latest_version == "1.9.4"
     assert pkg.repo_url == "https://github.com/Soneso/stellar-php-sdk.git"
+    assert pkg.releases
+    assert {release.version for release in pkg.releases} >= {"1.9.4", "1.8.0", "dev-main"}
+    assert all(release.purl == "pkg:composer/soneso/stellar-php-sdk" for release in pkg.releases)
 
 
 async def test_fetch_package_parses_dependencies(
@@ -242,7 +245,7 @@ async def test_dev_suffix_version_skipped(
     packagist_downloads_data: dict[str, Any],
 ) -> None:
     """Versions ending with -dev are treated as dev branches."""
-    package_data = {
+    package_data: dict[str, Any] = {
         "package": {
             "name": "test/dev-suffix",
             "versions": {
@@ -263,7 +266,7 @@ async def test_dev_only_fallback_first_branch(
     packagist_downloads_data: dict[str, Any],
 ) -> None:
     """When only non-main dev branches exist, first one is used."""
-    package_data = {
+    package_data: dict[str, Any] = {
         "package": {
             "name": "test/dev-only",
             "versions": {
@@ -283,7 +286,7 @@ async def test_empty_versions_dict(
     packagist_downloads_data: dict[str, Any],
 ) -> None:
     """Package with no versions at all returns empty latest_version."""
-    package_data = {
+    package_data: dict[str, Any] = {
         "package": {
             "name": "test/empty",
             "versions": {},
@@ -301,7 +304,7 @@ async def test_version_key_non_numeric_segment(
     packagist_downloads_data: dict[str, Any],
 ) -> None:
     """Version strings with non-numeric segments are handled gracefully."""
-    package_data = {
+    package_data: dict[str, Any] = {
         "package": {
             "name": "test/alpha-ver",
             "versions": {
@@ -325,7 +328,7 @@ async def test_version_sorting_semver(
     packagist_downloads_data: dict[str, Any],
 ) -> None:
     """Verify 1.10.0 > 1.9.4 (not string sort)."""
-    package_data = {
+    package_data: dict[str, Any] = {
         "package": {
             "name": "test/semver-pkg",
             "favers": 0,

--- a/tests/crawlers/test_pubdev.py
+++ b/tests/crawlers/test_pubdev.py
@@ -99,7 +99,7 @@ async def test_fetch_package_parses_scores_and_downloads(
     pkg = await crawler.fetch_package("stellar_flutter_sdk")
 
     # adoption_downloads = last 30 days; adoption_stars reserved for GitHub
-    assert pkg.downloads == 1469
+    assert pkg.downloads_30d == 1469
     assert pkg.stars is None
 
     assert pkg.metadata["pub_points"] == 140
@@ -125,7 +125,7 @@ async def test_fetch_package_no_scorecard(
     crawler = _make_crawler(mock_http_client)
     pkg = await crawler.fetch_package("stellar_flutter_sdk")
 
-    assert pkg.downloads == 100  # downloadCount30Days from score
+    assert pkg.downloads_30d == 100  # downloadCount30Days from score
     assert "download_count_4w" not in pkg.metadata
     assert "download_count_12w" not in pkg.metadata
     assert "download_count_52w" not in pkg.metadata
@@ -150,7 +150,7 @@ async def test_fetch_package_short_weekly_list(
     crawler = _make_crawler(mock_http_client)
     pkg = await crawler.fetch_package("stellar_flutter_sdk")
 
-    assert pkg.downloads == 200  # downloadCount30Days from score
+    assert pkg.downloads_30d == 200  # downloadCount30Days from score
     assert pkg.metadata["download_count_52w"] == sum(weekly_30)
     assert pkg.metadata["download_count_4w"] == sum(weekly_30[:4])
     assert pkg.metadata["download_count_12w"] == sum(weekly_30[:12])
@@ -176,7 +176,7 @@ async def test_fetch_package_metrics_failure(
     assert pkg.canonical_id == "pkg:pub/stellar_flutter_sdk"
     assert pkg.latest_version == "1.8.6"
     assert len(pkg.dependencies) > 0
-    assert pkg.downloads is None  # no metrics data available
+    assert pkg.downloads_30d is None  # no metrics data available
     assert pkg.stars is None
 
 

--- a/tests/crawlers/test_pubdev.py
+++ b/tests/crawlers/test_pubdev.py
@@ -56,6 +56,9 @@ async def test_fetch_package_parses_metadata(
     assert pkg.display_name == "stellar_flutter_sdk"
     assert pkg.latest_version == "1.8.6"
     assert pkg.repo_url == "https://github.com/Soneso/stellar_flutter_sdk"
+    assert pkg.releases
+    assert {release.version for release in pkg.releases} >= {"1.8.6", "1.7.0"}
+    assert all(release.purl == "pkg:pub/stellar_flutter_sdk" for release in pkg.releases)
 
 
 async def test_fetch_package_parses_dependencies(
@@ -199,7 +202,7 @@ async def test_fetch_package_handles_null_dependencies(
     mock_http_client: AsyncMock,
 ) -> None:
     """Dependencies key explicitly set to null does not crash."""
-    package_data = {
+    package_data: dict[str, Any] = {
         "name": "null_deps_pkg",
         "latest": {
             "version": "0.1.0",
@@ -207,7 +210,7 @@ async def test_fetch_package_handles_null_dependencies(
         },
         "versions": [],
     }
-    minimal_metrics = {"score": {}, "scorecard": {}}
+    minimal_metrics: dict[str, Any] = {"score": {}, "scorecard": {}}
     mock_http_client.get = AsyncMock(side_effect=[_response(package_data), _response(minimal_metrics)])
     crawler = _make_crawler(mock_http_client)
     pkg = await crawler.fetch_package("null_deps_pkg")
@@ -219,7 +222,7 @@ async def test_fetch_package_filters_sdk_dependencies(
     mock_http_client: AsyncMock,
 ) -> None:
     """SDK dependencies (dict constraints like {"sdk": "flutter"}) are excluded."""
-    package_data = {
+    package_data: dict[str, Any] = {
         "name": "sdk_deps_pkg",
         "latest": {
             "version": "1.0.0",
@@ -234,7 +237,7 @@ async def test_fetch_package_filters_sdk_dependencies(
         },
         "versions": [],
     }
-    minimal_metrics = {"score": {}, "scorecard": {}}
+    minimal_metrics: dict[str, Any] = {"score": {}, "scorecard": {}}
     mock_http_client.get = AsyncMock(side_effect=[_response(package_data), _response(minimal_metrics)])
     crawler = _make_crawler(mock_http_client)
     pkg = await crawler.fetch_package("sdk_deps_pkg")

--- a/tests/github_scripts/test_parse_worker_logs.py
+++ b/tests/github_scripts/test_parse_worker_logs.py
@@ -17,6 +17,8 @@ def test_parse_bootstrap_log(tmp_path: Path) -> None:
 Queue opengrants final status counts: todo=0 doing=0 succeeded=5 failed=0 cancelled=0 aborted=0
 2026-07-17 10:06:00,456 WARNING  task: Something odd happened
 Queue package-deps final status counts: todo=1 doing=0 succeeded=3 failed=1 cancelled=0 aborted=0
+Queue registry-crawl final status counts: todo=0 doing=0 succeeded=2 failed=0 cancelled=0 aborted=0
+2026-07-17 10:06:01,456 WARNING  task: registry-crawl unsupported ecosystem: system=CARGO purls=pkg:cargo/org/a pkg:cargo/org/b
 2026-07-17 10:07:00,789 ERROR    task: Critical failure
 """
     log_file = tmp_path / "bootstrap.log"
@@ -39,10 +41,14 @@ Queue package-deps final status counts: todo=1 doing=0 succeeded=3 failed=1 canc
     stdout = result.stdout
     assert "opengrants_succeeded=5" in stdout
     assert "package_deps_failed=1" in stdout
+    assert "registry_crawl_succeeded=2" in stdout
     assert "warning_count=1" in stdout
     assert "error_count=1" in stdout
     assert "warnings=Something odd happened" in stdout
     assert "errors=Critical failure" in stdout
+    assert "unsupported_ecosystem_group_count=1" in stdout
+    assert "unsupported_ecosystem_purl_count=2" in stdout
+    assert "- CARGO (2): pkg:cargo/org/a pkg:cargo/org/b" in stdout
 
 
 def test_parse_sbom_log(tmp_path: Path) -> None:

--- a/tests/metrics/test_materialize_adoption.py
+++ b/tests/metrics/test_materialize_adoption.py
@@ -33,6 +33,16 @@ class SeededAdoptionFixture:
     empty_project_id: int
 
 
+@dataclass(frozen=True)
+class SeededMonorepoDownloadsFixture:
+    """
+    Hold seeded IDs for monorepo download aggregation tests.
+    """
+
+    project_id: int
+    repo_id: int
+
+
 @pytest.fixture
 async def rollback_db_session(db_session: AsyncSession) -> AsyncGenerator[AsyncSession, None]:
     """
@@ -113,6 +123,11 @@ async def _seed_adoption_fixture(session: AsyncSession) -> SeededAdoptionFixture
                 project_id=project_a.id,
                 adoption_stars=20,
                 adoption_downloads=100,
+                repo_metadata={
+                    "adoption_downloads_by_purl": {
+                        f"pkg:pypi/adoption-a2-{suffix}": 100,
+                    }
+                },
             ),
             Repo(
                 canonical_id=f"pkg:github/test/adoption-b1-{suffix}",
@@ -122,6 +137,11 @@ async def _seed_adoption_fixture(session: AsyncSession) -> SeededAdoptionFixture
                 project_id=project_b.id,
                 adoption_forks=6,
                 adoption_downloads=300,
+                repo_metadata={
+                    "adoption_downloads_by_purl": {
+                        f"pkg:pypi/adoption-b1-{suffix}": 300,
+                    }
+                },
             ),
             Repo(
                 canonical_id=f"pkg:github/test/adoption-c1-{suffix}",
@@ -158,6 +178,42 @@ async def _get_project(session: AsyncSession, project_id: int) -> Project:
     assert project is not None
 
     return project
+
+
+async def _seed_monorepo_download_fixture(session: AsyncSession) -> SeededMonorepoDownloadsFixture:
+    """
+    Insert one repo with per-PURL download metadata for aggregation tests.
+    """
+
+    suffix = uuid4().hex[:8]
+
+    project = Project(
+        canonical_id=f"daoip-5:stellar:project:adoption-monorepo-{suffix}",
+        display_name=f"Adoption Monorepo {suffix}",
+        project_type=ProjectType.scf_project,
+        activity_status=ActivityStatus.live,
+    )
+    session.add(project)
+    await session.flush()
+
+    repo = Repo(
+        canonical_id=f"pkg:github/test/adoption-monorepo-{suffix}",
+        display_name=f"adoption-monorepo-{suffix}",
+        visibility=Visibility.public,
+        latest_version="1.0.0",
+        project_id=project.id,
+        adoption_downloads=5,
+        repo_metadata={
+            "adoption_downloads_by_purl": {
+                "pkg:pub/foo": 100,
+                "pkg:pub/bar": 200,
+            }
+        },
+    )
+    session.add(repo)
+    await session.flush()
+
+    return SeededMonorepoDownloadsFixture(project_id=project.id, repo_id=repo.id)
 
 
 async def test_materialize_adoption_scores_persists_project_scores(
@@ -218,3 +274,23 @@ async def test_materialize_adoption_scores_is_idempotent(
     assert project_b.adoption_score == Decimal("50.00")
     assert project_c.adoption_score is None
     assert empty_project.adoption_score is None
+
+
+async def test_materialize_adoption_scores_updates_repo_downloads_from_metadata(
+    rollback_db_session: AsyncSession,
+) -> None:
+    """
+    Materialization should persist summed per-PURL downloads onto Repo rows.
+    """
+
+    seeded = await _seed_monorepo_download_fixture(rollback_db_session)
+
+    await materialize_adoption_scores(rollback_db_session)
+    repo = await rollback_db_session.get(Repo, seeded.repo_id)
+    assert repo is not None
+    assert repo.adoption_downloads == 300
+
+    await materialize_adoption_scores(rollback_db_session)
+    repo = await rollback_db_session.get(Repo, seeded.repo_id)
+    assert repo is not None
+    assert repo.adoption_downloads == 300

--- a/tests/metrics/test_materialize_adoption.py
+++ b/tests/metrics/test_materialize_adoption.py
@@ -66,11 +66,15 @@ async def _seed_adoption_fixture(session: AsyncSession) -> SeededAdoptionFixture
 
     # Neutralize existing repo adoption signals inside the rollback-only
     # transaction so the percentile pools are deterministic for this test.
+    # Materialization now rebuilds downloads from repo_metadata maps, so we
+    # also clear repo_metadata to avoid background fixtures re-entering the
+    # ranking pools.
     await session.execute(
         update(Repo).values(
             adoption_stars=None,
             adoption_forks=None,
             adoption_downloads=None,
+            repo_metadata=None,
         )
     )
     await session.flush()

--- a/tests/metrics/test_metrics_adoption.py
+++ b/tests/metrics/test_metrics_adoption.py
@@ -9,10 +9,14 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+import pytest
+
 from pg_atlas.metrics.adoption import (
     RepoAdoptionSignals,
+    aggregate_repo_downloads,
     compute_project_adoption_scores,
     compute_repo_adoption_composites,
+    downloads_by_purl_from_metadata,
 )
 
 
@@ -80,3 +84,53 @@ def test_compute_project_adoption_scores_averages_child_repo_composites_only() -
         1: Decimal("12.50"),
         2: Decimal("50.00"),
     }
+
+
+def test_compute_repo_adoption_composites_uses_materialized_download_sum() -> None:
+    """
+    Repo download percentile inputs should use persisted reduced downloads values.
+    """
+
+    repo_a_downloads = aggregate_repo_downloads({"pkg:cargo/a": 100, "pkg:npm/a": 20})
+    repo_b_downloads = aggregate_repo_downloads({"pkg:cargo/b": 80})
+    assert repo_a_downloads == 120
+    assert repo_b_downloads == 80
+
+    repos = [
+        RepoAdoptionSignals(
+            canonical_id="repo-a",
+            project_id=1,
+            adoption_downloads=repo_a_downloads,
+        ),
+        RepoAdoptionSignals(
+            canonical_id="repo-b",
+            project_id=1,
+            adoption_downloads=repo_b_downloads,
+        ),
+    ]
+
+    composites = compute_repo_adoption_composites(repos)
+
+    assert composites["repo-a"] == Decimal("50.00")
+    assert composites["repo-b"] == Decimal("0.00")
+
+
+def test_downloads_by_purl_from_metadata_logs_invalid_entries(caplog: pytest.LogCaptureFixture) -> None:
+    """
+    Invalid metadata entries should be logged and filtered.
+    """
+
+    caplog.set_level("WARNING")
+    downloads_by_purl = downloads_by_purl_from_metadata(
+        {
+            "adoption_downloads_by_purl": {
+                "pkg:pypi/ok": 10,
+                "pkg:pypi/bad": "11",
+                99: 4,
+            }
+        },
+        repo_canonical_id="pkg:github/test/repo",
+    )
+
+    assert downloads_by_purl is None
+    assert "validation_errors=" in caplog.text

--- a/tests/persistence/test_releases.py
+++ b/tests/persistence/test_releases.py
@@ -1,0 +1,42 @@
+"""
+Unit tests for ``pg_atlas.db_models.release``.
+
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from pg_atlas.db_models.release import Release, merge_releases, preferred_latest_version
+
+
+def test_preferred_latest_version_semver_precedence() -> None:
+    selected = preferred_latest_version(
+        [
+            # first semver candidate should short-circuit
+            # regardless of hash/arbitrary values further down
+            Release(version="v3.1.2", release_date="", purl="pkg:npm/a"),
+            Release(version="abc1234", release_date="", purl="pkg:npm/a"),
+            Release(version="dev-main", release_date="", purl="pkg:npm/a"),
+        ]
+    )
+
+    assert selected == "v3.1.2"
+
+
+def test_preferred_latest_version_hash_fallback() -> None:
+    selected = preferred_latest_version(
+        [
+            Release(version="feature-branch", release_date="", purl="pkg:npm/a"),
+            Release(version="e57ab3dd9bbf", release_date="", purl="pkg:npm/a"),
+            Release(version="something-else", release_date="", purl="pkg:npm/a"),
+        ]
+    )
+
+    assert selected == "e57ab3dd9bbf"
+
+
+def test_merge_releases_accepts_legacy_null_release_date() -> None:
+    merged = merge_releases(existing=[{"purl": "pkg:pub/a", "version": "1.0.0", "release_date": None}], incoming=[])
+
+    assert merged is not None
+    assert merged[0].release_date == ""

--- a/tests/routers/test_openapi.py
+++ b/tests/routers/test_openapi.py
@@ -1,0 +1,33 @@
+"""
+Smoke tests for OpenAPI schema generation and serving.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+from httpx import AsyncClient
+
+from pg_atlas.main import app
+
+
+async def test_openapi_schema_can_be_generated() -> None:
+    """App-level OpenAPI generation should succeed and include expected top-level keys."""
+
+    schema = app.openapi()
+
+    assert isinstance(schema, dict)
+    assert schema.get("openapi")
+    assert isinstance(schema.get("paths"), dict)
+
+
+async def test_openapi_json_endpoint_serves_schema(async_client: AsyncClient) -> None:
+    """The OpenAPI document should be available from the canonical /openapi.json route."""
+
+    response = await async_client.get("/openapi.json")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload.get("openapi")
+    assert isinstance(payload.get("paths"), dict)


### PR DESCRIPTION
Deeply integrate the previously contributed but unused crawlers into the existing reference graph bootstrap.

The starting point is some A10 materialize adoption score scaffolding. The big missing part: `adoption_downloads`. The other adoption components `stars` and `forks` are repo-native. Download counts are package-based, so we needed a framework to properly link repos and packages.

There is no naive one-package-per-repo assumption: this PR properly deals with monorepos and everything in between. The adoption_downloads number is already a composite. Conceptualized as a map-reduce job, in which the map step can be spread over different package ecosystems, each using its own crawler class. The reduce step happens in materialization.

A nice side effect of the new framework is that I was forced to properly deal with package releases. There is now a strong msgspec-based contract between all components that read or write `RepoVertex.releases`.