### PR TITLE
Perf optimize metric materialization

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -2,8 +2,10 @@ name: pg-atlas-backend
 region: ams
 
 databases:
-  - engine: PG
+  - cluster_name: REDACTED
+    production: true
     name: pg-atlas-dev
+    engine: PG
     version: "18"
 
 features:
@@ -33,6 +35,32 @@ services:
       - key: PG_ATLAS_ARTIFACT_S3_ENDPOINT
         scope: RUN_TIME
         value: https://s3.filebase.com
+    alerts:
+      - rule: CPU_UTILIZATION
+        operator: GREATER_THAN
+        value: 50
+        window: TEN_MINUTES
+      - rule: MEM_UTILIZATION
+        operator: GREATER_THAN
+        value: 75
+        window: THIRTY_MINUTES
+      - rule: RESTART_COUNT
+        operator: GREATER_THAN
+        value: 1
+        window: FIVE_MINUTES
+    health_check:
+      failure_threshold: 9
+      http_path: /health
+      initial_delay_seconds: 1
+      period_seconds: 10
+      success_threshold: 1
+      timeout_seconds: 1
+    liveness_health_check:
+      failure_threshold: 9
+      http_path: /health
+      period_seconds: 60
+      success_threshold: 1
+      timeout_seconds: 1
 
 ingress:
   rules:

--- a/.github/scripts/parse-bootstrap-log.py
+++ b/.github/scripts/parse-bootstrap-log.py
@@ -32,11 +32,15 @@ def parse_log(log_path: str) -> tuple[dict[str, dict[str, int]], list[str], list
 
     Returns:
         A tuple of (status_counts_by_queue, warnings, errors, unsupported_purls).
+        All collections are empty if the file does not exist.
     """
     status_counts: dict[str, dict[str, int]] = {}
     warnings: list[str] = []
     errors: list[str] = []
     unsupported_purls: dict[str, set[str]] = {}
+
+    if not Path(log_path).exists():
+        return status_counts, warnings, errors, unsupported_purls
 
     with open(log_path) as f:
         for line in f:

--- a/.github/scripts/parse-gitlog-log.py
+++ b/.github/scripts/parse-gitlog-log.py
@@ -42,6 +42,16 @@ def parse_worker_log(log_path: str) -> tuple[dict[str, dict[str, int]], list[str
     total_rate_limit_hits = "0"
     terminal_failures_marked_private = "none"
 
+    if not Path(log_path).exists():
+        return (
+            status_counts,
+            warnings,
+            errors,
+            first_rate_limit_hit_after_n_repos,
+            total_rate_limit_hits,
+            terminal_failures_marked_private,
+        )
+
     with open(log_path) as file:
         for raw_line in file:
             line = raw_line.rstrip("\n")

--- a/.github/scripts/parse-materialize-adoption-log.py
+++ b/.github/scripts/parse-materialize-adoption-log.py
@@ -16,9 +16,13 @@ SPDX-License-Identifier: MPL-2.0
 
 from __future__ import annotations
 
-import os
 import re
 import sys
+from pathlib import Path
+
+# Add the scripts directory to sys.path to allow importing sibling modules
+sys.path.insert(0, str(Path(__file__).parent))
+from worker_log_utils import emit_github_output
 
 _SUMMARY_RE = re.compile(
     r"project adoption materialization finished: "
@@ -34,12 +38,16 @@ def parse_log(log_path: str) -> dict[str, str]:
     """
     Scan a tee'd materialize_adoption log for the summary line.
 
-    Returns a dict of output key→value pairs.
+    Returns a dict of output key→value pairs, empty if the file is absent.
     """
+
+    p = Path(log_path)
+    if not p.exists():
+        return {}
 
     result: dict[str, str] = {}
 
-    with open(log_path) as f:
+    with p.open() as f:
         for line in f:
             match = _SUMMARY_RE.search(line)
 
@@ -61,15 +69,7 @@ def main() -> None:
         sys.exit(1)
 
     outputs = parse_log(sys.argv[1])
-
-    github_output = os.environ.get("GITHUB_OUTPUT")
-    if github_output:
-        with open(github_output, "a") as f:
-            for key, value in outputs.items():
-                f.write(f"{key}={value}\n")
-    else:
-        for key, value in outputs.items():
-            print(f"{key}={value}")
+    emit_github_output({}, [], [], extra_outputs=outputs)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/parse-materialize-criticality-log.py
+++ b/.github/scripts/parse-materialize-criticality-log.py
@@ -16,9 +16,13 @@ SPDX-License-Identifier: MPL-2.0
 
 from __future__ import annotations
 
-import os
 import re
 import sys
+from pathlib import Path
+
+# Add the scripts directory to sys.path to allow importing sibling modules
+sys.path.insert(0, str(Path(__file__).parent))
+from worker_log_utils import emit_github_output
 
 _SUMMARY_RE = re.compile(
     r"A9 criticality materialization finished: "
@@ -32,12 +36,16 @@ def parse_log(log_path: str) -> dict[str, str]:
     """
     Scan a tee'd materialize_criticality log for the summary line.
 
-    Returns a dict of output key→value pairs.
+    Returns a dict of output key→value pairs, empty if the file is absent.
     """
+
+    p = Path(log_path)
+    if not p.exists():
+        return {}
 
     result: dict[str, str] = {}
 
-    with open(log_path) as f:
+    with p.open() as f:
         for line in f:
             m = _SUMMARY_RE.search(line)
 
@@ -57,15 +65,7 @@ def main() -> None:
         sys.exit(1)
 
     outputs = parse_log(sys.argv[1])
-
-    github_output = os.environ.get("GITHUB_OUTPUT")
-    if github_output:
-        with open(github_output, "a") as f:
-            for key, value in outputs.items():
-                f.write(f"{key}={value}\n")
-    else:
-        for key, value in outputs.items():
-            print(f"{key}={value}")
+    emit_github_output({}, [], [], extra_outputs=outputs)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/parse-materialize-pony-log.py
+++ b/.github/scripts/parse-materialize-pony-log.py
@@ -16,9 +16,13 @@ SPDX-License-Identifier: MPL-2.0
 
 from __future__ import annotations
 
-import os
 import re
 import sys
+from pathlib import Path
+
+# Add the scripts directory to sys.path to allow importing sibling modules
+sys.path.insert(0, str(Path(__file__).parent))
+from worker_log_utils import emit_github_output
 
 _SUMMARY_RE = re.compile(
     r"Pony-factor materialization finished: "
@@ -33,12 +37,16 @@ def parse_log(log_path: str) -> dict[str, str]:
     """
     Scan a tee'd materialize_pony log for the summary line.
 
-    Returns a dict of output key→value pairs.
+    Returns a dict of output key→value pairs, empty if the file is absent.
     """
+
+    p = Path(log_path)
+    if not p.exists():
+        return {}
 
     result: dict[str, str] = {}
 
-    with open(log_path) as f:
+    with p.open() as f:
         for line in f:
             m = _SUMMARY_RE.search(line)
 
@@ -59,15 +67,7 @@ def main() -> None:
         sys.exit(1)
 
     outputs = parse_log(sys.argv[1])
-
-    github_output = os.environ.get("GITHUB_OUTPUT")
-    if github_output:
-        with open(github_output, "a") as f:
-            for key, value in outputs.items():
-                f.write(f"{key}={value}\n")
-    else:
-        for key, value in outputs.items():
-            print(f"{key}={value}")
+    emit_github_output({}, [], [], extra_outputs=outputs)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/parse-sbom-log.py
+++ b/.github/scripts/parse-sbom-log.py
@@ -32,11 +32,15 @@ def parse_log(log_path: str) -> tuple[dict[str, dict[str, int]], list[str], list
 
     Returns:
         A tuple of (status_counts_by_queue, warnings, errors, spdx_parsed_lines).
+        All collections are empty if the file does not exist.
     """
     status_counts: dict[str, dict[str, int]] = {}
     warnings: list[str] = []
     errors: list[str] = []
     spdx_parsed_lines: list[str] = []
+
+    if not Path(log_path).exists():
+        return status_counts, warnings, errors, spdx_parsed_lines
 
     with open(log_path) as f:
         for line in f:

--- a/.github/scripts/render-template.py
+++ b/.github/scripts/render-template.py
@@ -7,7 +7,7 @@ them from ``KEY=VALUE`` pairs passed as command-line arguments.
 Usage::
 
     python .github/scripts/render-template.py \\
-        .github/templates/bootstrap-summary.md \\
+        .github/templates/<job-name>-summary.md \\
         trigger=schedule run_id=12345 ...
 
 SPDX-FileCopyrightText: 2026 PG Atlas contributors

--- a/.github/scripts/worker_log_utils.py
+++ b/.github/scripts/worker_log_utils.py
@@ -95,10 +95,18 @@ def emit_github_output(
                 print(f"{k}<<EOF\n{v}\nEOF")
 
         if all_warnings:
-            print(f"warnings={chr(10).join(all_warnings[:50])}")
+            print("warnings<<EOF\n")
+            for w in all_warnings[:50]:
+                print(f"* {w}")
+
+            print("EOF")
 
         if all_errors:
-            print(f"errors={chr(10).join(all_errors[:50])}")
+            print("errors<<EOF\n")
+            for e in all_errors[:50]:
+                print(f"* {e}")
+
+            print("EOF")
 
         return
 
@@ -119,15 +127,15 @@ def emit_github_output(
 
         # Multiline values use heredoc syntax.
         if all_warnings:
-            f.write("warnings<<EOF\n")
+            f.write("warnings<<EOF\n\n")
             for w in all_warnings[:50]:
-                f.write(f"{w}\n")
+                f.write(f"* {w}\n")
 
             f.write("EOF\n")
 
         if all_errors:
-            f.write("errors<<EOF\n")
+            f.write("errors<<EOF\n\n")
             for e in all_errors[:50]:
-                f.write(f"{e}\n")
+                f.write(f"* {e}\n")
 
             f.write("EOF\n")

--- a/.github/scripts/worker_log_utils.py
+++ b/.github/scripts/worker_log_utils.py
@@ -127,14 +127,14 @@ def emit_github_output(
 
         # Multiline values use heredoc syntax.
         if all_warnings:
-            f.write("warnings<<EOF\n\n")
+            f.write("warnings<<EOF\n")
             for w in all_warnings[:50]:
                 f.write(f"* {w}\n")
 
             f.write("EOF\n")
 
         if all_errors:
-            f.write("errors<<EOF\n\n")
+            f.write("errors<<EOF\n")
             for e in all_errors[:50]:
                 f.write(f"* {e}\n")
 

--- a/.github/templates/gitlog-queue-summary.md
+++ b/.github/templates/gitlog-queue-summary.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD033 -->
 <!-- markdownlint-disable MD041 -->
 ## Gitlog Queue Processing
 <!-- markdownlint-enable MD041 -->
@@ -13,9 +14,19 @@
 - **First rate-limit hit after N repos**: {first_rate_limit_hit_after_n_repos}
 - **Total rate-limit hits**: {total_rate_limit_hits}
 
-### Worker errors
+<details open>
+<summary>Errors ({error_count})</summary>
 
 {error_detail}
+
+</details>
+
+<details>
+<summary>Warnings ({warning_count})</summary>
+
+{warning_detail}
+
+</details>
 
 ### Pony factor materialization
 

--- a/.github/templates/opengrants-summary.md
+++ b/.github/templates/opengrants-summary.md
@@ -1,21 +1,27 @@
+<!-- markdownlint-disable MD033 -->
 <!-- markdownlint-disable MD041 -->
-## Reference Graph Bootstrap
+## Crawl — OpenGrants Queue
 <!-- markdownlint-enable MD041 -->
 
 | Queue | Succeeded | Failed | Pending | Cancelled |
 | ----- | --------: | -----: | ------: | --------: |
 | `opengrants` | {opengrants_succeeded} | {opengrants_failed} | {opengrants_todo} | {opengrants_cancelled} |
-| `package-deps` | {package_deps_succeeded} | {package_deps_failed} | {package_deps_todo} | {package_deps_cancelled} |
-| `registry-crawl` | {registry_crawl_succeeded} | {registry_crawl_failed} | {registry_crawl_todo} | {registry_crawl_cancelled} |
 
 - **Trigger**: {trigger}
 - **Run**: [{run_id}]({server_url}/{repository}/actions/runs/{run_id})
 - **Finished**: {finished}
 - **Warnings**: {warning_count} | **Errors**: {error_count}
-- **Unsupported ecosystems**: {unsupported_ecosystem_group_count} groups / {unsupported_ecosystem_purl_count} packages
 
-### Unsupported Ecosystems
-
-{unsupported_ecosystems}
+<details open>
+<summary>Errors ({error_count})</summary>
 
 {error_detail}
+
+</details>
+
+<details>
+<summary>Warnings ({warning_count})</summary>
+
+{warning_detail}
+
+</details>

--- a/.github/templates/package-deps-summary.md
+++ b/.github/templates/package-deps-summary.md
@@ -1,11 +1,10 @@
-<!-- markdownlint-disable MD033 -->
 <!-- markdownlint-disable MD041 -->
-## SBOM Queue Processing
+## deps.dev — Package Dependencies Queue
 <!-- markdownlint-enable MD041 -->
 
 | Queue | Succeeded | Failed | Pending | Cancelled |
 | ----- | --------: | -----: | ------: | --------: |
-| `sbom` | {sbom_succeeded} | {sbom_failed} | {sbom_todo} | {sbom_cancelled} |
+| `package-deps` | {package_deps_succeeded} | {package_deps_failed} | {package_deps_todo} | {package_deps_cancelled} |
 
 - **Trigger**: {trigger}
 - **Run**: [{run_id}]({server_url}/{repository}/actions/runs/{run_id})
@@ -25,13 +24,3 @@
 {warning_detail}
 
 </details>
-
-### Parsed SPDX Documents
-
-{spdx_details}
-
-### Criticality Materialization
-
-| Dep nodes seen | Active nodes scored | Duration (s) |
-| -------------: | ------------------: | -----------: |
-| {criticality_dep_nodes_seen} | {criticality_active_nodes_scored} | {criticality_duration_seconds} |

--- a/.github/templates/registry-crawl-summary.md
+++ b/.github/templates/registry-crawl-summary.md
@@ -1,16 +1,21 @@
 <!-- markdownlint-disable MD033 -->
 <!-- markdownlint-disable MD041 -->
-## SBOM Queue Processing
+## Registries — Registry Crawl Queue
 <!-- markdownlint-enable MD041 -->
 
 | Queue | Succeeded | Failed | Pending | Cancelled |
 | ----- | --------: | -----: | ------: | --------: |
-| `sbom` | {sbom_succeeded} | {sbom_failed} | {sbom_todo} | {sbom_cancelled} |
+| `registry-crawl` | {registry_crawl_succeeded} | {registry_crawl_failed} | {registry_crawl_todo} | {registry_crawl_cancelled} |
 
 - **Trigger**: {trigger}
 - **Run**: [{run_id}]({server_url}/{repository}/actions/runs/{run_id})
 - **Finished**: {finished}
 - **Warnings**: {warning_count} | **Errors**: {error_count}
+- **Unsupported ecosystems**: {unsupported_ecosystem_group_count} groups / {unsupported_ecosystem_purl_count} packages
+
+### Unsupported Ecosystems
+
+{unsupported_ecosystems}
 
 <details open>
 <summary>Errors ({error_count})</summary>
@@ -25,13 +30,3 @@
 {warning_detail}
 
 </details>
-
-### Parsed SPDX Documents
-
-{spdx_details}
-
-### Criticality Materialization
-
-| Dep nodes seen | Active nodes scored | Duration (s) |
-| -------------: | ------------------: | -----------: |
-| {criticality_dep_nodes_seen} | {criticality_active_nodes_scored} | {criticality_duration_seconds} |

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -33,7 +33,7 @@ jobs:
       warning_count: ${{ steps.parse-logs.outputs.warning_count }}
       error_count: ${{ steps.parse-logs.outputs.error_count }}
       errors: ${{ steps.parse-logs.outputs.errors }}
-    timeout-minutes: 300
+    timeout-minutes: 360
     env:
       PG_ATLAS_DATABASE_URL: ${{ secrets.DATABASE_URL }}
       PG_ATLAS_OPENGRANTS_KEY: ${{ secrets.OPENGRANTS_KEY }}
@@ -52,11 +52,33 @@ jobs:
         run: uv run python -m pg_atlas.procrastinate.seed_opengrants
 
       - name: Run worker — opengrants queue
+        timeout-minutes: 320
         run: uv run python -m pg_atlas.procrastinate.worker --queue=opengrants --drain-rounds=4 --concurrency=8 --tee=opengrants-worker.log
 
       - name: Parse worker logs
         id: parse-logs
+        if: always()
         run: python .github/scripts/parse-bootstrap-log.py opengrants-worker.log
+
+      - name: Write job summary
+        if: always()
+        run: |
+          python .github/scripts/render-template.py \
+            .github/templates/opengrants-summary.md \
+            trigger="${{ github.event_name }}" \
+            run_id="${{ github.run_id }}" \
+            server_url="${{ github.server_url }}" \
+            repository="${{ github.repository }}" \
+            finished="$(date -u '+%Y-%m-%d %H:%M:%S UTC')" \
+            opengrants_succeeded="${{ steps.parse-logs.outputs.opengrants_succeeded || '—' }}" \
+            opengrants_failed="${{ steps.parse-logs.outputs.opengrants_failed || '—' }}" \
+            opengrants_todo="${{ steps.parse-logs.outputs.opengrants_todo || '—' }}" \
+            opengrants_cancelled="${{ steps.parse-logs.outputs.opengrants_cancelled || '—' }}" \
+            warning_count="${{ steps.parse-logs.outputs.warning_count || '0' }}" \
+            error_count="${{ steps.parse-logs.outputs.error_count || '0' }}" \
+            error_detail="${{ steps.parse-logs.outputs.errors || '' }}" \
+            warning_detail="${{ steps.parse-logs.outputs.warnings || '' }}" \
+            >> "$GITHUB_STEP_SUMMARY"
 
   deps-dev:
     runs-on: ubuntu-latest
@@ -66,6 +88,62 @@ jobs:
       package_deps_failed: ${{ steps.parse-logs.outputs.package_deps_failed }}
       package_deps_todo: ${{ steps.parse-logs.outputs.package_deps_todo }}
       package_deps_cancelled: ${{ steps.parse-logs.outputs.package_deps_cancelled }}
+      warning_count: ${{ steps.parse-logs.outputs.warning_count }}
+      error_count: ${{ steps.parse-logs.outputs.error_count }}
+      errors: ${{ steps.parse-logs.outputs.errors }}
+    timeout-minutes: 360
+    env:
+      PG_ATLAS_DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      UV_NO_GROUP: dev
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run worker — package-deps queue
+        timeout-minutes: 320
+        run: uv run python -m pg_atlas.procrastinate.worker --queue=package-deps --drain-rounds=30 --concurrency=8 --tee=package-deps-worker.log
+
+      - name: Parse worker logs
+        id: parse-logs
+        if: always()
+        run: python .github/scripts/parse-bootstrap-log.py package-deps-worker.log
+
+      - name: Write job summary
+        if: always()
+        run: |
+          python .github/scripts/render-template.py \
+            .github/templates/package-deps-summary.md \
+            trigger="${{ github.event_name }}" \
+            run_id="${{ github.run_id }}" \
+            server_url="${{ github.server_url }}" \
+            repository="${{ github.repository }}" \
+            finished="$(date -u '+%Y-%m-%d %H:%M:%S UTC')" \
+            package_deps_succeeded="${{ steps.parse-logs.outputs.package_deps_succeeded || '—' }}" \
+            package_deps_failed="${{ steps.parse-logs.outputs.package_deps_failed || '—' }}" \
+            package_deps_todo="${{ steps.parse-logs.outputs.package_deps_todo || '—' }}" \
+            package_deps_cancelled="${{ steps.parse-logs.outputs.package_deps_cancelled || '—' }}" \
+            warning_count="${{ steps.parse-logs.outputs.warning_count || '0' }}" \
+            error_count="${{ steps.parse-logs.outputs.error_count || '0' }}" \
+            error_detail="${{ steps.parse-logs.outputs.errors || '' }}" \
+            warning_detail="${{ steps.parse-logs.outputs.warnings || '' }}" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+  registries:
+    runs-on: ubuntu-latest
+    needs: crawl
+    outputs:
+      registry_crawl_succeeded: ${{ steps.parse-logs.outputs.registry_crawl_succeeded }}
+      registry_crawl_failed: ${{ steps.parse-logs.outputs.registry_crawl_failed }}
+      registry_crawl_todo: ${{ steps.parse-logs.outputs.registry_crawl_todo }}
+      registry_crawl_cancelled: ${{ steps.parse-logs.outputs.registry_crawl_cancelled }}
+      unsupported_ecosystem_group_count: ${{ steps.parse-logs.outputs.unsupported_ecosystem_group_count }}
+      unsupported_ecosystem_purl_count: ${{ steps.parse-logs.outputs.unsupported_ecosystem_purl_count }}
+      unsupported_ecosystems: ${{ steps.parse-logs.outputs.unsupported_ecosystems }}
       warning_count: ${{ steps.parse-logs.outputs.warning_count }}
       error_count: ${{ steps.parse-logs.outputs.error_count }}
       errors: ${{ steps.parse-logs.outputs.errors }}
@@ -82,49 +160,41 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen
 
-      - name: Run worker — package-deps queue
-        run: uv run python -m pg_atlas.procrastinate.worker --queue=package-deps --drain-rounds=30 --concurrency=8 --tee=package-deps-worker.log
-
-      - name: Parse worker logs
-        id: parse-logs
-        run: python .github/scripts/parse-bootstrap-log.py package-deps-worker.log
-
-  registries:
-    runs-on: ubuntu-latest
-    needs: crawl
-    outputs:
-      registry_crawl_succeeded: ${{ steps.parse-logs.outputs.registry_crawl_succeeded }}
-      registry_crawl_failed: ${{ steps.parse-logs.outputs.registry_crawl_failed }}
-      registry_crawl_todo: ${{ steps.parse-logs.outputs.registry_crawl_todo }}
-      registry_crawl_cancelled: ${{ steps.parse-logs.outputs.registry_crawl_cancelled }}
-      unsupported_ecosystem_group_count: ${{ steps.parse-logs.outputs.unsupported_ecosystem_group_count }}
-      unsupported_ecosystem_purl_count: ${{ steps.parse-logs.outputs.unsupported_ecosystem_purl_count }}
-      unsupported_ecosystems: ${{ steps.parse-logs.outputs.unsupported_ecosystems }}
-      warning_count: ${{ steps.parse-logs.outputs.warning_count }}
-      error_count: ${{ steps.parse-logs.outputs.error_count }}
-      errors: ${{ steps.parse-logs.outputs.errors }}
-    timeout-minutes: 180
-    env:
-      PG_ATLAS_DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      UV_NO_GROUP: dev
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: astral-sh/setup-uv@v7
-
-      - name: Install dependencies
-        run: uv sync --frozen
-
       - name: Run worker — registry-crawl queue
+        timeout-minutes: 200
         run: uv run python -m pg_atlas.procrastinate.worker --queue=registry-crawl --drain-rounds=2 --concurrency=2 --tee=registry-crawl-worker.log
 
       - name: Parse worker logs
         id: parse-logs
+        if: always()
         run: python .github/scripts/parse-bootstrap-log.py registry-crawl-worker.log
+
+      - name: Write job summary
+        if: always()
+        run: |
+          python .github/scripts/render-template.py \
+            .github/templates/registry-crawl-summary.md \
+            trigger="${{ github.event_name }}" \
+            run_id="${{ github.run_id }}" \
+            server_url="${{ github.server_url }}" \
+            repository="${{ github.repository }}" \
+            finished="$(date -u '+%Y-%m-%d %H:%M:%S UTC')" \
+            registry_crawl_succeeded="${{ steps.parse-logs.outputs.registry_crawl_succeeded || '—' }}" \
+            registry_crawl_failed="${{ steps.parse-logs.outputs.registry_crawl_failed || '—' }}" \
+            registry_crawl_todo="${{ steps.parse-logs.outputs.registry_crawl_todo || '—' }}" \
+            registry_crawl_cancelled="${{ steps.parse-logs.outputs.registry_crawl_cancelled || '—' }}" \
+            warning_count="${{ steps.parse-logs.outputs.warning_count || '0' }}" \
+            error_count="${{ steps.parse-logs.outputs.error_count || '0' }}" \
+            unsupported_ecosystem_group_count="${{ steps.parse-logs.outputs.unsupported_ecosystem_group_count || '0' }}" \
+            unsupported_ecosystem_purl_count="${{ steps.parse-logs.outputs.unsupported_ecosystem_purl_count || '0' }}" \
+            unsupported_ecosystems="${{ steps.parse-logs.outputs.unsupported_ecosystems || 'None' }}" \
+            error_detail="${{ steps.parse-logs.outputs.errors || '' }}" \
+            warning_detail="${{ steps.parse-logs.outputs.warnings || '' }}" \
+            >> "$GITHUB_STEP_SUMMARY"
 
   metrics:
     runs-on: ubuntu-latest
+    if: always()
     needs:
       - crawl
       - deps-dev
@@ -142,60 +212,26 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen
 
-      - name: Write bootstrap summary
-        env:
-          WARN_CRAWL: ${{ needs.crawl.outputs.warning_count || '0' }}
-          WARN_DEPS: ${{ needs.deps-dev.outputs.warning_count || '0' }}
-          WARN_REG: ${{ needs.registries.outputs.warning_count || '0' }}
-          ERR_CRAWL: ${{ needs.crawl.outputs.error_count || '0' }}
-          ERR_DEPS: ${{ needs.deps-dev.outputs.error_count || '0' }}
-          ERR_REG: ${{ needs.registries.outputs.error_count || '0' }}
-        run: |
-          warning_total=$((WARN_CRAWL + WARN_DEPS + WARN_REG))
-          error_total=$((ERR_CRAWL + ERR_DEPS + ERR_REG))
-
-          python .github/scripts/render-template.py \
-            .github/templates/bootstrap-summary.md \
-            trigger="${{ github.event_name }}" \
-            run_id="${{ github.run_id }}" \
-            server_url="${{ github.server_url }}" \
-            repository="${{ github.repository }}" \
-            finished="$(date -u '+%Y-%m-%d %H:%M:%S UTC')" \
-            opengrants_succeeded="${{ needs.crawl.outputs.opengrants_succeeded || '—' }}" \
-            opengrants_failed="${{ needs.crawl.outputs.opengrants_failed || '—' }}" \
-            opengrants_todo="${{ needs.crawl.outputs.opengrants_todo || '—' }}" \
-            opengrants_cancelled="${{ needs.crawl.outputs.opengrants_cancelled || '—' }}" \
-            package_deps_succeeded="${{ needs.deps-dev.outputs.package_deps_succeeded || '—' }}" \
-            package_deps_failed="${{ needs.deps-dev.outputs.package_deps_failed || '—' }}" \
-            package_deps_todo="${{ needs.deps-dev.outputs.package_deps_todo || '—' }}" \
-            package_deps_cancelled="${{ needs.deps-dev.outputs.package_deps_cancelled || '—' }}" \
-            registry_crawl_succeeded="${{ needs.registries.outputs.registry_crawl_succeeded || '—' }}" \
-            registry_crawl_failed="${{ needs.registries.outputs.registry_crawl_failed || '—' }}" \
-            registry_crawl_todo="${{ needs.registries.outputs.registry_crawl_todo || '—' }}" \
-            registry_crawl_cancelled="${{ needs.registries.outputs.registry_crawl_cancelled || '—' }}" \
-            warning_count="$warning_total" \
-            error_count="$error_total" \
-            unsupported_ecosystem_group_count="${{ needs.registries.outputs.unsupported_ecosystem_group_count || '0' }}" \
-            unsupported_ecosystem_purl_count="${{ needs.registries.outputs.unsupported_ecosystem_purl_count || '0' }}" \
-            unsupported_ecosystems="${{ needs.registries.outputs.unsupported_ecosystems || 'None' }}" \
-            error_detail="${{ needs.crawl.outputs.errors || '' }}${{ needs.deps-dev.outputs.errors || '' }}${{ needs.registries.outputs.errors || '' }}" \
-            >> "$GITHUB_STEP_SUMMARY"
-
       - name: Materialize criticality
+        if: always()
         run: uv run python -m pg_atlas.metrics.materialize_criticality --tee=criticality.log
 
       - name: Parse criticality logs
         id: parse-criticality
+        if: always()
         run: python .github/scripts/parse-materialize-criticality-log.py criticality.log
 
       - name: Materialize adoption
+        if: always()
         run: uv run python -m pg_atlas.metrics.materialize_adoption --tee=adoption.log
 
       - name: Parse adoption logs
         id: parse-adoption
+        if: always()
         run: python .github/scripts/parse-materialize-adoption-log.py adoption.log
 
       - name: Write job summary
+        if: always()
         run: |
           python .github/scripts/render-template.py \
             .github/templates/bootstrap-metrics-summary.md \

--- a/.github/workflows/gitlog-queue.yml
+++ b/.github/workflows/gitlog-queue.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   process-gitlog:
     runs-on: ubuntu-latest
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       PG_ATLAS_DATABASE_URL: ${{ secrets.DATABASE_URL }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -44,6 +44,7 @@ jobs:
         run: uv run python -m pg_atlas.procrastinate.seed_gitlog
 
       - name: Run worker — gitlog queue
+        timeout-minutes: 320
         run: uv run python -m pg_atlas.procrastinate.worker --queue=gitlog --drain-rounds=2 --concurrency=6 --tee=gitlog-worker.log
         env:
           PG_ATLAS_ARTIFACT_S3_ENDPOINT: https://s3.filebase.com
@@ -51,17 +52,21 @@ jobs:
           PG_ATLAS_FILEBASE_SECRET_KEY: ${{ secrets.FILEBASE_SECRET_KEY }}
 
       - name: Materialize pony factor
+        if: always()
         run: uv run python -m pg_atlas.metrics.materialize_pony --latest-seed-run --tee=pony.log
 
       - name: Parse worker logs
         id: parse-logs
+        if: always()
         run: python .github/scripts/parse-gitlog-log.py gitlog-worker.log gh-auth-status.log
 
       - name: Parse pony factor logs
         id: parse-pony
+        if: always()
         run: python .github/scripts/parse-materialize-pony-log.py pony.log
 
       - name: Write job summary
+        if: always()
         run: |
           python .github/scripts/render-template.py \
             .github/templates/gitlog-queue-summary.md \
@@ -81,6 +86,7 @@ jobs:
             terminal_failures_marked_private="${{ steps.parse-logs.outputs.terminal_failures_marked_private || 'none' }}" \
             gh_auth_status="${{ steps.parse-logs.outputs.gh_auth_status || 'Unavailable' }}" \
             error_detail="${{ steps.parse-logs.outputs.errors || '' }}" \
+            warning_detail="${{ steps.parse-logs.outputs.warnings || '' }}" \
             pony_repo_rows_updated="${{ steps.parse-pony.outputs.pony_repo_rows_updated || '—' }}" \
             pony_project_rows_updated="${{ steps.parse-pony.outputs.pony_project_rows_updated || '—' }}" \
             pony_resolved_seed_run_ordinal="${{ steps.parse-pony.outputs.pony_resolved_seed_run_ordinal || '—' }}" \

--- a/.github/workflows/sbom-queue.yml
+++ b/.github/workflows/sbom-queue.yml
@@ -43,13 +43,16 @@ jobs:
 
       - name: Parse worker logs
         id: parse-logs
+        if: always()
         run: python .github/scripts/parse-sbom-log.py sbom-worker.log
 
       - name: Parse criticality logs
         id: parse-criticality
+        if: always()
         run: python .github/scripts/parse-materialize-criticality-log.py criticality.log
 
       - name: Write job summary
+        if: always()
         run: |
           python .github/scripts/render-template.py \
             .github/templates/sbom-queue-summary.md \
@@ -65,6 +68,7 @@ jobs:
             warning_count="${{ steps.parse-logs.outputs.warning_count || '0' }}" \
             error_count="${{ steps.parse-logs.outputs.error_count || '0' }}" \
             error_detail="${{ steps.parse-logs.outputs.errors || '' }}" \
+            warning_detail="${{ steps.parse-logs.outputs.warnings || '' }}" \
             spdx_details="${{ steps.parse-logs.outputs.spdx_details || 'No records details available.' }}" \
             criticality_dep_nodes_seen="${{ steps.parse-criticality.outputs.criticality_dep_nodes_seen || '—' }}" \
             criticality_active_nodes_scored="${{ steps.parse-criticality.outputs.criticality_active_nodes_scored || '—' }}" \

--- a/pg_atlas/crawlers/base.py
+++ b/pg_atlas/crawlers/base.py
@@ -66,7 +66,6 @@ class CrawledPackage:
     latest_version: str
     repo_url: str | None
     downloads_30d: int | None
-    stars: int | None
     metadata: dict[str, Any]
     dependencies: list[CrawledDependency]
     releases: list[Release]

--- a/pg_atlas/crawlers/packagist.py
+++ b/pg_atlas/crawlers/packagist.py
@@ -181,7 +181,6 @@ class PackagistCrawler(RegistryCrawler):
             latest_version=latest_version,
             repo_url=repo_url,
             downloads_30d=monthly,
-            stars=None,
             metadata=metadata,
             dependencies=dependencies,
             releases=releases,

--- a/pg_atlas/crawlers/pubdev.py
+++ b/pg_atlas/crawlers/pubdev.py
@@ -215,7 +215,6 @@ class PubDevCrawler(RegistryCrawler):
             latest_version=version,
             repo_url=repo_url,
             downloads_30d=downloads_30d,
-            stars=None,
             metadata=metadata,
             dependencies=dependencies,
             releases=releases,

--- a/pg_atlas/metrics/adoption.py
+++ b/pg_atlas/metrics/adoption.py
@@ -21,13 +21,11 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Final
 
+import numpy as np
 from pydantic import StrictInt, TypeAdapter, ValidationError
-
-from pg_atlas.metrics.criticality import compute_percentile_ranks
 
 PERCENTILE_QUANTUM = Decimal("0.01")
 ADOPTION_DOWNLOADS_BY_PURL_KEY = "adoption_downloads_by_purl"
@@ -36,25 +34,52 @@ _DOWNLOADS_BY_PURL_ADAPTER: Final[TypeAdapter[dict[str, int]]] = TypeAdapter(dic
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Percentile ranking (vectorised, columnar)
+# ---------------------------------------------------------------------------
+
+
+def compute_percentile_ranks(values: np.ndarray) -> np.ndarray:
+    """
+    Convert raw scores to percentile ranks within [0.0, 100.0).
+
+    Vectorised via ``np.searchsorted``:
+
+        sorted  = sort(values)
+        ranks   = searchsorted(sorted, values)   # count of scores < this score
+        pctiles = ranks / n * 100.0
+
+    Properties:
+        - Minimum score  → 0th percentile (rank = 0).
+        - Maximum score  → (n-1)/n * 100 < 100 (no element is top-ranked).
+        - Ties           → all tied values receive the same (lowest) percentile.
+        - Single element → 0th percentile.
+        - Empty input    → empty output.
+
+    Ecological intent: avoids the illusion that any single package is
+    unconditionally "top-ranked" — the ecosystem is always the reference frame.
+    """
+
+    if values.size == 0:
+        return np.empty(0, dtype=np.float64)
+
+    sorted_values = np.sort(values)
+    ranks = np.searchsorted(sorted_values, values).astype(np.float64)
+
+    return ranks / len(values) * 100.0
+
+
+# ---------------------------------------------------------------------------
+# Score quantization
+# ---------------------------------------------------------------------------
+
+
 def _quantize_score(value: Decimal) -> Decimal:
     """
     Quantize one adoption score to two decimal places.
     """
 
     return value.quantize(PERCENTILE_QUANTUM, rounding=ROUND_HALF_UP)
-
-
-@dataclass(frozen=True)
-class RepoAdoptionSignals:
-    """
-    Snapshot the adoption signal columns needed for one repo-level computation.
-    """
-
-    canonical_id: str
-    project_id: int | None
-    adoption_downloads: int | None = None
-    adoption_stars: int | None = None
-    adoption_forks: int | None = None
 
 
 def aggregate_repo_downloads(
@@ -127,41 +152,58 @@ def merge_download_into_repo_metadata(
     return metadata
 
 
-def compute_repo_adoption_composites(repos: Sequence[RepoAdoptionSignals]) -> dict[str, Decimal]:
+def compute_repo_adoption_composites(
+    canonical_ids: Sequence[str],
+    downloads: Sequence[int | None],
+    stars: Sequence[int | None],
+    forks: Sequence[int | None],
+) -> dict[str, Decimal]:
     """
-    Compute transient repo-level adoption composites from available signals.
+    Compute transient repo-level adoption composites from columnar signal arrays.
 
-    The ranking domain is all provided ``Repo`` rows. Missing signal values are
-    excluded from that signal's percentile pool rather than coerced to ``0``.
+    The ranking domain is all provided rows. Missing signal values (``None``)
+    are excluded from that signal's percentile pool rather than coerced to ``0``.
     Repos with no available signals are omitted from the result.
     """
 
-    downloads = compute_percentile_ranks(
-        {repo.canonical_id: repo.adoption_downloads for repo in repos if repo.adoption_downloads is not None}
-    )
-    stars = compute_percentile_ranks(
-        {repo.canonical_id: repo.adoption_stars for repo in repos if repo.adoption_stars is not None}
-    )
-    forks = compute_percentile_ranks(
-        {repo.canonical_id: repo.adoption_forks for repo in repos if repo.adoption_forks is not None}
-    )
+    n = len(canonical_ids)
+    dl_mask = np.array([v is not None for v in downloads], dtype=np.bool_)
+    st_mask = np.array([v is not None for v in stars], dtype=np.bool_)
+    fk_mask = np.array([v is not None for v in forks], dtype=np.bool_)
+
+    # Percentile arrays — NaN for rows not in pool, float for pool members.
+    dl_pctiles = np.full(n, np.nan, dtype=np.float64)
+    st_pctiles = np.full(n, np.nan, dtype=np.float64)
+    fk_pctiles = np.full(n, np.nan, dtype=np.float64)
+
+    if dl_mask.any():
+        dl_pctiles[dl_mask] = compute_percentile_ranks(np.array([v for v in downloads if v is not None], dtype=np.float64))
+
+    if st_mask.any():
+        st_pctiles[st_mask] = compute_percentile_ranks(np.array([v for v in stars if v is not None], dtype=np.float64))
+
+    if fk_mask.any():
+        fk_pctiles[fk_mask] = compute_percentile_ranks(np.array([v for v in forks if v is not None], dtype=np.float64))
+
+    signal_stack = np.column_stack([dl_pctiles, st_pctiles, fk_pctiles])
 
     composites: dict[str, Decimal] = {}
-    for repo in repos:
-        signal_percentiles: list[Decimal] = []
-        for signal_scores in (downloads, stars, forks):
-            percentile = signal_scores.get(repo.canonical_id)
-            if percentile is not None:
-                signal_percentiles.append(_quantize_score(Decimal(str(percentile))))
+    for i in range(n):
+        row = signal_stack[i]
+        valid = row[~np.isnan(row)]
+        if valid.size == 0:
+            continue
 
-        if signal_percentiles:
-            composites[repo.canonical_id] = _quantize_score(sum(signal_percentiles) / Decimal(len(signal_percentiles)))
+        mean_val: float = valid.sum() / valid.size
+        mean = _quantize_score(Decimal(str(mean_val)))
+        composites[canonical_ids[i]] = mean
 
     return composites
 
 
 def compute_project_adoption_scores(
-    repos: Sequence[RepoAdoptionSignals],
+    project_ids: Sequence[int | None],
+    canonical_ids: Sequence[str],
     repo_composites: Mapping[str, Decimal],
 ) -> dict[int, Decimal]:
     """
@@ -172,14 +214,15 @@ def compute_project_adoption_scores(
     """
 
     project_values: dict[int, list[Decimal]] = {}
-    for repo in repos:
-        if repo.project_id is None:
+    for i, cid in enumerate(canonical_ids):
+        pid = project_ids[i]
+        if pid is None:
             continue
 
-        composite = repo_composites.get(repo.canonical_id)
+        composite = repo_composites.get(cid)
         if composite is None:
             continue
 
-        project_values.setdefault(repo.project_id, []).append(composite)
+        project_values.setdefault(pid, []).append(composite)
 
-    return {project_id: _quantize_score(sum(values) / Decimal(len(values))) for project_id, values in project_values.items()}
+    return {pid: _quantize_score(sum(values) / Decimal(len(values))) for pid, values in project_values.items()}

--- a/pg_atlas/metrics/criticality.py
+++ b/pg_atlas/metrics/criticality.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import logging
 
 import networkx as nx
-import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -81,52 +80,3 @@ def compute_criticality(G_active: nx.DiGraph[str]) -> dict[str, int]:
         f"compute_criticality: scored {len(criticality)} nodes; max={max(criticality.values(), default=0)}, nonzero={nonzero}"
     )
     return criticality
-
-
-def compute_percentile_ranks(
-    scores: dict[str, int | float],
-    ranking_nodes: set[str] | None = None,
-) -> dict[str, float]:
-    """
-    Convert raw scores to percentile ranks within [0.0, 100.0).
-
-    Uses numpy searchsorted (exclusive / left-side rank):
-        rank        = searchsorted(sorted_scores, score)   # 0-based count of scores < this score
-        percentile  = rank / n * 100.0
-
-    Parameters:
-        scores: raw scores keyed by canonical_id.
-        ranking_nodes: when provided, restrict the ranking reference distribution
-            and result to this node set (e.g., only ``project_type="public-good"``
-            Repos). Pass ``None`` to rank all nodes (default).
-
-    Properties:
-        - Minimum score  -> 0th percentile (rank = 0).
-        - Maximum score  -> (n-1)/n * 100 < 100 (no node is universally top-ranked).
-        - Ties           -> all tied values receive the same (lowest) percentile.
-        - Single element -> 0th percentile.
-
-    Ecological intent: avoids the illusion that any single package is
-    unconditionally "top-ranked" — the ecosystem is always the reference frame.
-    Consistent with scipy.stats.percentileofscore(kind="weak") minus 100 ceiling.
-
-    Returns:
-        dict[canonical_id, float] — all values in [0.0, 100.0).
-        Empty dict when scores is empty.
-    """
-    if ranking_nodes is not None:
-        scores = {k: v for k, v in scores.items() if k in ranking_nodes}
-
-    if not scores:
-        return {}
-
-    all_scores = np.array(list(scores.values()), dtype=np.float64)
-    sorted_scores = np.sort(all_scores)
-    n = len(sorted_scores)
-
-    percentiles: dict[str, float] = {}
-    for node, score in scores.items():
-        rank = int(np.searchsorted(sorted_scores, float(score)))
-        percentiles[node] = rank / n * 100.0
-
-    return percentiles

--- a/pg_atlas/metrics/materialize_adoption.py
+++ b/pg_atlas/metrics/materialize_adoption.py
@@ -5,7 +5,8 @@ This module computes transient repo-level adoption composites from existing
 stars, forks, and downloads columns, then materializes ``Project.adoption_score``
 as the mean of child repo composites.
 
-The core helper mutates the provided SQLAlchemy session but does not commit.
+All writeback is via bulk DML (``session.execute(update(…), …)``). The session
+identity map is never mutated; no ``flush()`` is issued.
 
 Usage::
 
@@ -24,8 +25,9 @@ import logging
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, NamedTuple
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from pg_atlas.db_models.project import Project
@@ -33,7 +35,6 @@ from pg_atlas.db_models.repo_vertex import Repo
 from pg_atlas.db_models.session import get_session_factory
 from pg_atlas.instruments.tee import run_with_tee
 from pg_atlas.metrics.adoption import (
-    RepoAdoptionSignals,
     aggregate_repo_downloads,
     compute_project_adoption_scores,
     compute_repo_adoption_composites,
@@ -55,7 +56,6 @@ class AdoptionMaterializationStats:
 
     repos_seen: int
     repo_composites_computed: int
-    projects_seen: int
     projects_scored: int
     duration_seconds: float
 
@@ -64,44 +64,106 @@ async def materialize_adoption_scores(session: AsyncSession) -> AdoptionMaterial
     """
     Recompute and persist project adoption scores within one session.
 
-    The session is mutated and flushed, but not committed.
-    Projects with no child repo composites are materialized back to ``NULL`` so
-    stale values are cleared.
+    All writes use bulk DML; the ORM identity map is untouched.
+    Projects with no child repo composites are cleared to ``NULL`` via a
+    ``WHERE NOT IN`` set-based update so stale values are removed.
     """
 
     started_at = time.perf_counter()
 
-    repos = (await session.execute(select(Repo).order_by(Repo.id))).scalars().all()
-    repo_snapshots: list[RepoAdoptionSignals] = []
-    for repo in repos:
-        downloads_by_purl = downloads_by_purl_from_metadata(repo.repo_metadata, repo_canonical_id=repo.canonical_id)
-        aggregated_downloads = aggregate_repo_downloads(downloads_by_purl)
-        repo.adoption_downloads = aggregated_downloads
+    class RepoAdoptionRow(NamedTuple):
+        id: int
+        canonical_id: str
+        project_id: int | None
+        adoption_downloads: int | None
+        adoption_stars: int | None
+        adoption_forks: int | None
+        metadata: dict[str, Any] | None
 
-        repo_snapshots.append(
-            RepoAdoptionSignals(
-                canonical_id=repo.canonical_id,
-                project_id=repo.project_id,
-                adoption_downloads=aggregated_downloads,
-                adoption_stars=repo.adoption_stars,
-                adoption_forks=repo.adoption_forks,
-            )
+    # --- raw columnar load (no ORM instances) ---
+    rows = (
+        await session.execute(
+            select(
+                Repo.id,
+                Repo.canonical_id,
+                Repo.project_id,
+                Repo.adoption_downloads,
+                Repo.adoption_stars,
+                Repo.adoption_forks,
+                Repo.repo_metadata,
+            ).order_by(Repo.id)
         )
+    ).all()
 
-    repo_composites = compute_repo_adoption_composites(repo_snapshots)
-    project_scores = compute_project_adoption_scores(repo_snapshots, repo_composites)
+    # column lists
+    ids: list[int] = []
+    canonical_ids: list[str] = []
+    project_ids: list[int | None] = []
+    downloads: list[int | None] = []
+    stars: list[int | None] = []
+    forks: list[int | None] = []
 
-    projects = (await session.execute(select(Project).order_by(Project.id))).scalars().all()
-    for project in projects:
-        project.adoption_score = project_scores.get(project.id)
+    # bulk update plan
+    download_updates: list[dict[str, int | None]] = []
 
-    await session.flush()
+    # --- transpose rows to columns and plan updates ---
+    repo_rows = (RepoAdoptionRow(*row) for row in rows)
+    for row in repo_rows:
+        ids.append(row.id)
+        canonical_ids.append(row.canonical_id)
+        project_ids.append(row.project_id)
+        by_purl: dict[str, int] | None = downloads_by_purl_from_metadata(row.metadata, repo_canonical_id=row.canonical_id)
+        total_downloads: int | None = aggregate_repo_downloads(by_purl)
+        downloads.append(total_downloads)
+        stars.append(row.adoption_stars)
+        forks.append(row.adoption_forks)
+
+        if total_downloads != row.adoption_downloads:
+            download_updates.append({"id": row.id, "adoption_downloads": total_downloads})
+
+    # sanity check to ensure equal-length columns
+    expected_len = len(rows)
+    assert all(len(col) == expected_len for col in (ids, canonical_ids, project_ids, downloads, stars, forks)), (
+        "Transposition failed: one or more columns do not match the input row count."
+    )
+
+    # --- bulk-persist download sums (only changed rows) ---
+    if download_updates:
+        await session.execute(update(Repo), download_updates)
+
+    # --- compute composites and project scores ---
+    repo_composites = compute_repo_adoption_composites(canonical_ids, downloads, stars, forks)
+    project_scores = compute_project_adoption_scores(project_ids, canonical_ids, repo_composites)
+
+    # --- bulk-update scored projects ---
+    if project_scores:
+        project_updates = [{"id": pid, "adoption_score": score} for pid, score in project_scores.items()]
+        await session.execute(update(Project), project_updates)
+
+    # --- null-out stale unscored projects ---
+    scored_ids = set(project_scores.keys())
+    if scored_ids:
+        stale_stmt = (
+            update(Project)
+            .where(Project.id.not_in(scored_ids))
+            .where(Project.adoption_score.is_not(None))
+            .values(adoption_score=None)
+            .execution_options(synchronize_session=False)
+        )
+        await session.execute(stale_stmt)
+    else:
+        stale_stmt = (
+            update(Project)
+            .where(Project.adoption_score.is_not(None))
+            .values(adoption_score=None)
+            .execution_options(synchronize_session=False)
+        )
+        await session.execute(stale_stmt)
 
     duration_seconds = time.perf_counter() - started_at
     stats = AdoptionMaterializationStats(
-        repos_seen=len(repos),
+        repos_seen=len(rows),
         repo_composites_computed=len(repo_composites),
-        projects_seen=len(projects),
         projects_scored=len(project_scores),
         duration_seconds=duration_seconds,
     )
@@ -110,7 +172,6 @@ async def materialize_adoption_scores(session: AsyncSession) -> AdoptionMaterial
         "materialize_adoption_scores: "
         f"repos_seen={stats.repos_seen} "
         f"repo_composites_computed={stats.repo_composites_computed} "
-        f"projects_seen={stats.projects_seen} "
         f"projects_scored={stats.projects_scored} "
         f"duration_seconds={stats.duration_seconds:.3f}"
     )
@@ -132,7 +193,6 @@ async def main() -> None:
         "project adoption materialization finished: "
         f"repos_seen={stats.repos_seen} "
         f"repo_composites_computed={stats.repo_composites_computed} "
-        f"projects_seen={stats.projects_seen} "
         f"projects_scored={stats.projects_scored} "
         f"duration_seconds={stats.duration_seconds:.3f}"
     )

--- a/pg_atlas/metrics/materialize_criticality.py
+++ b/pg_atlas/metrics/materialize_criticality.py
@@ -1,12 +1,12 @@
 """
 A9 criticality materialization for repo-resolution dependency graphs.
 
-This module turns the already-merged A6 and A9 in-memory metric functions into
+This module turns the A6 and A9 in-memory metric functions into
 an offline persistence pass:
 
 1. Load the repo-resolution dependency graph from PostgreSQL.
-2. Project the active ecosystem with A6.
-3. Compute repo/external criticality with A9.
+2. Project the active ecosystem (A6).
+3. Compute repo/external criticality (A9).
 4. Materialize dep-layer scores back onto ORM rows.
 5. Aggregate project scores from child repos.
 
@@ -68,7 +68,8 @@ async def materialize_criticality_scores(session: AsyncSession) -> CriticalityMa
     """
     Recompute and persist A9 criticality scores within one session.
 
-    The session is mutated and flushed, but not committed.
+    All writes use bulk DML; the ORM identity map is untouched. No ``flush()``
+    is issued.
 
     Behavior:
     - Repo and ExternalRepo rows are always materialized to an integer score.
@@ -86,20 +87,22 @@ async def materialize_criticality_scores(session: AsyncSession) -> CriticalityMa
     active_graph = project_active_subgraph(dependency_graph)
     active_scores = compute_criticality(active_graph)
 
-    repos = (await session.execute(select(Repo))).scalars().all()
-    external_repos = (await session.execute(select(ExternalRepo))).scalars().all()
-    project_rows_updated = await session.scalar(select(func.count(Project.id))) or 0
+    # --- columnar load: id + canonical_id only ---
+    repo_rows = (await session.execute(select(Repo.id, Repo.canonical_id))).all()
+    ext_rows = (await session.execute(select(ExternalRepo.id, ExternalRepo.canonical_id))).all()
+    dep_nodes_seen = len(repo_rows) + len(ext_rows)
 
-    dep_nodes_seen = len(repos) + len(external_repos)
+    # --- bulk update Repo criticality scores ---
+    repo_updates = [{"id": rid, "criticality_score": active_scores.get(cid, 0)} for rid, cid in repo_rows]
+    if repo_updates:
+        await session.execute(update(Repo), repo_updates)
 
-    for repo in repos:
-        repo.criticality_score = active_scores.get(repo.canonical_id, 0)
+    # --- bulk update ExternalRepo criticality scores ---
+    ext_updates = [{"id": rid, "criticality_score": active_scores.get(cid, 0)} for rid, cid in ext_rows]
+    if ext_updates:
+        await session.execute(update(ExternalRepo), ext_updates)
 
-    for external_repo in external_repos:
-        external_repo.criticality_score = active_scores.get(external_repo.canonical_id, 0)
-
-    await session.flush()
-
+    # --- set-based Project aggregation (sum of child Repo scores) ---
     project_score_subquery = (
         select(
             Repo.project_id.label("project_id"),
@@ -123,18 +126,15 @@ async def materialize_criticality_scores(session: AsyncSession) -> CriticalityMa
     )
     await session.execute(project_update)
 
-    # Keep already-loaded Project rows usable inside the current AsyncSession.
-    await session.execute(select(Project).execution_options(populate_existing=True))
-
-    await session.flush()
+    project_rows_updated = await session.scalar(select(func.count(Project.id))) or 0
 
     duration_seconds = time.perf_counter() - started_at
 
     stats = CriticalityMaterializationStats(
         dep_nodes_seen=dep_nodes_seen,
         active_dep_nodes_scored=len(active_scores),
-        repo_rows_updated=len(repos),
-        external_repo_rows_updated=len(external_repos),
+        repo_rows_updated=len(repo_rows),
+        external_repo_rows_updated=len(ext_rows),
         project_rows_updated=project_rows_updated,
         duration_seconds=duration_seconds,
     )

--- a/pg_atlas/metrics/materialize_criticality.py
+++ b/pg_atlas/metrics/materialize_criticality.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from sqlalchemy import func, select, update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from pg_atlas.db_models.project import Project
@@ -87,18 +88,28 @@ async def materialize_criticality_scores(session: AsyncSession) -> CriticalityMa
     active_graph = project_active_subgraph(dependency_graph)
     active_scores = compute_criticality(active_graph)
 
-    # --- columnar load: id + canonical_id only ---
-    repo_rows = (await session.execute(select(Repo.id, Repo.canonical_id))).all()
-    ext_rows = (await session.execute(select(ExternalRepo.id, ExternalRepo.canonical_id))).all()
+    # --- columnar load: id + canonical_id + current score (for diff-filtering) ---
+    repo_rows = (await session.execute(select(Repo.id, Repo.canonical_id, Repo.criticality_score))).all()
+    ext_rows = (
+        await session.execute(select(ExternalRepo.id, ExternalRepo.canonical_id, ExternalRepo.criticality_score))
+    ).all()
     dep_nodes_seen = len(repo_rows) + len(ext_rows)
 
-    # --- bulk update Repo criticality scores ---
-    repo_updates = [{"id": rid, "criticality_score": active_scores.get(cid, 0)} for rid, cid in repo_rows]
+    # --- bulk update Repo criticality scores (skip rows where score is unchanged) ---
+    repo_updates = [
+        {"id": rid, "criticality_score": active_scores.get(cid, 0)}
+        for rid, cid, current_score in repo_rows
+        if current_score != active_scores.get(cid, 0)
+    ]
     if repo_updates:
         await session.execute(update(Repo), repo_updates)
 
-    # --- bulk update ExternalRepo criticality scores ---
-    ext_updates = [{"id": rid, "criticality_score": active_scores.get(cid, 0)} for rid, cid in ext_rows]
+    # --- bulk update ExternalRepo criticality scores (skip rows where score is unchanged) ---
+    ext_updates = [
+        {"id": rid, "criticality_score": active_scores.get(cid, 0)}
+        for rid, cid, current_score in ext_rows
+        if current_score != active_scores.get(cid, 0)
+    ]
     if ext_updates:
         await session.execute(update(ExternalRepo), ext_updates)
 
@@ -124,17 +135,17 @@ async def materialize_criticality_scores(session: AsyncSession) -> CriticalityMa
         )
         .execution_options(synchronize_session=False)
     )
-    await session.execute(project_update)
-
-    project_rows_updated = await session.scalar(select(func.count(Project.id))) or 0
+    project_result = await session.execute(project_update)
+    assert isinstance(project_result, CursorResult)
+    project_rows_updated = project_result.rowcount
 
     duration_seconds = time.perf_counter() - started_at
 
     stats = CriticalityMaterializationStats(
         dep_nodes_seen=dep_nodes_seen,
         active_dep_nodes_scored=len(active_scores),
-        repo_rows_updated=len(repo_rows),
-        external_repo_rows_updated=len(ext_rows),
+        repo_rows_updated=len(repo_updates),
+        external_repo_rows_updated=len(ext_updates),
         project_rows_updated=project_rows_updated,
         duration_seconds=duration_seconds,
     )

--- a/pg_atlas/metrics/materialize_pony.py
+++ b/pg_atlas/metrics/materialize_pony.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from pg_atlas.db_models.contributed_to import ContributedTo
@@ -153,19 +153,19 @@ async def _load_project_repo_membership(
     *,
     full_recompute: bool,
     target_repo_ids: list[int],
-) -> tuple[list[Project], dict[int, list[int]]]:
+) -> tuple[list[int], dict[int, list[int]]]:
     """
-    Return affected projects and their child repo ids.
+    Return affected project ids and their child repo id membership.
     """
 
     if full_recompute:
-        projects = list((await session.execute(select(Project).order_by(Project.id))).scalars().all())
+        project_ids = [int(pid) for pid in (await session.execute(select(Project.id).order_by(Project.id))).scalars().all()]
         membership_rows = (await session.execute(select(Repo.id, Repo.project_id).where(Repo.project_id.is_not(None)))).all()
     else:
         if not target_repo_ids:
             return [], {}
 
-        project_ids = (
+        affected_project_ids_raw = (
             (
                 await session.execute(
                     select(Repo.project_id)
@@ -178,17 +178,12 @@ async def _load_project_repo_membership(
             .scalars()
             .all()
         )
-        affected_project_ids = [int(project_id) for project_id in project_ids if project_id is not None]
-        if not affected_project_ids:
+        project_ids = [int(pid) for pid in affected_project_ids_raw if pid is not None]
+        if not project_ids:
             return [], {}
 
-        projects = list(
-            (await session.execute(select(Project).where(Project.id.in_(affected_project_ids)).order_by(Project.id)))
-            .scalars()
-            .all()
-        )
         membership_rows = (
-            await session.execute(select(Repo.id, Repo.project_id).where(Repo.project_id.in_(affected_project_ids)))
+            await session.execute(select(Repo.id, Repo.project_id).where(Repo.project_id.in_(project_ids)))
         ).all()
 
     repos_by_project: defaultdict[int, list[int]] = defaultdict(list)
@@ -198,7 +193,7 @@ async def _load_project_repo_membership(
 
         repos_by_project[int(project_id)].append(int(repo_id))
 
-    return projects, dict(repos_by_project)
+    return project_ids, dict(repos_by_project)
 
 
 async def materialize_pony_factor_scores(
@@ -210,7 +205,7 @@ async def materialize_pony_factor_scores(
     """
     Recompute and persist pony factor on Repo and Project rows within one session.
 
-    The session is mutated and flushed, but not committed.
+    All writes use bulk DML; the ORM identity map is untouched. No ``flush()`` is issued.
     """
 
     if latest_seed_run and seed_run_ordinal is not None:
@@ -224,15 +219,19 @@ async def materialize_pony_factor_scores(
         seed_run_ordinal=seed_run_ordinal,
     )
 
-    target_repos = list(
-        (await session.execute(select(Repo).where(Repo.id.in_(target_repo_ids)).order_by(Repo.id))).scalars().all()
-    )
+    # --- compute repo pony factors (no ORM load) ---
     repo_counts = await _load_repo_email_commit_counts(session, target_repo_ids)
-    for repo in target_repos:
-        counts_by_email = repo_counts.get(repo.id, {})
-        repo.pony_factor = compute_pony_factor(counts_by_email.values())
+    repo_updates: list[dict[str, int]] = []
+    for repo_id in target_repo_ids:
+        counts_by_email = repo_counts.get(repo_id, {})
+        repo_pony = compute_pony_factor(counts_by_email.values())
+        repo_updates.append({"id": repo_id, "pony_factor": repo_pony})
 
-    projects, repos_by_project = await _load_project_repo_membership(
+    if repo_updates:
+        await session.execute(update(Repo), repo_updates)
+
+    # --- compute project pony factors ---
+    project_ids, repos_by_project = await _load_project_repo_membership(
         session,
         full_recompute=full_recompute,
         target_repo_ids=target_repo_ids,
@@ -240,10 +239,11 @@ async def materialize_pony_factor_scores(
     project_repo_ids = sorted({repo_id for repo_ids in repos_by_project.values() for repo_id in repo_ids})
     project_repo_counts = await _load_repo_email_commit_counts(session, project_repo_ids)
 
-    for project in projects:
-        repo_ids = repos_by_project.get(project.id, [])
+    project_updates: list[dict[str, int | None]] = []
+    for pid in project_ids:
+        repo_ids = repos_by_project.get(pid, [])
         if not repo_ids:
-            project.pony_factor = None
+            project_updates.append({"id": pid, "pony_factor": None})
             continue
 
         project_counts_by_email: defaultdict[str, int] = defaultdict(int)
@@ -251,14 +251,26 @@ async def materialize_pony_factor_scores(
             for email_hash, commit_count in project_repo_counts.get(repo_id, {}).items():
                 project_counts_by_email[email_hash] += commit_count
 
-        project.pony_factor = compute_pony_factor(project_counts_by_email.values())
+        project_updates.append({"id": pid, "pony_factor": compute_pony_factor(project_counts_by_email.values())})
 
-    await session.flush()
+    if project_updates:
+        await session.execute(update(Project), project_updates)
+
+    # --- null-out stale repos on full recompute ---
+    if full_recompute and target_repo_ids:
+        stale_repo_stmt = (
+            update(Repo)
+            .where(Repo.id.not_in(target_repo_ids))
+            .where(Repo.pony_factor.is_not(None))
+            .values(pony_factor=None)
+            .execution_options(synchronize_session=False)
+        )
+        await session.execute(stale_repo_stmt)
 
     duration_seconds = time.perf_counter() - started_at
     stats = PonyFactorMaterializationStats(
-        repo_rows_updated=len(target_repos),
-        project_rows_updated=len(projects),
+        repo_rows_updated=len(repo_updates),
+        project_rows_updated=len(project_updates),
         resolved_seed_run_ordinal=resolved_seed_run_ordinal,
         duration_seconds=duration_seconds,
     )

--- a/pg_atlas/metrics/materialize_pony.py
+++ b/pg_atlas/metrics/materialize_pony.py
@@ -221,11 +221,20 @@ async def materialize_pony_factor_scores(
 
     # --- compute repo pony factors (no ORM load) ---
     repo_counts = await _load_repo_email_commit_counts(session, target_repo_ids)
+
+    # Load current values so we only UPDATE rows where the score has changed,
+    # reducing row lock pressure when the DB is under concurrent write load.
+    current_repo_pony: dict[int, int | None] = {}
+    if target_repo_ids:
+        current_repo_pony_stmt = select(Repo.id, Repo.pony_factor).where(Repo.id.in_(target_repo_ids))
+        current_repo_pony = {int(rid): val for rid, val in (await session.execute(current_repo_pony_stmt)).all()}
+
     repo_updates: list[dict[str, int]] = []
     for repo_id in target_repo_ids:
         counts_by_email = repo_counts.get(repo_id, {})
         repo_pony = compute_pony_factor(counts_by_email.values())
-        repo_updates.append({"id": repo_id, "pony_factor": repo_pony})
+        if current_repo_pony.get(repo_id) != repo_pony:
+            repo_updates.append({"id": repo_id, "pony_factor": repo_pony})
 
     if repo_updates:
         await session.execute(update(Repo), repo_updates)
@@ -239,33 +248,30 @@ async def materialize_pony_factor_scores(
     project_repo_ids = sorted({repo_id for repo_ids in repos_by_project.values() for repo_id in repo_ids})
     project_repo_counts = await _load_repo_email_commit_counts(session, project_repo_ids)
 
+    current_proj_pony: dict[int, int | None] = {}
+    if project_ids:
+        current_proj_pony_stmt = select(Project.id, Project.pony_factor).where(Project.id.in_(project_ids))
+        current_proj_pony = {int(pid): val for pid, val in (await session.execute(current_proj_pony_stmt)).all()}
+
     project_updates: list[dict[str, int | None]] = []
     for pid in project_ids:
         repo_ids = repos_by_project.get(pid, [])
+
         if not repo_ids:
-            project_updates.append({"id": pid, "pony_factor": None})
-            continue
+            new_pony: int | None = None
+        else:
+            project_counts_by_email: defaultdict[str, int] = defaultdict(int)
+            for repo_id in repo_ids:
+                for email_hash, commit_count in project_repo_counts.get(repo_id, {}).items():
+                    project_counts_by_email[email_hash] += commit_count
 
-        project_counts_by_email: defaultdict[str, int] = defaultdict(int)
-        for repo_id in repo_ids:
-            for email_hash, commit_count in project_repo_counts.get(repo_id, {}).items():
-                project_counts_by_email[email_hash] += commit_count
+            new_pony = compute_pony_factor(project_counts_by_email.values())
 
-        project_updates.append({"id": pid, "pony_factor": compute_pony_factor(project_counts_by_email.values())})
+        if current_proj_pony.get(pid) != new_pony:
+            project_updates.append({"id": pid, "pony_factor": new_pony})
 
     if project_updates:
         await session.execute(update(Project), project_updates)
-
-    # --- null-out stale repos on full recompute ---
-    if full_recompute and target_repo_ids:
-        stale_repo_stmt = (
-            update(Repo)
-            .where(Repo.id.not_in(target_repo_ids))
-            .where(Repo.pony_factor.is_not(None))
-            .values(pony_factor=None)
-            .execution_options(synchronize_session=False)
-        )
-        await session.execute(stale_repo_stmt)
 
     duration_seconds = time.perf_counter() - started_at
     stats = PonyFactorMaterializationStats(

--- a/tests/crawlers/test_db_integration.py
+++ b/tests/crawlers/test_db_integration.py
@@ -134,7 +134,6 @@ def _make_package(
         latest_version="1.0.0",
         repo_url=repo_url,
         downloads_30d=downloads_30d,
-        stars=None,
         metadata={},
         dependencies=dependencies or [],
         releases=[],

--- a/tests/crawlers/test_packagist.py
+++ b/tests/crawlers/test_packagist.py
@@ -108,7 +108,6 @@ async def test_fetch_package_parses_stats(
     pkg = await crawler.fetch_package("soneso/stellar-php-sdk")
 
     assert pkg.downloads_30d == 1970  # monthly (last 30 days per spec)
-    assert pkg.stars is None  # reserved for GitHub
     assert pkg.metadata["downloads_total"] == 46925
     assert pkg.metadata["download_count_30d"] == 1970
     assert pkg.metadata["downloads_daily"] == 68

--- a/tests/crawlers/test_pubdev.py
+++ b/tests/crawlers/test_pubdev.py
@@ -101,9 +101,8 @@ async def test_fetch_package_parses_scores_and_downloads(
     crawler = _make_crawler(mock_http_client)
     pkg = await crawler.fetch_package("stellar_flutter_sdk")
 
-    # adoption_downloads = last 30 days; adoption_stars reserved for GitHub
+    # adoption_downloads = last 30 days
     assert pkg.downloads_30d == 1469
-    assert pkg.stars is None
 
     assert pkg.metadata["pub_points"] == 140
     assert pkg.metadata["pub_points_max"] == 160
@@ -180,7 +179,6 @@ async def test_fetch_package_metrics_failure(
     assert pkg.latest_version == "1.8.6"
     assert len(pkg.dependencies) > 0
     assert pkg.downloads_30d is None  # no metrics data available
-    assert pkg.stars is None
 
 
 async def test_fetch_package_handles_missing_fields(

--- a/tests/github_scripts/test_parse_worker_logs.py
+++ b/tests/github_scripts/test_parse_worker_logs.py
@@ -18,6 +18,7 @@ Queue opengrants final status counts: todo=0 doing=0 succeeded=5 failed=0 cancel
 2026-07-17 10:06:00,456 WARNING  task: Something odd happened
 Queue package-deps final status counts: todo=1 doing=0 succeeded=3 failed=1 cancelled=0 aborted=0
 Queue registry-crawl final status counts: todo=0 doing=0 succeeded=2 failed=0 cancelled=0 aborted=0
+2026-07-17 10:06:01,005 WARNING  task: another blemish
 2026-07-17 10:06:01,456 WARNING  task: registry-crawl unsupported ecosystem: system=CARGO purls=pkg:cargo/org/a pkg:cargo/org/b
 2026-07-17 10:07:00,789 ERROR    task: Critical failure
 """
@@ -42,10 +43,10 @@ Queue registry-crawl final status counts: todo=0 doing=0 succeeded=2 failed=0 ca
     assert "opengrants_succeeded=5" in stdout
     assert "package_deps_failed=1" in stdout
     assert "registry_crawl_succeeded=2" in stdout
-    assert "warning_count=1" in stdout
+    assert "warning_count=2" in stdout
     assert "error_count=1" in stdout
-    assert "warnings=Something odd happened" in stdout
-    assert "errors=Critical failure" in stdout
+    assert "warnings<<EOF\n\n* Something odd happened\n* another blemish\nEOF" in stdout
+    assert "errors<<EOF\n\n* Critical failure\nEOF" in stdout
     assert "unsupported_ecosystem_group_count=1" in stdout
     assert "unsupported_ecosystem_purl_count=2" in stdout
     assert "- CARGO (2): pkg:cargo/org/a pkg:cargo/org/b" in stdout

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -1,0 +1,53 @@
+"""
+Shared helpers for metrics tests.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+__all__ = ["_make_flush_guard"]
+
+
+def _make_flush_guard(session: AsyncSession) -> tuple[AsyncMock, Callable[[], None]]:
+    """
+    Patch ``session.flush`` to raise if called, and return (mock, teardown).
+    """
+
+    original_flush = session.flush
+    mock = AsyncMock(side_effect=AssertionError("flush() must not be called by bulk-DML materializers"))
+    session.flush = mock  # type: ignore[assignment]
+
+    def _restore() -> None:
+        session.flush = original_flush  # type: ignore[assignment]
+
+    return mock, _restore
+
+
+@pytest.fixture
+def assert_no_uow(db_session: AsyncSession) -> Callable[[AsyncSession], None]:
+    """
+    Return a callable that asserts no ORM Unit-of-Work mutations occurred.
+
+    Usage in test::
+
+        await materialize_foo(session)
+        assert_no_uow(session)
+
+    Checks:
+    1. ``session.dirty`` is empty (no tracked attribute mutations).
+    2. ``session.new`` is empty (no pending inserts from ORM add).
+    """
+
+    def _check(session: AsyncSession) -> None:
+        assert not session.dirty, f"session.dirty is not empty: {session.dirty}"
+        assert not session.new, f"session.new is not empty: {session.new}"
+
+    return _check

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -32,7 +32,7 @@ def _make_flush_guard(session: AsyncSession) -> tuple[AsyncMock, Callable[[], No
 
 
 @pytest.fixture
-def assert_no_uow(db_session: AsyncSession) -> Callable[[AsyncSession], None]:
+def assert_no_uow() -> Callable[[AsyncSession], None]:
     """
     Return a callable that asserts no ORM Unit-of-Work mutations occurred.
 

--- a/tests/metrics/test_materialize_adoption.py
+++ b/tests/metrics/test_materialize_adoption.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from decimal import Decimal
+from typing import Callable
 from uuid import uuid4
 
 import pytest
@@ -19,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from pg_atlas.db_models import Project, Repo
 from pg_atlas.db_models.base import ActivityStatus, ProjectType, Visibility
 from pg_atlas.metrics.materialize_adoption import AdoptionMaterializationStats, materialize_adoption_scores
+from tests.metrics.conftest import _make_flush_guard
 
 
 @dataclass(frozen=True)
@@ -230,11 +232,11 @@ async def test_materialize_adoption_scores_persists_project_scores(
     seeded = await _seed_adoption_fixture(rollback_db_session)
 
     stats = await materialize_adoption_scores(rollback_db_session)
+    rollback_db_session.expire_all()
 
     assert isinstance(stats, AdoptionMaterializationStats)
     assert stats.repos_seen >= 5
     assert stats.repo_composites_computed >= 3
-    assert stats.projects_seen >= 4
     assert stats.projects_scored >= 2
 
     project_a = await _get_project(rollback_db_session, seeded.project_a_id)
@@ -258,6 +260,7 @@ async def test_materialize_adoption_scores_is_idempotent(
     seeded = await _seed_adoption_fixture(rollback_db_session)
 
     await materialize_adoption_scores(rollback_db_session)
+    rollback_db_session.expire_all()
     project_a = await _get_project(rollback_db_session, seeded.project_a_id)
     project_b = await _get_project(rollback_db_session, seeded.project_b_id)
     project_c = await _get_project(rollback_db_session, seeded.project_c_id)
@@ -269,6 +272,7 @@ async def test_materialize_adoption_scores_is_idempotent(
     assert empty_project.adoption_score is None
 
     await materialize_adoption_scores(rollback_db_session)
+    rollback_db_session.expire_all()
     project_a = await _get_project(rollback_db_session, seeded.project_a_id)
     project_b = await _get_project(rollback_db_session, seeded.project_b_id)
     project_c = await _get_project(rollback_db_session, seeded.project_c_id)
@@ -290,11 +294,34 @@ async def test_materialize_adoption_scores_updates_repo_downloads_from_metadata(
     seeded = await _seed_monorepo_download_fixture(rollback_db_session)
 
     await materialize_adoption_scores(rollback_db_session)
+    rollback_db_session.expire_all()
     repo = await rollback_db_session.get(Repo, seeded.repo_id)
     assert repo is not None
     assert repo.adoption_downloads == 300
 
     await materialize_adoption_scores(rollback_db_session)
+    rollback_db_session.expire_all()
     repo = await rollback_db_session.get(Repo, seeded.repo_id)
     assert repo is not None
     assert repo.adoption_downloads == 300
+
+
+async def test_materialize_adoption_scores_does_not_use_uow(
+    rollback_db_session: AsyncSession, assert_no_uow: Callable[[AsyncSession], None]
+) -> None:
+    """
+    Adoption materialization must use bulk DML only — no ORM UoW dirty-tracking or flush.
+    """
+
+    await _seed_adoption_fixture(rollback_db_session)
+    await rollback_db_session.flush()
+    rollback_db_session.expire_all()
+
+    flush_mock, restore_flush = _make_flush_guard(rollback_db_session)
+    try:
+        await materialize_adoption_scores(rollback_db_session)
+    finally:
+        restore_flush()
+
+    flush_mock.assert_not_called()
+    assert_no_uow(rollback_db_session)

--- a/tests/metrics/test_materialize_criticality.py
+++ b/tests/metrics/test_materialize_criticality.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
+from typing import Callable
 from uuid import uuid4
 
 import pytest
@@ -21,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from pg_atlas.db_models import DependsOn, ExternalRepo, Project, Repo
 from pg_atlas.db_models.base import ActivityStatus, EdgeConfidence, ProjectType, Visibility
 from pg_atlas.metrics.materialize_criticality import CriticalityMaterializationStats, materialize_criticality_scores
+from tests.metrics.conftest import _make_flush_guard
 
 
 @dataclass(frozen=True)
@@ -217,6 +219,7 @@ async def test_materialize_criticality_scores_persists_repo_external_and_project
     seeded = await _seed_disconnected_component(rollback_db_session)
 
     stats = await materialize_criticality_scores(rollback_db_session)
+    rollback_db_session.expire_all()
 
     assert isinstance(stats, CriticalityMaterializationStats)
     assert stats.repo_rows_updated >= 4
@@ -270,6 +273,7 @@ async def test_materialize_criticality_scores_is_idempotent(
     seeded = await _seed_disconnected_component(rollback_db_session)
 
     await materialize_criticality_scores(rollback_db_session)
+    rollback_db_session.expire_all()
     leaf_repo = await _get_repo(rollback_db_session, seeded.leaf_repo_id)
     core_repo = await _get_repo(rollback_db_session, seeded.core_repo_id)
     zero_repo = await _get_repo(rollback_db_session, seeded.zero_repo_id)
@@ -295,6 +299,7 @@ async def test_materialize_criticality_scores_is_idempotent(
     )
 
     await materialize_criticality_scores(rollback_db_session)
+    rollback_db_session.expire_all()
     leaf_repo = await _get_repo(rollback_db_session, seeded.leaf_repo_id)
     core_repo = await _get_repo(rollback_db_session, seeded.core_repo_id)
     zero_repo = await _get_repo(rollback_db_session, seeded.zero_repo_id)
@@ -320,3 +325,24 @@ async def test_materialize_criticality_scores_is_idempotent(
     )
 
     assert first_scores == second_scores
+
+
+async def test_materialize_criticality_scores_does_not_use_uow(
+    rollback_db_session: AsyncSession, assert_no_uow: Callable[[AsyncSession], None]
+) -> None:
+    """
+    Criticality materialization must use bulk DML only — no ORM UoW dirty-tracking or flush.
+    """
+
+    await _seed_disconnected_component(rollback_db_session)
+    await rollback_db_session.flush()
+    rollback_db_session.expire_all()
+
+    flush_mock, restore_flush = _make_flush_guard(rollback_db_session)
+    try:
+        await materialize_criticality_scores(rollback_db_session)
+    finally:
+        restore_flush()
+
+    flush_mock.assert_not_called()
+    assert_no_uow(rollback_db_session)

--- a/tests/metrics/test_materialize_pony.py
+++ b/tests/metrics/test_materialize_pony.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import datetime as dt
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
+from typing import Callable
 from uuid import uuid4
 
 import pytest
@@ -20,6 +21,7 @@ from pg_atlas.db_models import ContributedTo, Contributor, GitLogArtifact, Proje
 from pg_atlas.db_models.base import ActivityStatus, ProjectType, SubmissionStatus, Visibility
 from pg_atlas.gitlog.parser import hash_email
 from pg_atlas.metrics.materialize_pony import PonyFactorMaterializationStats, materialize_pony_factor_scores
+from tests.metrics.conftest import _make_flush_guard
 
 
 @dataclass(frozen=True)
@@ -284,6 +286,7 @@ async def test_materialize_pony_factor_scores_persists_repo_and_project_scores(
     seeded = await _seed_pony_component(rollback_db_session)
 
     stats = await materialize_pony_factor_scores(rollback_db_session)
+    rollback_db_session.expire_all()
 
     assert isinstance(stats, PonyFactorMaterializationStats)
     assert stats.resolved_seed_run_ordinal is None
@@ -321,7 +324,9 @@ async def test_materialize_pony_factor_scores_is_idempotent(
     seeded = await _seed_pony_component(rollback_db_session)
 
     first_stats = await materialize_pony_factor_scores(rollback_db_session)
+    rollback_db_session.expire_all()
     second_stats = await materialize_pony_factor_scores(rollback_db_session)
+    rollback_db_session.expire_all()
 
     assert first_stats.repo_rows_updated == second_stats.repo_rows_updated
     assert first_stats.project_rows_updated == second_stats.project_rows_updated
@@ -342,6 +347,7 @@ async def test_materialize_pony_factor_scores_latest_seed_run_limits_updates(
     seeded = await _seed_pony_component(rollback_db_session)
 
     stats = await materialize_pony_factor_scores(rollback_db_session, latest_seed_run=True)
+    rollback_db_session.expire_all()
 
     assert stats.resolved_seed_run_ordinal == seeded.seed_run_ordinal_upper
     assert stats.repo_rows_updated == 1
@@ -374,6 +380,7 @@ async def test_materialize_pony_factor_scores_explicit_seed_run_recomputes_affec
     seeded = await _seed_pony_component(rollback_db_session)
 
     stats = await materialize_pony_factor_scores(rollback_db_session, seed_run_ordinal=seeded.seed_run_ordinal_lower)
+    rollback_db_session.expire_all()
 
     assert stats.resolved_seed_run_ordinal == seeded.seed_run_ordinal_lower
     assert stats.repo_rows_updated == 2
@@ -394,3 +401,24 @@ async def test_materialize_pony_factor_scores_explicit_seed_run_recomputes_affec
     assert alpha_project.pony_factor == 2
     assert beta_project.pony_factor == 99
     assert gamma_project.pony_factor == 0
+
+
+async def test_materialize_pony_factor_scores_does_not_use_uow(
+    rollback_db_session: AsyncSession, assert_no_uow: Callable[[AsyncSession], None]
+) -> None:
+    """
+    Pony-factor materialization must use bulk DML only — no ORM UoW dirty-tracking or flush.
+    """
+
+    await _seed_pony_component(rollback_db_session)
+    await rollback_db_session.flush()
+    rollback_db_session.expire_all()
+
+    flush_mock, restore_flush = _make_flush_guard(rollback_db_session)
+    try:
+        await materialize_pony_factor_scores(rollback_db_session)
+    finally:
+        restore_flush()
+
+    flush_mock.assert_not_called()
+    assert_no_uow(rollback_db_session)

--- a/tests/metrics/test_materialize_pony.py
+++ b/tests/metrics/test_materialize_pony.py
@@ -328,8 +328,11 @@ async def test_materialize_pony_factor_scores_is_idempotent(
     second_stats = await materialize_pony_factor_scores(rollback_db_session)
     rollback_db_session.expire_all()
 
-    assert first_stats.repo_rows_updated == second_stats.repo_rows_updated
-    assert first_stats.project_rows_updated == second_stats.project_rows_updated
+    assert first_stats.repo_rows_updated > 0
+    assert first_stats.project_rows_updated > 0
+    # On the second pass all values are already current — diff-filter produces zero updates.
+    assert second_stats.repo_rows_updated == 0
+    assert second_stats.project_rows_updated == 0
 
     alpha_project = await _get_project(rollback_db_session, seeded.alpha_project_id)
     gamma_project = await _get_project(rollback_db_session, seeded.gamma_project_id)

--- a/tests/metrics/test_metrics_adoption.py
+++ b/tests/metrics/test_metrics_adoption.py
@@ -9,15 +9,60 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+import numpy as np
 import pytest
 
 from pg_atlas.metrics.adoption import (
-    RepoAdoptionSignals,
     aggregate_repo_downloads,
+    compute_percentile_ranks,
     compute_project_adoption_scores,
     compute_repo_adoption_composites,
     downloads_by_purl_from_metadata,
 )
+
+# ---------------------------------------------------------------------------
+# compute_percentile_ranks (ndarray → ndarray)
+# ---------------------------------------------------------------------------
+
+
+def test_percentile_min_is_zero() -> None:
+    pcts = compute_percentile_ranks(np.array([0, 5, 10], dtype=np.float64))
+    assert pcts[0] == 0.0
+
+
+def test_percentile_max_less_than_100() -> None:
+    pcts = compute_percentile_ranks(np.array([0, 5, 10], dtype=np.float64))
+    assert all(v < 100.0 for v in pcts)
+
+
+def test_percentile_single_element_is_zero() -> None:
+    pcts = compute_percentile_ranks(np.array([42], dtype=np.float64))
+    assert pcts[0] == 0.0
+
+
+def test_percentile_all_same_is_zero() -> None:
+    pcts = compute_percentile_ranks(np.array([5, 5, 5], dtype=np.float64))
+    assert all(v == 0.0 for v in pcts)
+
+
+def test_percentile_ascending_for_distinct_scores() -> None:
+    pcts = compute_percentile_ranks(np.array([1, 5, 10], dtype=np.float64))
+    assert pcts[0] < pcts[1] < pcts[2]
+
+
+def test_percentile_values_in_range() -> None:
+    pcts = compute_percentile_ranks(np.arange(10, dtype=np.float64))
+    assert all(0.0 <= v < 100.0 for v in pcts)
+
+
+def test_percentile_empty_returns_empty() -> None:
+    pcts = compute_percentile_ranks(np.empty(0, dtype=np.float64))
+    assert pcts.size == 0
+
+
+# ---------------------------------------------------------------------------
+# compute_repo_adoption_composites (columnar)
+# ---------------------------------------------------------------------------
 
 
 def test_compute_repo_adoption_composites_uses_percentiles_and_excludes_nulls() -> None:
@@ -25,14 +70,12 @@ def test_compute_repo_adoption_composites_uses_percentiles_and_excludes_nulls() 
     Repo composites should average only the available signal percentiles.
     """
 
-    repos = [
-        RepoAdoptionSignals(canonical_id="repo-a1", project_id=1, adoption_stars=10, adoption_forks=2),
-        RepoAdoptionSignals(canonical_id="repo-a2", project_id=1, adoption_stars=20, adoption_downloads=100),
-        RepoAdoptionSignals(canonical_id="repo-b1", project_id=2, adoption_forks=6, adoption_downloads=300),
-        RepoAdoptionSignals(canonical_id="repo-c1", project_id=3),
-    ]
-
-    composites = compute_repo_adoption_composites(repos)
+    composites = compute_repo_adoption_composites(
+        canonical_ids=["repo-a1", "repo-a2", "repo-b1", "repo-c1"],
+        downloads=[None, 100, 300, None],
+        stars=[10, 20, None, None],
+        forks=[2, None, 6, None],
+    )
 
     assert composites == {
         "repo-a1": Decimal("0.00"),
@@ -46,13 +89,12 @@ def test_compute_repo_adoption_composites_gives_ties_the_same_percentile() -> No
     Tied signal values should receive the same percentile rank.
     """
 
-    repos = [
-        RepoAdoptionSignals(canonical_id="repo-a", project_id=1, adoption_stars=10),
-        RepoAdoptionSignals(canonical_id="repo-b", project_id=1, adoption_stars=10),
-        RepoAdoptionSignals(canonical_id="repo-c", project_id=1, adoption_stars=20),
-    ]
-
-    composites = compute_repo_adoption_composites(repos)
+    composites = compute_repo_adoption_composites(
+        canonical_ids=["repo-a", "repo-b", "repo-c"],
+        downloads=[None, None, None],
+        stars=[10, 10, 20],
+        forks=[None, None, None],
+    )
 
     assert composites["repo-a"] == Decimal("0.00")
     assert composites["repo-b"] == Decimal("0.00")
@@ -64,13 +106,6 @@ def test_compute_project_adoption_scores_averages_child_repo_composites_only() -
     Project scores should ignore repos without composites and orphan repos.
     """
 
-    repos = [
-        RepoAdoptionSignals(canonical_id="repo-a1", project_id=1),
-        RepoAdoptionSignals(canonical_id="repo-a2", project_id=1),
-        RepoAdoptionSignals(canonical_id="repo-b1", project_id=2),
-        RepoAdoptionSignals(canonical_id="repo-c1", project_id=3),
-        RepoAdoptionSignals(canonical_id="orphan", project_id=None),
-    ]
     repo_composites = {
         "repo-a1": Decimal("0.00"),
         "repo-a2": Decimal("25.00"),
@@ -78,7 +113,11 @@ def test_compute_project_adoption_scores_averages_child_repo_composites_only() -
         "orphan": Decimal("75.00"),
     }
 
-    project_scores = compute_project_adoption_scores(repos, repo_composites)
+    project_scores = compute_project_adoption_scores(
+        project_ids=[1, 1, 2, 3, None],
+        canonical_ids=["repo-a1", "repo-a2", "repo-b1", "repo-c1", "orphan"],
+        repo_composites=repo_composites,
+    )
 
     assert project_scores == {
         1: Decimal("12.50"),
@@ -96,20 +135,12 @@ def test_compute_repo_adoption_composites_uses_materialized_download_sum() -> No
     assert repo_a_downloads == 120
     assert repo_b_downloads == 80
 
-    repos = [
-        RepoAdoptionSignals(
-            canonical_id="repo-a",
-            project_id=1,
-            adoption_downloads=repo_a_downloads,
-        ),
-        RepoAdoptionSignals(
-            canonical_id="repo-b",
-            project_id=1,
-            adoption_downloads=repo_b_downloads,
-        ),
-    ]
-
-    composites = compute_repo_adoption_composites(repos)
+    composites = compute_repo_adoption_composites(
+        canonical_ids=["repo-a", "repo-b"],
+        downloads=[repo_a_downloads, repo_b_downloads],
+        stars=[None, None],
+        forks=[None, None],
+    )
 
     assert composites["repo-a"] == Decimal("50.00")
     assert composites["repo-b"] == Decimal("0.00")

--- a/tests/metrics/test_metrics_criticality.py
+++ b/tests/metrics/test_metrics_criticality.py
@@ -9,14 +9,14 @@ from __future__ import annotations
 
 import networkx as nx
 
-from pg_atlas.metrics.criticality import compute_criticality, compute_percentile_ranks
+from pg_atlas.metrics.criticality import compute_criticality
 
 
-def _repo() -> dict:
+def _repo() -> dict[str, str]:
     return {"vertex_type": "Repo"}
 
 
-def _ext() -> dict:
+def _ext() -> dict[str, str]:
     return {"vertex_type": "ExternalRepo"}
 
 
@@ -30,7 +30,7 @@ def test_chain_a_depends_b_depends_c():
     A -> B -> C (A depends on B, B depends on C).
     Chain invariant: C.criticality=2, B.criticality=1, A.criticality=0.
     """
-    G = nx.DiGraph()
+    G: nx.DiGraph[str] = nx.DiGraph()
     G.add_node("A", **_repo())
     G.add_node("B", **_repo())
     G.add_node("C", **_ext())
@@ -44,7 +44,7 @@ def test_chain_a_depends_b_depends_c():
 
 def test_direct_dependency_only():
     """A -> B: B.criticality=1, A.criticality=0."""
-    G = nx.DiGraph()
+    G: nx.DiGraph[str] = nx.DiGraph()
     G.add_node("A", **_repo())
     G.add_node("B", **_ext())
     G.add_edge("A", "B")
@@ -60,7 +60,7 @@ def test_direct_dependency_only():
 
 def test_star_hub_criticality():
     """Hub depended on by n leaves -> hub.criticality = n."""
-    G = nx.DiGraph()
+    G: nx.DiGraph[str] = nx.DiGraph()
     G.add_node("hub", **_ext())
     leaves = [f"leaf_{i}" for i in range(4)]
     for leaf in leaves:
@@ -73,7 +73,7 @@ def test_star_hub_criticality():
 
 
 def test_disconnected_components_scored_independently():
-    G = nx.DiGraph()
+    G: nx.DiGraph[str] = nx.DiGraph()
     G.add_node("A", **_repo())
     G.add_node("B", **_ext())
     G.add_node("X", **_repo())
@@ -88,7 +88,7 @@ def test_disconnected_components_scored_independently():
 
 
 def test_isolated_node_has_zero_criticality():
-    G = nx.DiGraph()
+    G: nx.DiGraph[str] = nx.DiGraph()
     G.add_node("alone", **_ext())
     scores = compute_criticality(G)
     assert scores["alone"] == 0
@@ -101,7 +101,7 @@ def test_isolated_node_has_zero_criticality():
 
 def test_all_graph_members_count_toward_criticality():
     """All nodes in the active subgraph count toward criticality — graph membership is sufficient."""
-    G = nx.DiGraph()
+    G: nx.DiGraph[str] = nx.DiGraph()
     G.add_node("dep_a", **_repo())
     G.add_node("dep_b", **_repo())
     G.add_node("lib", **_ext())
@@ -122,58 +122,7 @@ def test_empty_graph_returns_empty():
 
 def test_no_dep_layer_nodes_returns_empty():
     """Graphs with only Project/Contributor nodes have no dep-layer nodes."""
-    G = nx.DiGraph()
+    G: nx.DiGraph[str] = nx.DiGraph()
     G.add_node("P", vertex_type="Project")
     G.add_node("C", vertex_type="Contributor")
     assert compute_criticality(G) == {}
-
-
-# ---------------------------------------------------------------------------
-# compute_percentile_ranks
-# ---------------------------------------------------------------------------
-
-
-def test_percentile_min_is_zero():
-    pcts = compute_percentile_ranks({"A": 0, "B": 5, "C": 10})
-    assert pcts["A"] == 0.0
-
-
-def test_percentile_max_less_than_100():
-    pcts = compute_percentile_ranks({"A": 0, "B": 5, "C": 10})
-    assert all(v < 100.0 for v in pcts.values())
-
-
-def test_percentile_single_element_is_zero():
-    pcts = compute_percentile_ranks({"X": 42})
-    assert pcts["X"] == 0.0
-
-
-def test_percentile_all_same_is_zero():
-    pcts = compute_percentile_ranks({"A": 5, "B": 5, "C": 5})
-    assert all(v == 0.0 for v in pcts.values())
-
-
-def test_percentile_ascending_for_distinct_scores():
-    pcts = compute_percentile_ranks({"low": 1, "mid": 5, "high": 10})
-    assert pcts["low"] < pcts["mid"] < pcts["high"]
-
-
-def test_percentile_values_in_range():
-    scores = {str(i): i for i in range(10)}
-    pcts = compute_percentile_ranks(scores)
-    assert all(0.0 <= v < 100.0 for v in pcts.values())
-
-
-def test_percentile_empty_returns_empty():
-    assert compute_percentile_ranks({}) == {}
-
-
-def test_percentile_ranking_nodes_restricts_result():
-    """ranking_nodes limits both the reference distribution and the result set."""
-    scores = {"a": 10, "b": 5, "c": 1}
-    pool = {"a", "b"}
-    pcts = compute_percentile_ranks(scores, ranking_nodes=pool)
-    assert set(pcts.keys()) == pool
-    # within the pool: "b" < "a", so "b" is 0th percentile
-    assert pcts["b"] == 0.0
-    assert pcts["a"] > 0.0


### PR DESCRIPTION
Run one-by-one in a controlled environment, the metrics could each be materialized. In a full bootstrap run, however, with gitlog and SBOM ingestion/processing running outside of the control of the bootstrap orchestrator, I was seeing row locking issues and generally degraded DB performance.

This PR is conservative about what to load from the DB, which conversions to do in Python, and especially what to write back into entire DB tables. It's not completely minimalist, but this should cause fewer problems already.