### PR TITLE
feat(crawlers): add NPM, Cargo, and PyPI registry crawlers

### DIFF
--- a/.github/agent-handoff/implementation-notes.md
+++ b/.github/agent-handoff/implementation-notes.md
@@ -269,6 +269,19 @@ These conventions emerged during A10 adoption-signal wiring and apply to future 
   semantics, but the crawler calls the endpoint through `_request_with_retry()` because the package
   wrapper does not expose the `mirrors` argument on `recent()`.
 
+### Msgspec payload decoding pattern
+
+- Registry crawler JSON responses are decoded immediately from response bytes using
+  `msgspec.json.decode(response.content, type=<TypedPayloadStruct>)`.
+- Each endpoint has a dedicated private typed payload model (`msgspec.Struct`) with
+  `forbid_unknown_fields=False` and defaults for optional fields.
+- Decoding is payload-level best effort: catch `msgspec.ValidationError`, log a warning, and
+  continue with a default payload object instead of raising.
+- Numeric normalization happens right after decode (for example `int | float | None` to `int | None`),
+  so downstream crawler logic consumes normalized ints and avoids ad-hoc coercion.
+- Runtime parsing code should read typed model attributes directly; avoid `dict[str, Any]`/
+  `list[object]` JSON walk patterns and avoid `typing.cast`.
+
 ### Monorepo adoption downloads map-reduce
 
 - Registry crawls now persist per-package download snapshots under

--- a/.github/agent-handoff/implementation-notes.md
+++ b/.github/agent-handoff/implementation-notes.md
@@ -260,9 +260,9 @@ These conventions emerged during A10 adoption-signal wiring and apply to future 
 
 ### Registry-specific A10 conventions
 
-- NPM and PyPI intentionally leave reverse dependents empty for now; keep the explicit TODO in the
+- NPM and PyPI intentionally leave dependents empty for now; keep the explicit TODO in the
   crawler implementation until a practical first-party API exists.
-- Cargo reverse dependents paginate with the same 50-page / 500-item ceiling used for Packagist
+- Cargo dependents paginate with the same 50-page / 500-item ceiling used for Packagist
   validation runs.
 - PyPI download totals come from the PyPIStats `recent` endpoint with
   `period=month&mirrors=true`; the `pypistats` package is still the source of truth for endpoint

--- a/.github/agent-handoff/implementation-notes.md
+++ b/.github/agent-handoff/implementation-notes.md
@@ -255,7 +255,19 @@ These conventions emerged during A10 adoption-signal wiring and apply to future 
 
 - `package-deps` (deps.dev) and `registry-crawl` (direct ecosystem registries) are intentionally separate paths.
 - deps.dev scope is fixed to seven systems (`PYPI`, `NPM`, `CARGO`, `MAVEN`, `GO`, `RUBYGEMS`, `NUGET`) and should not be extended in A10 code.
-- Direct registry crawling currently supports `DART` (pub.dev) and `COMPOSER` (Packagist) via `pg_atlas.crawlers.factory`.
+- Direct registry crawling currently supports `DART` (pub.dev), `COMPOSER` (Packagist), `NPM`,
+  `CARGO`, and `PYPI` via `pg_atlas.crawlers.factory`.
+
+### Registry-specific A10 conventions
+
+- NPM and PyPI intentionally leave reverse dependents empty for now; keep the explicit TODO in the
+  crawler implementation until a practical first-party API exists.
+- Cargo reverse dependents paginate with the same 50-page / 500-item ceiling used for Packagist
+  validation runs.
+- PyPI download totals come from the PyPIStats `recent` endpoint with
+  `period=month&mirrors=true`; the `pypistats` package is still the source of truth for endpoint
+  semantics, but the crawler calls the endpoint through `_request_with_retry()` because the package
+  wrapper does not expose the `mirrors` argument on `recent()`.
 
 ### Monorepo adoption downloads map-reduce
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -137,6 +137,9 @@ When you have validated that a deliverable has been completed, update `implement
 - **A8 complete**: SBOM post-validation processing now runs in a dedicated Procrastinate `sbom`
   queue, with parser and semantic-hash hot-path optimizations (`msgspec` +
   `JsonLikeDictParser`) and canonical unwrapped SPDX artifact storage for new submissions.
+- **A9 complete**: Criticality materialization (`pg_atlas/metrics/materialize_criticality.py`)
+  is triggered in bootstrap and sbom-queue, and Pony factor materialization
+  (`pg_atlas/metrics/materialize_pony.py`) is triggered in gitlog-queue.
 - **A10 complete**: Direct registry crawling now supports `NPM`, `CARGO`, and `PYPI` alongside
   `DART` and `COMPOSER`; bootstrap writes per-package download snapshots into
   `Repo.repo_metadata["adoption_downloads_by_purl"]` for later adoption materialization.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -137,6 +137,9 @@ When you have validated that a deliverable has been completed, update `implement
 - **A8 complete**: SBOM post-validation processing now runs in a dedicated Procrastinate `sbom`
   queue, with parser and semantic-hash hot-path optimizations (`msgspec` +
   `JsonLikeDictParser`) and canonical unwrapped SPDX artifact storage for new submissions.
+- **A10 complete**: Direct registry crawling now supports `NPM`, `CARGO`, and `PYPI` alongside
+  `DART` and `COMPOSER`; bootstrap writes per-package download snapshots into
+  `Repo.repo_metadata["adoption_downloads_by_purl"]` for later adoption materialization.
 
 ## Keeping These Instructions Current
 

--- a/pg_atlas/crawlers/__main__.py
+++ b/pg_atlas/crawlers/__main__.py
@@ -28,7 +28,25 @@ logger = logging.getLogger(__name__)
 async def main() -> None:
     """Parse arguments, configure the crawler, and run the crawl."""
     parser = argparse.ArgumentParser(description="PG Atlas registry crawler")
-    parser.add_argument("registry", choices=["pubdev", "packagist", "dart", "composer", "flutter", "php"])
+    parser.add_argument(
+        "registry",
+        choices=[
+            "pubdev",
+            "packagist",
+            "dart",
+            "composer",
+            "flutter",
+            "php",
+            "npm",
+            "node",
+            "nodejs",
+            "cargo",
+            "crates",
+            "cratesio",
+            "pypi",
+            "pip",
+        ],
+    )
     parser.add_argument("packages", nargs="+", help="Package names to crawl")
     args = parser.parse_args()
 

--- a/pg_atlas/crawlers/__main__.py
+++ b/pg_atlas/crawlers/__main__.py
@@ -19,6 +19,7 @@ import logging
 import httpx
 
 from pg_atlas.config import settings
+from pg_atlas.crawlers.base import USER_AGENT
 from pg_atlas.crawlers.factory import build_registry_crawler, normalize_registry_system
 from pg_atlas.db_models.session import get_session_factory
 
@@ -65,7 +66,7 @@ async def main() -> None:
     async with httpx.AsyncClient(
         timeout=httpx.Timeout(settings.CRAWLER_TIMEOUT, connect=10.0),
         follow_redirects=True,
-        headers={"User-Agent": "pg-atlas-crawler/0.1"},
+        headers={"User-Agent": USER_AGENT},
     ) as client:
         crawler = build_registry_crawler(
             normalized_system,

--- a/pg_atlas/crawlers/base.py
+++ b/pg_atlas/crawlers/base.py
@@ -26,6 +26,7 @@ import msgspec
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from pg_atlas.api_metadata import VERSION
 from pg_atlas.db_models.release import Release, merge_releases
 from pg_atlas.db_models.repo_vertex import Repo
 from pg_atlas.db_models.vertex_ops import upsert_external_repo
@@ -34,6 +35,7 @@ from pg_atlas.procrastinate.upserts import find_repo_by_release_purl, upsert_dep
 
 logger = logging.getLogger(__name__)
 
+USER_AGENT = f"pg-atlas-crawler/{VERSION}"
 
 # ---------------------------------------------------------------------------
 # Data classes
@@ -91,6 +93,9 @@ class SourceRepoNotFound(Exception): ...
 
 
 class AllPackagesFailed(Exception): ...
+
+
+class ExhaustedRetries(Exception): ...
 
 
 # ---------------------------------------------------------------------------
@@ -194,7 +199,7 @@ class RegistryCrawler(ABC):
 
         if last_exc is not None:
             raise last_exc
-        raise RuntimeError(f"Exhausted retries for {url}")
+        raise ExhaustedRetries(f"Exhausted retries for {url}")
 
     async def crawl_and_persist(
         self,

--- a/pg_atlas/crawlers/cargo.py
+++ b/pg_atlas/crawlers/cargo.py
@@ -1,0 +1,265 @@
+"""
+crates.io registry crawler for PG Atlas.
+
+Fetches crate metadata, latest-version dependencies, and reverse dependencies
+from crates.io. The 30-day download count uses the issue-defined
+``recent_downloads / 3`` approximation.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+import httpx
+
+from pg_atlas.crawlers.base import CrawledDependency, CrawledDependent, CrawledPackage, RegistryCrawler, as_str_key_dict
+from pg_atlas.db_models.release import Release, preferred_latest_version, sorted_releases_desc
+
+logger = logging.getLogger(__name__)
+
+
+class CargoCrawler(RegistryCrawler):
+    """
+    Crawler for the public crates.io API.
+
+    crates.io asks API consumers to stay at or below one request per second.
+    The default crawler rate limit is already ``1.0``, and this crawler applies
+    that pacing to each crates.io request, not only between packages.
+    """
+
+    REGISTRY = "crates.io"
+    BASE_URL = "https://crates.io/api/v1/crates"
+    MAX_DEPENDENT_PAGES = 50
+    DEPENDENTS_PER_PAGE = 10
+    MAX_DEPENDENTS = 500
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        session_factory: Any,
+        rate_limit: float = 1.0,
+        max_retries: int = 3,
+    ) -> None:
+        super().__init__(
+            client=client,
+            session_factory=session_factory,
+            rate_limit=rate_limit,
+            max_retries=max_retries,
+        )
+        self._next_request_ready_at = 0.0
+
+    async def fetch_package(self, package_name: str) -> CrawledPackage:
+        """Fetch crate metadata plus dependency information for the newest version."""
+
+        metadata_resp = await self._request_with_rate_limit(f"{self.BASE_URL}/{package_name}")
+        metadata: dict[str, Any] = metadata_resp.json()
+
+        crate = as_str_key_dict(metadata.get("crate"))
+        selected_version = _selected_cargo_version(crate)
+        dependency_payload: dict[str, Any] = {}
+        if selected_version:
+            dependency_resp = await self._request_with_rate_limit(
+                f"{self.BASE_URL}/{package_name}/{selected_version}/dependencies"
+            )
+            dependency_payload = dependency_resp.json()
+
+        return self._parse_package(metadata, dependency_payload)
+
+    async def fetch_dependents(self, package_name: str) -> list[CrawledDependent]:
+        """Fetch reverse dependencies from crates.io up to the configured pagination ceiling."""
+
+        dependents_by_canonical_id: dict[str, CrawledDependent] = {}
+
+        for page in range(1, self.MAX_DEPENDENT_PAGES + 1):
+            try:
+                resp = await self._request_with_rate_limit(
+                    f"{self.BASE_URL}/{package_name}/reverse_dependencies?page={page}&per_page={self.DEPENDENTS_PER_PAGE}"
+                )
+            except (httpx.HTTPStatusError, httpx.TimeoutException) as exc:
+                logger.warning(f"Failed to fetch crates.io dependents for {package_name}: {exc}")
+
+                return list(dependents_by_canonical_id.values())
+
+            payload: dict[str, Any] = resp.json()
+            version_crates = _dependent_version_crates(payload)
+            dependencies_obj = payload.get("dependencies")
+            dependencies: list[object] = dependencies_obj if isinstance(dependencies_obj, list) else []
+
+            for dependency_obj in dependencies:
+                dependency = as_str_key_dict(dependency_obj)
+                kind_obj = dependency.get("kind")
+                kind = kind_obj if isinstance(kind_obj, str) else ""
+                if kind and kind != "normal":
+                    continue
+
+                version_id_obj = dependency.get("version_id")
+                if not isinstance(version_id_obj, int):
+                    continue
+
+                dependent_name = version_crates.get(version_id_obj)
+                if not dependent_name or dependent_name == package_name:
+                    continue
+
+                canonical_id = f"pkg:cargo/{dependent_name}"
+                dependents_by_canonical_id.setdefault(
+                    canonical_id,
+                    CrawledDependent(
+                        canonical_id=canonical_id,
+                        display_name=dependent_name,
+                    ),
+                )
+
+                if len(dependents_by_canonical_id) >= self.MAX_DEPENDENTS:
+                    logger.warning(f"Truncated crates.io dependents for {package_name} at {self.MAX_DEPENDENTS}")
+
+                    return list(dependents_by_canonical_id.values())
+
+            meta = as_str_key_dict(payload.get("meta"))
+            total_obj = meta.get("total")
+            total = total_obj if isinstance(total_obj, int) else 0
+            if page * self.DEPENDENTS_PER_PAGE >= total:
+                break
+
+        return list(dependents_by_canonical_id.values())
+
+    async def _request_with_rate_limit(self, url: str) -> httpx.Response:
+        """Apply per-request pacing before delegating to shared retry logic."""
+
+        if self.rate_limit > 0:
+            wait_seconds = self._next_request_ready_at - time.monotonic()
+            if wait_seconds > 0:
+                await asyncio.sleep(wait_seconds)
+
+            self._next_request_ready_at = time.monotonic() + self.rate_limit
+
+        return await self._request_with_retry(url)
+
+    def _parse_package(
+        self,
+        metadata: dict[str, Any],
+        dependency_payload: dict[str, Any],
+    ) -> CrawledPackage:
+        """Parse crates.io metadata into the shared crawler contract."""
+
+        crate = as_str_key_dict(metadata.get("crate"))
+        name_obj = crate.get("name")
+        name = name_obj if isinstance(name_obj, str) else ""
+        package_purl = f"pkg:cargo/{name}"
+
+        releases: list[Release] = []
+        versions_obj = metadata.get("versions")
+        versions: list[object] = versions_obj if isinstance(versions_obj, list) else []
+        for version_obj in versions:
+            version = as_str_key_dict(version_obj)
+            release_version_obj = version.get("num")
+            if not isinstance(release_version_obj, str) or not release_version_obj:
+                continue
+
+            created_at_obj = version.get("created_at")
+            release_date = created_at_obj if isinstance(created_at_obj, str) else ""
+            releases.append(Release(purl=package_purl, version=release_version_obj, release_date=release_date))
+
+        releases = sorted_releases_desc(releases)
+        latest_version = preferred_latest_version(releases) or _selected_cargo_version(crate)
+
+        dependencies: list[CrawledDependency] = []
+        dependencies_obj = dependency_payload.get("dependencies")
+        dependency_rows: list[object] = dependencies_obj if isinstance(dependencies_obj, list) else []
+        for dependency_obj in dependency_rows:
+            dependency = as_str_key_dict(dependency_obj)
+            kind_obj = dependency.get("kind")
+            kind = kind_obj if isinstance(kind_obj, str) else ""
+            if kind and kind != "normal":
+                continue
+
+            dependency_name_obj = dependency.get("crate_id")
+            if not isinstance(dependency_name_obj, str) or not dependency_name_obj:
+                continue
+
+            requirement_obj = dependency.get("req")
+            version_range = requirement_obj if isinstance(requirement_obj, str) else None
+            dependencies.append(
+                CrawledDependency(
+                    canonical_id=f"pkg:cargo/{dependency_name_obj}",
+                    display_name=dependency_name_obj,
+                    version_range=version_range,
+                )
+            )
+
+        downloads_30d = _downloads_30d(crate)
+        package_metadata: dict[str, Any] = {}
+        recent_downloads_obj = crate.get("recent_downloads")
+        if isinstance(recent_downloads_obj, int):
+            package_metadata["recent_downloads_90d"] = recent_downloads_obj
+
+        if downloads_30d is not None:
+            package_metadata["download_count_30d"] = downloads_30d
+
+        repo_url = _cargo_repo_url(crate)
+        return CrawledPackage(
+            canonical_id=package_purl,
+            display_name=name,
+            latest_version=latest_version,
+            repo_url=repo_url,
+            downloads_30d=downloads_30d,
+            metadata=package_metadata,
+            dependencies=dependencies,
+            releases=releases,
+        )
+
+
+def _selected_cargo_version(crate: dict[str, Any]) -> str:
+    """Select the version to query for dependency metadata."""
+
+    stable_version_obj = crate.get("max_stable_version")
+    if isinstance(stable_version_obj, str) and stable_version_obj:
+        return stable_version_obj
+
+    max_version_obj = crate.get("max_version")
+    if isinstance(max_version_obj, str):
+        return max_version_obj
+
+    return ""
+
+
+def _downloads_30d(crate: dict[str, Any]) -> int | None:
+    """Convert crates.io recent downloads (90 days) into the issue-defined 30-day approximation."""
+
+    recent_downloads_obj = crate.get("recent_downloads")
+    if not isinstance(recent_downloads_obj, int):
+        return None
+
+    return recent_downloads_obj // 3
+
+
+def _cargo_repo_url(crate: dict[str, Any]) -> str | None:
+    """Extract the most repository-like URL from crates.io metadata."""
+
+    for key in ("repository", "homepage", "documentation"):
+        value = crate.get(key)
+        if isinstance(value, str) and value:
+            return value
+
+    return None
+
+
+def _dependent_version_crates(payload: dict[str, Any]) -> dict[int, str]:
+    """Build a lookup from version ID to dependent crate name."""
+
+    versions_obj = payload.get("versions")
+    versions: list[object] = versions_obj if isinstance(versions_obj, list) else []
+    version_crates: dict[int, str] = {}
+    for version_obj in versions:
+        version = as_str_key_dict(version_obj)
+        version_id_obj = version.get("id")
+        crate_name_obj = version.get("crate")
+        if isinstance(version_id_obj, int) and isinstance(crate_name_obj, str) and crate_name_obj:
+            version_crates[version_id_obj] = crate_name_obj
+
+    return version_crates

--- a/pg_atlas/crawlers/cargo.py
+++ b/pg_atlas/crawlers/cargo.py
@@ -18,7 +18,14 @@ from typing import Any
 
 import httpx
 
-from pg_atlas.crawlers.base import CrawledDependency, CrawledDependent, CrawledPackage, RegistryCrawler, as_str_key_dict
+from pg_atlas.crawlers.base import (
+    CrawledDependency,
+    CrawledDependent,
+    CrawledPackage,
+    ExhaustedRetries,
+    RegistryCrawler,
+    as_str_key_dict,
+)
 from pg_atlas.db_models.release import Release, preferred_latest_version, sorted_releases_desc
 
 logger = logging.getLogger(__name__)
@@ -81,7 +88,7 @@ class CargoCrawler(RegistryCrawler):
                 resp = await self._request_with_rate_limit(
                     f"{self.BASE_URL}/{package_name}/reverse_dependencies?page={page}&per_page={self.DEPENDENTS_PER_PAGE}"
                 )
-            except (httpx.HTTPStatusError, httpx.TimeoutException) as exc:
+            except (httpx.HTTPStatusError, httpx.TimeoutException, ExhaustedRetries) as exc:
                 logger.warning(f"Failed to fetch crates.io dependents for {package_name}: {exc}")
 
                 return list(dependents_by_canonical_id.values())

--- a/pg_atlas/crawlers/cargo.py
+++ b/pg_atlas/crawlers/cargo.py
@@ -13,10 +13,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import time
 from typing import Any
 
 import httpx
+import msgspec
 
 from pg_atlas.crawlers.base import (
     CrawledDependency,
@@ -24,11 +26,102 @@ from pg_atlas.crawlers.base import (
     CrawledPackage,
     ExhaustedRetries,
     RegistryCrawler,
-    as_str_key_dict,
 )
 from pg_atlas.db_models.release import Release, preferred_latest_version, sorted_releases_desc
 
 logger = logging.getLogger(__name__)
+
+
+class _CargoCratePayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    name: str = ""
+    repository: str | None = None
+    homepage: str | None = None
+    documentation: str | None = None
+    max_stable_version: str = ""
+    max_version: str = ""
+    recent_downloads: int | float | None = None
+
+
+class _CargoVersionPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    num: str = ""
+    created_at: str = ""
+
+
+class _CargoMetadataPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    crate: _CargoCratePayload = msgspec.field(default_factory=_CargoCratePayload)
+    versions: list[_CargoVersionPayload] = msgspec.field(default_factory=list[_CargoVersionPayload])
+
+
+class _CargoDependencyPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    crate_id: str = ""
+    req: str | None = None
+    kind: str = ""
+
+
+class _CargoDependencyListPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    dependencies: list[_CargoDependencyPayload] = msgspec.field(default_factory=list[_CargoDependencyPayload])
+
+
+class _CargoReverseDependencyPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    version_id: int | None = None
+    kind: str = ""
+
+
+class _CargoReverseVersionPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    id: int | None = None
+    crate: str = ""
+
+
+class _CargoReverseMetaPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    total: int = 0
+
+
+class _CargoReverseDependenciesPagePayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    dependencies: list[_CargoReverseDependencyPayload] = msgspec.field(default_factory=list[_CargoReverseDependencyPayload])
+    versions: list[_CargoReverseVersionPayload] = msgspec.field(default_factory=list[_CargoReverseVersionPayload])
+    meta: _CargoReverseMetaPayload = msgspec.field(default_factory=_CargoReverseMetaPayload)
+
+
+def _decode_cargo_metadata_payload(content: bytes, package_name: str) -> _CargoMetadataPayload:
+    try:
+        return msgspec.json.decode(content, type=_CargoMetadataPayload)
+    except msgspec.ValidationError as exc:
+        logger.warning(f"Failed to decode crates.io metadata payload for {package_name}: {exc}")
+
+        return _CargoMetadataPayload()
+
+
+def _decode_cargo_dependency_payload(content: bytes, package_name: str) -> _CargoDependencyListPayload:
+    try:
+        return msgspec.json.decode(content, type=_CargoDependencyListPayload)
+    except msgspec.ValidationError as exc:
+        logger.warning(f"Failed to decode crates.io dependency payload for {package_name}: {exc}")
+
+        return _CargoDependencyListPayload()
+
+
+def _decode_cargo_reverse_dependencies_page(content: bytes, package_name: str) -> _CargoReverseDependenciesPagePayload:
+    try:
+        return msgspec.json.decode(content, type=_CargoReverseDependenciesPagePayload)
+    except msgspec.ValidationError as exc:
+        logger.warning(f"Failed to decode crates.io reverse dependencies payload for {package_name}: {exc}")
+
+        return _CargoReverseDependenciesPagePayload()
+
+
+def _normalize_download_count(value: int | float | None, field_name: str, package_name: str) -> int | None:
+    if value is None:
+        return None
+
+    if isinstance(value, int):
+        return value
+
+    if math.isfinite(value):
+        return int(value)
+
+    logger.warning(f"Ignoring non-numeric {field_name} value for {package_name}: {value}")
+
+    return None
 
 
 class CargoCrawler(RegistryCrawler):
@@ -65,16 +158,15 @@ class CargoCrawler(RegistryCrawler):
         """Fetch crate metadata plus dependency information for the newest version."""
 
         metadata_resp = await self._request_with_rate_limit(f"{self.BASE_URL}/{package_name}")
-        metadata: dict[str, Any] = metadata_resp.json()
+        metadata = _decode_cargo_metadata_payload(metadata_resp.content, package_name)
 
-        crate = as_str_key_dict(metadata.get("crate"))
-        selected_version = _selected_cargo_version(crate)
-        dependency_payload: dict[str, Any] = {}
+        selected_version = _selected_cargo_version(metadata.crate)
+        dependency_payload = _CargoDependencyListPayload()
         if selected_version:
             dependency_resp = await self._request_with_rate_limit(
                 f"{self.BASE_URL}/{package_name}/{selected_version}/dependencies"
             )
-            dependency_payload = dependency_resp.json()
+            dependency_payload = _decode_cargo_dependency_payload(dependency_resp.content, package_name)
 
         return self._parse_package(metadata, dependency_payload)
 
@@ -93,23 +185,19 @@ class CargoCrawler(RegistryCrawler):
 
                 return list(dependents_by_canonical_id.values())
 
-            payload: dict[str, Any] = resp.json()
+            payload = _decode_cargo_reverse_dependencies_page(resp.content, package_name)
             version_crates = _dependent_version_crates(payload)
-            dependencies_obj = payload.get("dependencies")
-            dependencies: list[object] = dependencies_obj if isinstance(dependencies_obj, list) else []
 
-            for dependency_obj in dependencies:
-                dependency = as_str_key_dict(dependency_obj)
-                kind_obj = dependency.get("kind")
-                kind = kind_obj if isinstance(kind_obj, str) else ""
+            for dependency in payload.dependencies:
+                kind = dependency.kind
                 if kind and kind != "normal":
                     continue
 
-                version_id_obj = dependency.get("version_id")
-                if not isinstance(version_id_obj, int):
+                version_id = dependency.version_id
+                if version_id is None:
                     continue
 
-                dependent_name = version_crates.get(version_id_obj)
+                dependent_name = version_crates.get(version_id)
                 if not dependent_name or dependent_name == package_name:
                     continue
 
@@ -127,9 +215,7 @@ class CargoCrawler(RegistryCrawler):
 
                     return list(dependents_by_canonical_id.values())
 
-            meta = as_str_key_dict(payload.get("meta"))
-            total_obj = meta.get("total")
-            total = total_obj if isinstance(total_obj, int) else 0
+            total = payload.meta.total
             if page * self.DEPENDENTS_PER_PAGE >= total:
                 break
 
@@ -149,61 +235,49 @@ class CargoCrawler(RegistryCrawler):
 
     def _parse_package(
         self,
-        metadata: dict[str, Any],
-        dependency_payload: dict[str, Any],
+        metadata: _CargoMetadataPayload,
+        dependency_payload: _CargoDependencyListPayload,
     ) -> CrawledPackage:
         """Parse crates.io metadata into the shared crawler contract."""
 
-        crate = as_str_key_dict(metadata.get("crate"))
-        name_obj = crate.get("name")
-        name = name_obj if isinstance(name_obj, str) else ""
+        crate = metadata.crate
+        name = crate.name
         package_purl = f"pkg:cargo/{name}"
 
         releases: list[Release] = []
-        versions_obj = metadata.get("versions")
-        versions: list[object] = versions_obj if isinstance(versions_obj, list) else []
-        for version_obj in versions:
-            version = as_str_key_dict(version_obj)
-            release_version_obj = version.get("num")
-            if not isinstance(release_version_obj, str) or not release_version_obj:
+        for version in metadata.versions:
+            release_version = version.num
+            if not release_version:
                 continue
 
-            created_at_obj = version.get("created_at")
-            release_date = created_at_obj if isinstance(created_at_obj, str) else ""
-            releases.append(Release(purl=package_purl, version=release_version_obj, release_date=release_date))
+            releases.append(Release(purl=package_purl, version=release_version, release_date=version.created_at))
 
         releases = sorted_releases_desc(releases)
         latest_version = preferred_latest_version(releases) or _selected_cargo_version(crate)
 
         dependencies: list[CrawledDependency] = []
-        dependencies_obj = dependency_payload.get("dependencies")
-        dependency_rows: list[object] = dependencies_obj if isinstance(dependencies_obj, list) else []
-        for dependency_obj in dependency_rows:
-            dependency = as_str_key_dict(dependency_obj)
-            kind_obj = dependency.get("kind")
-            kind = kind_obj if isinstance(kind_obj, str) else ""
+        for dependency in dependency_payload.dependencies:
+            kind = dependency.kind
             if kind and kind != "normal":
                 continue
 
-            dependency_name_obj = dependency.get("crate_id")
-            if not isinstance(dependency_name_obj, str) or not dependency_name_obj:
+            dependency_name = dependency.crate_id
+            if not dependency_name:
                 continue
 
-            requirement_obj = dependency.get("req")
-            version_range = requirement_obj if isinstance(requirement_obj, str) else None
             dependencies.append(
                 CrawledDependency(
-                    canonical_id=f"pkg:cargo/{dependency_name_obj}",
-                    display_name=dependency_name_obj,
-                    version_range=version_range,
+                    canonical_id=f"pkg:cargo/{dependency_name}",
+                    display_name=dependency_name,
+                    version_range=dependency.req,
                 )
             )
 
         downloads_30d = _downloads_30d(crate)
         package_metadata: dict[str, Any] = {}
-        recent_downloads_obj = crate.get("recent_downloads")
-        if isinstance(recent_downloads_obj, int):
-            package_metadata["recent_downloads_90d"] = recent_downloads_obj
+        recent_downloads_90d = _normalize_download_count(crate.recent_downloads, "recent_downloads", name)
+        if recent_downloads_90d is not None:
+            package_metadata["recent_downloads_90d"] = recent_downloads_90d
 
         if downloads_30d is not None:
             package_metadata["download_count_30d"] = downloads_30d
@@ -221,52 +295,47 @@ class CargoCrawler(RegistryCrawler):
         )
 
 
-def _selected_cargo_version(crate: dict[str, Any]) -> str:
+def _selected_cargo_version(crate: _CargoCratePayload) -> str:
     """Select the version to query for dependency metadata."""
 
-    stable_version_obj = crate.get("max_stable_version")
-    if isinstance(stable_version_obj, str) and stable_version_obj:
-        return stable_version_obj
+    if crate.max_stable_version:
+        return crate.max_stable_version
 
-    max_version_obj = crate.get("max_version")
-    if isinstance(max_version_obj, str):
-        return max_version_obj
+    if crate.max_version:
+        return crate.max_version
 
     return ""
 
 
-def _downloads_30d(crate: dict[str, Any]) -> int | None:
+def _downloads_30d(crate: _CargoCratePayload) -> int | None:
     """Convert crates.io recent downloads (90 days) into the issue-defined 30-day approximation."""
 
-    recent_downloads_obj = crate.get("recent_downloads")
-    if not isinstance(recent_downloads_obj, int):
+    recent_downloads = _normalize_download_count(crate.recent_downloads, "recent_downloads", crate.name)
+    if recent_downloads is None:
         return None
 
-    return recent_downloads_obj // 3
+    return recent_downloads // 3
 
 
-def _cargo_repo_url(crate: dict[str, Any]) -> str | None:
+def _cargo_repo_url(crate: _CargoCratePayload) -> str | None:
     """Extract the most repository-like URL from crates.io metadata."""
 
-    for key in ("repository", "homepage", "documentation"):
-        value = crate.get(key)
-        if isinstance(value, str) and value:
+    for value in (crate.repository, crate.homepage, crate.documentation):
+        if value:
             return value
 
     return None
 
 
-def _dependent_version_crates(payload: dict[str, Any]) -> dict[int, str]:
+def _dependent_version_crates(payload: _CargoReverseDependenciesPagePayload) -> dict[int, str]:
     """Build a lookup from version ID to dependent crate name."""
 
-    versions_obj = payload.get("versions")
-    versions: list[object] = versions_obj if isinstance(versions_obj, list) else []
     version_crates: dict[int, str] = {}
-    for version_obj in versions:
-        version = as_str_key_dict(version_obj)
-        version_id_obj = version.get("id")
-        crate_name_obj = version.get("crate")
-        if isinstance(version_id_obj, int) and isinstance(crate_name_obj, str) and crate_name_obj:
-            version_crates[version_id_obj] = crate_name_obj
+    for version in payload.versions:
+        version_id = version.id
+        if version_id is None or not version.crate:
+            continue
+
+        version_crates[version_id] = version.crate
 
     return version_crates

--- a/pg_atlas/crawlers/factory.py
+++ b/pg_atlas/crawlers/factory.py
@@ -20,7 +20,7 @@ from pg_atlas.crawlers.cargo import CargoCrawler
 from pg_atlas.crawlers.npm import NpmCrawler
 from pg_atlas.crawlers.packagist import PackagistCrawler
 from pg_atlas.crawlers.pubdev import PubDevCrawler
-from pg_atlas.crawlers.pypi import PypiCrawler
+from pg_atlas.crawlers.pypi import PyPICrawler
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +94,7 @@ def build_registry_crawler(
                 max_retries=max_retries,
             )
         case "PYPI":
-            return PypiCrawler(
+            return PyPICrawler(
                 client=client,
                 session_factory=session_factory,
                 rate_limit=rate_limit,

--- a/pg_atlas/crawlers/factory.py
+++ b/pg_atlas/crawlers/factory.py
@@ -16,8 +16,11 @@ import httpx
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from pg_atlas.crawlers.base import RegistryCrawler
+from pg_atlas.crawlers.cargo import CargoCrawler
+from pg_atlas.crawlers.npm import NpmCrawler
 from pg_atlas.crawlers.packagist import PackagistCrawler
 from pg_atlas.crawlers.pubdev import PubDevCrawler
+from pg_atlas.crawlers.pypi import PypiCrawler
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +37,12 @@ def normalize_registry_system(system: str) -> str | None:
             return "DART"
         case "COMPOSER" | "PHP" | "PACKAGIST":
             return "COMPOSER"
+        case "NPM" | "NODE" | "NODEJS":
+            return "NPM"
+        case "CARGO" | "CRATES" | "CRATESIO":
+            return "CARGO"
+        case "PYPI" | "PIP":
+            return "PYPI"
         case _:
             return None
 
@@ -65,6 +74,27 @@ def build_registry_crawler(
             )
         case "COMPOSER":
             return PackagistCrawler(
+                client=client,
+                session_factory=session_factory,
+                rate_limit=rate_limit,
+                max_retries=max_retries,
+            )
+        case "NPM":
+            return NpmCrawler(
+                client=client,
+                session_factory=session_factory,
+                rate_limit=rate_limit,
+                max_retries=max_retries,
+            )
+        case "CARGO":
+            return CargoCrawler(
+                client=client,
+                session_factory=session_factory,
+                rate_limit=rate_limit,
+                max_retries=max_retries,
+            )
+        case "PYPI":
+            return PypiCrawler(
                 client=client,
                 session_factory=session_factory,
                 rate_limit=rate_limit,

--- a/pg_atlas/crawlers/npm.py
+++ b/pg_atlas/crawlers/npm.py
@@ -1,0 +1,184 @@
+"""
+npm registry crawler for PG Atlas.
+
+Fetches package metadata and last-30-day downloads from the public npm APIs.
+Reverse dependents are intentionally stubbed because npm does not expose a
+practical first-party dependents API for this crawler path.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from pg_atlas.crawlers.base import CrawledDependency, CrawledDependent, CrawledPackage, RegistryCrawler, as_str_key_dict
+from pg_atlas.db_models.release import Release, preferred_latest_version, sorted_releases_desc
+
+logger = logging.getLogger(__name__)
+
+
+class NpmCrawler(RegistryCrawler):
+    """
+    Crawler for the public npm registry and downloads APIs.
+
+    The package metadata endpoint is the source of repository URLs, releases,
+    and runtime dependency declarations. The downloads endpoint supplies the
+    30-day aggregate used by adoption materialization.
+    """
+
+    REGISTRY = "npmjs.com"
+    METADATA_BASE_URL = "https://registry.npmjs.org"
+    DOWNLOADS_BASE_URL = "https://api.npmjs.org/downloads/point/last-month"
+
+    async def fetch_package(self, package_name: str) -> CrawledPackage:
+        """
+        Fetch package metadata and last-30-day downloads from npm.
+        """
+
+        escaped_name = _encode_npm_package_name_for_url(package_name)
+        metadata_resp = await self._request_with_retry(f"{self.METADATA_BASE_URL}/{escaped_name}")
+        metadata: dict[str, Any] = metadata_resp.json()
+
+        downloads: dict[str, Any] = {}
+        try:
+            downloads_resp = await self._request_with_retry(f"{self.DOWNLOADS_BASE_URL}/{escaped_name}")
+            downloads = downloads_resp.json()
+        except (httpx.HTTPStatusError, httpx.TimeoutException) as exc:
+            logger.warning(f"Failed to fetch npm downloads for {package_name}: {exc}")
+
+        return self._parse_package(metadata, downloads)
+
+    async def fetch_dependents(self, package_name: str) -> list[CrawledDependent]:
+        """
+        Return an explicit empty dependent list for npm.
+
+        TODO A10: revisit when npm exposes a practical first-party dependents
+        endpoint suitable for bootstrap crawling.
+        """
+
+        return []
+
+    def _parse_package(
+        self,
+        metadata: dict[str, Any],
+        downloads: dict[str, Any],
+    ) -> CrawledPackage:
+        """Parse npm API responses into the shared crawler contract."""
+
+        name_obj = metadata.get("name")
+        name = name_obj if isinstance(name_obj, str) else ""
+        package_purl = f"pkg:npm/{_canonical_npm_name(name)}"
+        versions = as_str_key_dict(metadata.get("versions"))
+        dist_tags = as_str_key_dict(metadata.get("dist-tags"))
+        time_map = as_str_key_dict(metadata.get("time"))
+
+        releases: list[Release] = []
+        for version_key, version_payload_obj in versions.items():
+            if not isinstance(version_payload_obj, dict):
+                continue
+
+            version_payload = as_str_key_dict(version_payload_obj)
+            version_value_obj = version_payload.get("version")
+            version_value = version_value_obj if isinstance(version_value_obj, str) and version_value_obj else version_key
+            release_date_obj = time_map.get(version_value)
+            release_date = release_date_obj if isinstance(release_date_obj, str) else ""
+            releases.append(Release(purl=package_purl, version=version_value, release_date=release_date))
+
+        releases = sorted_releases_desc(releases)
+        latest_version_obj = dist_tags.get("latest")
+        latest_version = latest_version_obj if isinstance(latest_version_obj, str) else ""
+        if releases:
+            latest_version = preferred_latest_version(releases) or latest_version
+
+        latest_payload = as_str_key_dict(versions.get(latest_version))
+        if not latest_payload and releases:
+            latest_payload = as_str_key_dict(versions.get(releases[0].version))
+
+        dependencies: list[CrawledDependency] = []
+        latest_dependencies = as_str_key_dict(latest_payload.get("dependencies"))
+        for dep_name, dep_range_obj in latest_dependencies.items():
+            version_range = dep_range_obj if isinstance(dep_range_obj, str) else None
+            dependencies.append(
+                CrawledDependency(
+                    canonical_id=f"pkg:npm/{_canonical_npm_name(dep_name)}",
+                    display_name=dep_name,
+                    version_range=version_range,
+                )
+            )
+
+        repo_url = _repository_url(latest_payload, metadata)
+        downloads_30d_obj = downloads.get("downloads")
+        downloads_30d = downloads_30d_obj if isinstance(downloads_30d_obj, int) else None
+
+        package_metadata: dict[str, Any] = {}
+        if downloads_30d is not None:
+            package_metadata["download_count_30d"] = downloads_30d
+
+        start_obj = downloads.get("start")
+        if isinstance(start_obj, str):
+            package_metadata["downloads_start"] = start_obj
+
+        end_obj = downloads.get("end")
+        if isinstance(end_obj, str):
+            package_metadata["downloads_end"] = end_obj
+
+        return CrawledPackage(
+            canonical_id=package_purl,
+            display_name=name,
+            latest_version=latest_version,
+            repo_url=repo_url,
+            downloads_30d=downloads_30d,
+            metadata=package_metadata,
+            dependencies=dependencies,
+            releases=releases,
+        )
+
+
+def _encode_npm_package_name_for_url(package_name: str) -> str:
+    """Encode an npm package name for use in registry API URLs."""
+
+    return quote(package_name, safe="")
+
+
+def _canonical_npm_name(package_name: str) -> str:
+    """Normalize an npm package name for use in a package PURL."""
+
+    return quote(package_name.lower(), safe="/")
+
+
+def _repository_url(version_payload: dict[str, Any], metadata: dict[str, Any]) -> str | None:
+    """Extract and normalize a repository URL from npm metadata."""
+
+    repository = version_payload.get("repository")
+    if repository is None:
+        repository = metadata.get("repository")
+
+    if isinstance(repository, str):
+        return _normalize_repo_url(repository)
+
+    repository_dict = as_str_key_dict(repository)
+    repository_url = repository_dict.get("url")
+    if isinstance(repository_url, str):
+        return _normalize_repo_url(repository_url)
+
+    return None
+
+
+def _normalize_repo_url(repo_url: str) -> str | None:
+    """Normalize an npm-style repository URL into a git-hosted HTTPS URL."""
+
+    normalized = repo_url.strip()
+    if not normalized:
+        return None
+
+    if normalized.startswith("git+"):
+        normalized = normalized[4:]
+
+    normalized = normalized.split("#", 1)[0].rstrip("/")
+    return normalized or None

--- a/pg_atlas/crawlers/npm.py
+++ b/pg_atlas/crawlers/npm.py
@@ -17,7 +17,14 @@ from urllib.parse import quote
 
 import httpx
 
-from pg_atlas.crawlers.base import CrawledDependency, CrawledDependent, CrawledPackage, RegistryCrawler, as_str_key_dict
+from pg_atlas.crawlers.base import (
+    CrawledDependency,
+    CrawledDependent,
+    CrawledPackage,
+    ExhaustedRetries,
+    RegistryCrawler,
+    as_str_key_dict,
+)
 from pg_atlas.db_models.release import Release, preferred_latest_version, sorted_releases_desc
 
 logger = logging.getLogger(__name__)
@@ -49,7 +56,7 @@ class NpmCrawler(RegistryCrawler):
         try:
             downloads_resp = await self._request_with_retry(f"{self.DOWNLOADS_BASE_URL}/{escaped_name}")
             downloads = downloads_resp.json()
-        except (httpx.HTTPStatusError, httpx.TimeoutException) as exc:
+        except (httpx.HTTPStatusError, httpx.TimeoutException, ExhaustedRetries) as exc:
             logger.warning(f"Failed to fetch npm downloads for {package_name}: {exc}")
 
         return self._parse_package(metadata, downloads)

--- a/pg_atlas/crawlers/packagist.py
+++ b/pg_atlas/crawlers/packagist.py
@@ -18,7 +18,14 @@ from typing import Any
 
 import httpx
 
-from pg_atlas.crawlers.base import CrawledDependency, CrawledDependent, CrawledPackage, RegistryCrawler, as_str_key_dict
+from pg_atlas.crawlers.base import (
+    CrawledDependency,
+    CrawledDependent,
+    CrawledPackage,
+    ExhaustedRetries,
+    RegistryCrawler,
+    as_str_key_dict,
+)
 from pg_atlas.db_models.release import Release
 
 logger = logging.getLogger(__name__)
@@ -76,7 +83,7 @@ class PackagistCrawler(RegistryCrawler):
         try:
             dl_resp = await self._request_with_retry(f"{self.BASE_URL}/packages/{package_name}/downloads.json")
             downloads_data = dl_resp.json()
-        except (httpx.HTTPStatusError, httpx.TimeoutException) as exc:
+        except (httpx.HTTPStatusError, httpx.TimeoutException, ExhaustedRetries) as exc:
             logger.warning(f"Failed to fetch downloads for {package_name}: {exc}")
 
         return self._parse_package(pkg_data, downloads_data)
@@ -90,7 +97,7 @@ class PackagistCrawler(RegistryCrawler):
         """
         try:
             resp = await self._request_with_retry(f"{self.BASE_URL}/packages/{package_name}/dependents.json")
-        except (httpx.HTTPStatusError, httpx.TimeoutException) as exc:
+        except (httpx.HTTPStatusError, httpx.TimeoutException, ExhaustedRetries) as exc:
             logger.warning(f"Failed to fetch dependents for {package_name}: {exc}")
             return []
 

--- a/pg_atlas/crawlers/pubdev.py
+++ b/pg_atlas/crawlers/pubdev.py
@@ -20,7 +20,14 @@ import httpx
 import msgspec
 from pydantic import TypeAdapter, ValidationError
 
-from pg_atlas.crawlers.base import CrawledDependency, CrawledDependent, CrawledPackage, RegistryCrawler, as_str_key_dict
+from pg_atlas.crawlers.base import (
+    CrawledDependency,
+    CrawledDependent,
+    CrawledPackage,
+    ExhaustedRetries,
+    RegistryCrawler,
+    as_str_key_dict,
+)
 from pg_atlas.db_models.release import Release
 
 logger = logging.getLogger(__name__)
@@ -70,7 +77,7 @@ class PubDevCrawler(RegistryCrawler):
         try:
             metrics_resp = await self._request_with_retry(f"{self.BASE_URL}/packages/{package_name}/metrics")
             metrics_data = metrics_resp.json()
-        except (httpx.HTTPStatusError, httpx.TimeoutException) as exc:
+        except (httpx.HTTPStatusError, httpx.TimeoutException, ExhaustedRetries) as exc:
             logger.warning(f"Failed to fetch metrics for {package_name}: {exc}")
 
         return self._parse_package(pkg_data, metrics_data)

--- a/pg_atlas/crawlers/pubdev.py
+++ b/pg_atlas/crawlers/pubdev.py
@@ -178,9 +178,9 @@ class PubDevCrawler(RegistryCrawler):
             weekly_downloads = []
 
         if weekly_downloads:
-            metadata["download_count_4w"] = sum(weekly_downloads[:4])
-            metadata["download_count_12w"] = sum(weekly_downloads[:12])
-            metadata["download_count_52w"] = sum(weekly_downloads[:52])
+            metadata["download_count_4w"] = int(sum(weekly_downloads[:4]))
+            metadata["download_count_12w"] = int(sum(weekly_downloads[:12]))
+            metadata["download_count_52w"] = int(sum(weekly_downloads[:52]))
 
         if pub_points is not None:
             metadata["pub_points"] = pub_points

--- a/pg_atlas/crawlers/pubdev.py
+++ b/pg_atlas/crawlers/pubdev.py
@@ -14,11 +14,10 @@ SPDX-License-Identifier: MPL-2.0
 from __future__ import annotations
 
 import logging
-from typing import Any
+import math
 
 import httpx
 import msgspec
-from pydantic import TypeAdapter, ValidationError
 
 from pg_atlas.crawlers.base import (
     CrawledDependency,
@@ -26,15 +25,60 @@ from pg_atlas.crawlers.base import (
     CrawledPackage,
     ExhaustedRetries,
     RegistryCrawler,
-    as_str_key_dict,
 )
 from pg_atlas.db_models.release import Release
 
 logger = logging.getLogger(__name__)
 
 
-_DEPENDENCIES_ADAPTER: TypeAdapter[dict[str, object]] = TypeAdapter(dict[str, object])
-_WEEKLY_DOWNLOADS_ADAPTER: TypeAdapter[list[float]] = TypeAdapter(list[float])
+class _PubDevPubspecPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    homepage: str | None = None
+    repository: str | None = None
+    dependencies: dict[str, object] = msgspec.field(default_factory=dict[str, object])
+
+
+class _PubDevLatestPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    version: str = ""
+    pubspec: _PubDevPubspecPayload = msgspec.field(default_factory=_PubDevPubspecPayload)
+
+
+class _PubDevVersionPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    version: str = ""
+    published: str = ""
+
+
+class _PubDevPackagePayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    name: str = ""
+    latest: _PubDevLatestPayload = msgspec.field(default_factory=_PubDevLatestPayload)
+    versions: list[_PubDevVersionPayload] = msgspec.field(default_factory=list[_PubDevVersionPayload])
+
+
+class _PubDevScorePayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    downloadCount30Days: int | float | None = None
+    grantedPoints: int | float | None = None
+    maxPoints: int | float | None = None
+
+
+class _PubDevWeeklyDownloadsPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    totalWeeklyDownloads: list[int | float] = msgspec.field(default_factory=list[int | float])
+
+
+class _PubDevScorecardPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    weeklyVersionDownloads: _PubDevWeeklyDownloadsPayload = msgspec.field(default_factory=_PubDevWeeklyDownloadsPayload)
+
+
+class _PubDevMetricsPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    score: _PubDevScorePayload = msgspec.field(default_factory=_PubDevScorePayload)
+    scorecard: _PubDevScorecardPayload = msgspec.field(default_factory=_PubDevScorecardPayload)
+
+
+class _PubDevDependentPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    package: str = ""
+
+
+class _PubDevDependentsPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    packages: list[_PubDevDependentPayload] = msgspec.field(default_factory=list[_PubDevDependentPayload])
+    next: str = ""
 
 
 class PubDevCrawler(RegistryCrawler):
@@ -67,16 +111,16 @@ class PubDevCrawler(RegistryCrawler):
         Fetch package metadata and metrics from pub.dev.
 
         Makes two API calls:
-        1. GET /api/packages/{name} — metadata, versions, dependencies
-        2. GET /api/packages/{name}/metrics — scores, downloads, weekly history
+        1. GET /api/packages/{name} - metadata, versions, dependencies
+        2. GET /api/packages/{name}/metrics - scores, downloads, weekly history
         """
         pkg_resp = await self._request_with_retry(f"{self.BASE_URL}/packages/{package_name}")
-        pkg_data: dict[str, Any] = pkg_resp.json()
+        pkg_data = _decode_pubdev_package_payload(pkg_resp.content, package_name)
 
-        metrics_data: dict[str, Any] = {}
+        metrics_data = _PubDevMetricsPayload()
         try:
             metrics_resp = await self._request_with_retry(f"{self.BASE_URL}/packages/{package_name}/metrics")
-            metrics_data = metrics_resp.json()
+            metrics_data = _decode_pubdev_metrics_payload(metrics_resp.content, package_name)
         except (httpx.HTTPStatusError, httpx.TimeoutException, ExhaustedRetries) as exc:
             logger.warning(f"Failed to fetch metrics for {package_name}: {exc}")
 
@@ -97,58 +141,36 @@ class PubDevCrawler(RegistryCrawler):
         while url and pages_fetched < max_pages and len(dependents) < max_dependents:
             pages_fetched += 1
             resp = await self._request_with_retry(url)
-            data = as_str_key_dict(resp.json())
+            data = _decode_pubdev_dependents_payload(resp.content, package_name)
 
-            packages_obj = data.get("packages")
-            packages: list[object] = []
-            if isinstance(packages_obj, list):
-                try:
-                    packages = msgspec.convert(packages_obj, type=list[object])
-                except msgspec.ValidationError:
-                    packages = []
-
-            for entry_obj in packages:
-                entry = as_str_key_dict(entry_obj)
-                name_obj = entry.get("package")
-                name = name_obj if isinstance(name_obj, str) else ""
-                if name:
+            for entry in data.packages:
+                if entry.package:
                     dependents.append(
                         CrawledDependent(
-                            canonical_id=f"pkg:pub/{name.lower()}",
-                            display_name=name,
+                            canonical_id=f"pkg:pub/{entry.package.lower()}",
+                            display_name=entry.package,
                         )
                     )
 
-            next_url = data.get("next")
-            url = next_url if isinstance(next_url, str) else ""
+            url = data.next
 
         if len(dependents) >= max_dependents:
             logger.warning(f"Truncated dependents for {package_name} at {max_dependents}")
 
         return dependents
 
-    def _parse_package(self, pkg_data: dict[str, Any], metrics_data: dict[str, Any]) -> CrawledPackage:
+    def _parse_package(self, pkg_data: _PubDevPackagePayload, metrics_data: _PubDevMetricsPayload) -> CrawledPackage:
         """Parse pub.dev API responses into a CrawledPackage."""
-        name_obj = pkg_data.get("name")
-        name = name_obj if isinstance(name_obj, str) else ""
+        name = pkg_data.name
         package_purl = f"pkg:pub/{name.lower()}"
-        latest = as_str_key_dict(pkg_data.get("latest"))
-        version_obj = latest.get("version")
-        version = version_obj if isinstance(version_obj, str) else ""
-        pubspec = as_str_key_dict(latest.get("pubspec"))
-
-        homepage = pubspec.get("homepage") or pubspec.get("repository")
-        repo_url: str | None = homepage if isinstance(homepage, str) else None
+        latest = pkg_data.latest
+        version = latest.version
+        pubspec = latest.pubspec
+        repo_url = pubspec.homepage or pubspec.repository
 
         # Parse runtime dependencies only (not dev_dependencies or dependency_overrides)
-        raw_deps_obj = pubspec.get("dependencies")
-        try:
-            raw_deps = _DEPENDENCIES_ADAPTER.validate_python(raw_deps_obj)
-        except ValidationError:
-            raw_deps = {}
-
         dependencies: list[CrawledDependency] = []
-        for dep_name, dep_constraint in raw_deps.items():
+        for dep_name, dep_constraint in pubspec.dependencies.items():
             if dep_name.lower() in self.FRAMEWORK_PACKAGES:
                 continue
 
@@ -165,56 +187,42 @@ class PubDevCrawler(RegistryCrawler):
                 )
             )
 
-        # Extract score data (nested under "score" in metrics response)
-        score = as_str_key_dict(metrics_data.get("score"))
-        downloads_30d = score.get("downloadCount30Days")
-        pub_points = score.get("grantedPoints")
-        pub_points_max = score.get("maxPoints")
+        score = metrics_data.score
+        downloads_30d = _normalize_download_count(score.downloadCount30Days, name, "downloadCount30Days")
+        pub_points = _normalize_download_count(score.grantedPoints, name, "grantedPoints")
+        pub_points_max = _normalize_download_count(score.maxPoints, name, "maxPoints")
 
-        metadata: dict[str, Any] = {}
+        metadata: dict[str, int] = {}
         if downloads_30d is not None:
             metadata["download_count_30d"] = downloads_30d
 
-        # Extract weekly download history from scorecard
-        scorecard = as_str_key_dict(metrics_data.get("scorecard"))
-        wvd = as_str_key_dict(scorecard.get("weeklyVersionDownloads"))
-        weekly_downloads_obj = wvd.get("totalWeeklyDownloads")
-        try:
-            weekly_downloads = _WEEKLY_DOWNLOADS_ADAPTER.validate_python(weekly_downloads_obj)
-        except ValidationError:
-            weekly_downloads = []
-
+        weekly_downloads = _normalize_weekly_downloads(
+            metrics_data.scorecard.weeklyVersionDownloads.totalWeeklyDownloads,
+            name,
+        )
         if weekly_downloads:
-            metadata["download_count_4w"] = int(sum(weekly_downloads[:4]))
-            metadata["download_count_12w"] = int(sum(weekly_downloads[:12]))
-            metadata["download_count_52w"] = int(sum(weekly_downloads[:52]))
+            metadata["download_count_4w"] = sum(weekly_downloads[:4])
+            metadata["download_count_12w"] = sum(weekly_downloads[:12])
+            metadata["download_count_52w"] = sum(weekly_downloads[:52])
 
         if pub_points is not None:
             metadata["pub_points"] = pub_points
+
         if pub_points_max is not None:
             metadata["pub_points_max"] = pub_points_max
 
         releases: list[Release] = []
-        versions_obj = pkg_data.get("versions")
-        if isinstance(versions_obj, list):
-            try:
-                versions: list[object] = msgspec.convert(versions_obj, type=list[object])
-            except msgspec.ValidationError:
-                versions = []
+        for version_payload in pkg_data.versions:
+            if not version_payload.version:
+                continue
 
-            for version_payload_obj in versions:
-                if not isinstance(version_payload_obj, dict):
-                    continue
-
-                version_payload = as_str_key_dict(version_payload_obj)
-
-                version_value = version_payload.get("version")
-                if not isinstance(version_value, str) or not version_value:
-                    continue
-
-                published_value = version_payload.get("published")
-                release_date = published_value if isinstance(published_value, str) else ""
-                releases.append(Release(purl=package_purl, version=version_value, release_date=release_date))
+            releases.append(
+                Release(
+                    purl=package_purl,
+                    version=version_payload.version,
+                    release_date=version_payload.published,
+                )
+            )
 
         return CrawledPackage(
             canonical_id=package_purl,
@@ -226,3 +234,61 @@ class PubDevCrawler(RegistryCrawler):
             dependencies=dependencies,
             releases=releases,
         )
+
+
+def _decode_pubdev_package_payload(content: bytes, package_name: str) -> _PubDevPackagePayload:
+    try:
+        return msgspec.json.decode(content, type=_PubDevPackagePayload)
+    except msgspec.ValidationError as exc:
+        logger.warning(f"Failed to decode pub.dev package payload for {package_name}: {exc}")
+
+        return _PubDevPackagePayload()
+
+
+def _decode_pubdev_metrics_payload(content: bytes, package_name: str) -> _PubDevMetricsPayload:
+    try:
+        return msgspec.json.decode(content, type=_PubDevMetricsPayload)
+    except msgspec.ValidationError as exc:
+        logger.warning(f"Failed to decode pub.dev metrics payload for {package_name}: {exc}")
+
+        return _PubDevMetricsPayload()
+
+
+def _decode_pubdev_dependents_payload(content: bytes, package_name: str) -> _PubDevDependentsPayload:
+    try:
+        return msgspec.json.decode(content, type=_PubDevDependentsPayload)
+    except msgspec.ValidationError as exc:
+        logger.warning(f"Failed to decode pub.dev dependents payload for {package_name}: {exc}")
+
+        return _PubDevDependentsPayload()
+
+
+def _normalize_download_count(value: int | float | None, package_name: str, field_name: str) -> int | None:
+    if value is None:
+        return None
+
+    if isinstance(value, int):
+        return value
+
+    if math.isfinite(value):
+        return int(value)
+
+    logger.warning(f"Ignoring non-numeric {field_name} value for {package_name}: {value}")
+
+    return None
+
+
+def _normalize_weekly_downloads(values: list[int | float], package_name: str) -> list[int]:
+    normalized: list[int] = []
+    for value in values:
+        if isinstance(value, int):
+            normalized.append(value)
+            continue
+
+        if math.isfinite(value):
+            normalized.append(int(value))
+            continue
+
+        logger.warning(f"Ignoring non-numeric weekly download value for {package_name}: {value}")
+
+    return normalized

--- a/pg_atlas/crawlers/pypi.py
+++ b/pg_atlas/crawlers/pypi.py
@@ -11,10 +11,12 @@ SPDX-License-Identifier: MPL-2.0
 from __future__ import annotations
 
 import logging
+import math
 import re
 from typing import Any
 
 import httpx
+import msgspec
 import pypistats  # pyright: ignore[reportMissingTypeStubs]
 from packaging.requirements import InvalidRequirement, Requirement
 
@@ -24,13 +26,72 @@ from pg_atlas.crawlers.base import (
     CrawledPackage,
     ExhaustedRetries,
     RegistryCrawler,
-    as_str_key_dict,
 )
 from pg_atlas.db_models.release import Release, preferred_latest_version, sorted_releases_desc
 
 logger = logging.getLogger(__name__)
 
 _PYPI_NAME_NORMALIZER = re.compile(r"[-_.]+")
+
+
+class _PyPIInfoPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    name: str = ""
+    version: str = ""
+    requires_dist: list[str] = msgspec.field(default_factory=list[str])
+    project_urls: dict[str, str] = msgspec.field(default_factory=dict[str, str])
+    home_page: str | None = None
+
+
+class _PyPIReleaseFilePayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    upload_time_iso_8601: str | None = None
+
+
+class _PyPIPackagePayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    info: _PyPIInfoPayload = msgspec.field(default_factory=_PyPIInfoPayload)
+    releases: dict[str, list[_PyPIReleaseFilePayload]] = msgspec.field(
+        default_factory=dict[str, list[_PyPIReleaseFilePayload]]
+    )
+
+
+class _PyPIStatsRecentDataPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    last_month: int | float | None = None
+
+
+class _PyPIStatsRecentPayload(msgspec.Struct, omit_defaults=True, forbid_unknown_fields=False):
+    data: _PyPIStatsRecentDataPayload = msgspec.field(default_factory=_PyPIStatsRecentDataPayload)
+
+
+def _decode_pypi_package_payload(content: bytes, package_name: str) -> _PyPIPackagePayload:
+    try:
+        return msgspec.json.decode(content, type=_PyPIPackagePayload)
+    except msgspec.ValidationError as exc:
+        logger.warning(f"Failed to decode PyPI package payload for {package_name}: {exc}")
+
+        return _PyPIPackagePayload()
+
+
+def _decode_pypi_stats_payload(content: bytes, package_name: str) -> _PyPIStatsRecentPayload:
+    try:
+        return msgspec.json.decode(content, type=_PyPIStatsRecentPayload)
+    except msgspec.ValidationError as exc:
+        logger.warning(f"Failed to decode PyPIStats payload for {package_name}: {exc}")
+
+        return _PyPIStatsRecentPayload()
+
+
+def _normalize_download_count(value: int | float | None, package_name: str, field_name: str) -> int | None:
+    if value is None:
+        return None
+
+    if isinstance(value, int):
+        return value
+
+    if math.isfinite(value):
+        return int(value)
+
+    logger.warning(f"Ignoring non-numeric {field_name} value for {package_name}: {value}")
+
+    return None
 
 
 class PyPICrawler(RegistryCrawler):
@@ -49,7 +110,7 @@ class PyPICrawler(RegistryCrawler):
         """Fetch project metadata from PyPI and download counts from PyPIStats."""
 
         metadata_resp = await self._request_with_retry(f"{self.BASE_URL}/{package_name}/json")
-        metadata: dict[str, Any] = metadata_resp.json()
+        metadata = _decode_pypi_package_payload(metadata_resp.content, package_name)
         downloads_30d, stats_metadata = await self._fetch_downloads_30d(package_name)
         return self._parse_package(metadata, downloads_30d, stats_metadata)
 
@@ -79,15 +140,14 @@ class PyPICrawler(RegistryCrawler):
 
             return None, {}
 
-        stats_payload: dict[str, Any] = stats_resp.json()
-        stats_data = as_str_key_dict(stats_payload.get("data"))
-        downloads_30d_obj = stats_data.get("last_month")
-        if not isinstance(downloads_30d_obj, int):
-            logger.warning(f"Unexpected PyPIStats recent payload for {package_name}: {stats_payload!r}")
+        stats_payload = _decode_pypi_stats_payload(stats_resp.content, package_name)
+        downloads_30d = _normalize_download_count(stats_payload.data.last_month, package_name, "last_month")
+        if downloads_30d is None:
+            logger.warning(f"Unexpected PyPIStats recent payload for {package_name}")
 
             return None, {}
 
-        return downloads_30d_obj, {
+        return downloads_30d, {
             "download_source": "pypistats",
             "download_period": "month",
             "download_mirror_policy": "with_mirrors",
@@ -95,24 +155,18 @@ class PyPICrawler(RegistryCrawler):
 
     def _parse_package(
         self,
-        metadata: dict[str, Any],
+        metadata: _PyPIPackagePayload,
         downloads_30d: int | None,
         stats_metadata: dict[str, Any],
     ) -> CrawledPackage:
         """Parse PyPI JSON and PyPIStats payloads into the shared crawler contract."""
 
-        info = as_str_key_dict(metadata.get("info"))
-        name_obj = info.get("name")
-        name = name_obj if isinstance(name_obj, str) else ""
+        info = metadata.info
+        name = info.name
         package_purl = f"pkg:pypi/{_normalize_pypi_name(name)}"
 
         dependencies: list[CrawledDependency] = []
-        requires_dist_obj = info.get("requires_dist")
-        requires_dist: list[object] = requires_dist_obj if isinstance(requires_dist_obj, list) else []
-        for requirement_obj in requires_dist:
-            if not isinstance(requirement_obj, str):
-                continue
-
+        for requirement_obj in info.requires_dist:
             try:
                 requirement = Requirement(requirement_obj)
             except InvalidRequirement:
@@ -133,22 +187,15 @@ class PyPICrawler(RegistryCrawler):
             )
 
         releases: list[Release] = []
-        releases_obj = metadata.get("releases")
-        release_map = as_str_key_dict(releases_obj)
-        for version, files_obj in release_map.items():
-            file_entries: list[object] = files_obj if isinstance(files_obj, list) else []
-            upload_times = [
-                file_entry["upload_time_iso_8601"]
-                for file_entry in file_entries
-                if isinstance(file_entry, dict) and isinstance(file_entry.get("upload_time_iso_8601"), str)
+        for version, file_entries in metadata.releases.items():
+            upload_times: list[str] = [
+                upload_time for file_entry in file_entries if (upload_time := file_entry.upload_time_iso_8601) is not None
             ]
             release_date = min(upload_times) if upload_times else ""
             releases.append(Release(purl=package_purl, version=version, release_date=release_date))
 
         releases = sorted_releases_desc(releases)
-        info_version_obj = info.get("version")
-        info_version = info_version_obj if isinstance(info_version_obj, str) else ""
-        latest_version = preferred_latest_version(releases) or info_version
+        latest_version = preferred_latest_version(releases) or info.version
 
         package_metadata = dict(stats_metadata)
         if downloads_30d is not None:
@@ -173,25 +220,24 @@ def _normalize_pypi_name(package_name: str) -> str:
     return _PYPI_NAME_NORMALIZER.sub("-", package_name).lower()
 
 
-def _extract_repo_url(info: dict[str, Any]) -> str | None:
+def _extract_repo_url(info: _PyPIInfoPayload) -> str | None:
     """Extract the most repository-like URL from PyPI project metadata."""
 
-    project_urls = as_str_key_dict(info.get("project_urls"))
+    project_urls = info.project_urls
     for key in ("Repository", "Source", "Source Code", "Homepage", "Home"):
         value = project_urls.get(key)
-        if isinstance(value, str) and value:
+        if value:
             return _normalize_repo_url(value)
 
     first_project_url = next(
-        (value for value in project_urls.values() if isinstance(value, str) and value),
+        (value for value in project_urls.values() if value),
         None,
     )
     if first_project_url:
         return _normalize_repo_url(first_project_url)
 
-    home_page_obj = info.get("home_page")
-    if isinstance(home_page_obj, str) and home_page_obj:
-        return _normalize_repo_url(home_page_obj)
+    if info.home_page:
+        return _normalize_repo_url(info.home_page)
 
     return None
 

--- a/pg_atlas/crawlers/pypi.py
+++ b/pg_atlas/crawlers/pypi.py
@@ -1,0 +1,203 @@
+"""
+PyPI registry crawler for PG Atlas.
+
+Fetches project metadata and releases from the official PyPI JSON API and uses
+the ``pypistats`` client for mirror-inclusive download totals.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+import pypistats
+from packaging.requirements import InvalidRequirement, Requirement
+
+from pg_atlas.crawlers.base import CrawledDependency, CrawledDependent, CrawledPackage, RegistryCrawler, as_str_key_dict
+from pg_atlas.db_models.release import Release, preferred_latest_version, sorted_releases_desc
+
+logger = logging.getLogger(__name__)
+
+_PYPI_NAME_NORMALIZER = re.compile(r"[-_.]+")
+
+
+class PypiCrawler(RegistryCrawler):
+    """
+    Crawler for the official PyPI JSON API plus PyPIStats.
+
+    The PyPI JSON API does not expose usable download counts. This crawler uses
+    the PyPIStats recent-downloads endpoint with ``period=month`` and
+    ``mirrors=true`` to satisfy the adoption-signal requirement.
+    """
+
+    REGISTRY = "pypi.org"
+    BASE_URL = "https://pypi.org/pypi"
+
+    async def fetch_package(self, package_name: str) -> CrawledPackage:
+        """Fetch project metadata from PyPI and download counts from PyPIStats."""
+
+        metadata_resp = await self._request_with_retry(f"{self.BASE_URL}/{package_name}/json")
+        metadata: dict[str, Any] = metadata_resp.json()
+        downloads_30d, stats_metadata = await self._fetch_downloads_30d(package_name)
+        return self._parse_package(metadata, downloads_30d, stats_metadata)
+
+    async def fetch_dependents(self, package_name: str) -> list[CrawledDependent]:
+        """
+        Return an explicit empty dependent list for PyPI.
+
+        TODO A10: revisit when a practical first-party dependents API exists.
+        """
+
+        return []
+
+    async def _fetch_downloads_30d(self, package_name: str) -> tuple[int | None, dict[str, Any]]:
+        """
+        Fetch mirror-inclusive monthly download totals from PyPIStats.
+
+        The ``pypistats`` package exposes the API base URL and user-agent string,
+        but its ``recent()`` wrapper does not currently surface the ``mirrors``
+        query parameter. Use the underlying API endpoint directly so the crawler
+        can request the exact semantics required by A10.
+        """
+
+        stats_url = f"{pypistats.BASE_URL}packages/{package_name}/recent?period=month&mirrors=true"
+        try:
+            stats_resp = await self._request_with_retry(stats_url)
+        except Exception as exc:
+            logger.warning(f"Failed to fetch PyPIStats downloads for {package_name}: {exc}")
+
+            return None, {}
+
+        stats_payload: dict[str, Any] = stats_resp.json()
+        stats_data = as_str_key_dict(stats_payload.get("data"))
+        downloads_30d_obj = stats_data.get("last_month")
+        if not isinstance(downloads_30d_obj, int):
+            logger.warning(f"Unexpected PyPIStats recent payload for {package_name}: {stats_payload!r}")
+
+            return None, {}
+
+        return downloads_30d_obj, {
+            "download_source": "pypistats",
+            "download_period": "month",
+            "download_mirror_policy": "with_mirrors",
+        }
+
+    def _parse_package(
+        self,
+        metadata: dict[str, Any],
+        downloads_30d: int | None,
+        stats_metadata: dict[str, Any],
+    ) -> CrawledPackage:
+        """Parse PyPI JSON and PyPIStats payloads into the shared crawler contract."""
+
+        info = as_str_key_dict(metadata.get("info"))
+        name_obj = info.get("name")
+        name = name_obj if isinstance(name_obj, str) else ""
+        package_purl = f"pkg:pypi/{_normalize_pypi_name(name)}"
+
+        dependencies: list[CrawledDependency] = []
+        requires_dist_obj = info.get("requires_dist")
+        requires_dist: list[object] = requires_dist_obj if isinstance(requires_dist_obj, list) else []
+        for requirement_obj in requires_dist:
+            if not isinstance(requirement_obj, str):
+                continue
+
+            try:
+                requirement = Requirement(requirement_obj)
+            except InvalidRequirement:
+                logger.warning(f"Skipping invalid PyPI requirement for {name}: {requirement_obj}")
+                continue
+
+            if requirement.marker and "extra" in str(requirement.marker):
+                continue
+
+            version_range = str(requirement.specifier) or None
+            dependency_name = _normalize_pypi_name(requirement.name)
+            dependencies.append(
+                CrawledDependency(
+                    canonical_id=f"pkg:pypi/{dependency_name}",
+                    display_name=requirement.name,
+                    version_range=version_range,
+                )
+            )
+
+        releases: list[Release] = []
+        releases_obj = metadata.get("releases")
+        release_map = as_str_key_dict(releases_obj)
+        for version, files_obj in release_map.items():
+            file_entries: list[object] = files_obj if isinstance(files_obj, list) else []
+            upload_times = [
+                file_entry["upload_time_iso_8601"]
+                for file_entry in file_entries
+                if isinstance(file_entry, dict) and isinstance(file_entry.get("upload_time_iso_8601"), str)
+            ]
+            release_date = min(upload_times) if upload_times else ""
+            releases.append(Release(purl=package_purl, version=version, release_date=release_date))
+
+        releases = sorted_releases_desc(releases)
+        info_version_obj = info.get("version")
+        info_version = info_version_obj if isinstance(info_version_obj, str) else ""
+        latest_version = preferred_latest_version(releases) or info_version
+
+        package_metadata = dict(stats_metadata)
+        if downloads_30d is not None:
+            package_metadata["download_count_30d"] = downloads_30d
+
+        repo_url = _extract_repo_url(info)
+        return CrawledPackage(
+            canonical_id=package_purl,
+            display_name=name,
+            latest_version=latest_version,
+            repo_url=repo_url,
+            downloads_30d=downloads_30d,
+            metadata=package_metadata,
+            dependencies=dependencies,
+            releases=releases,
+        )
+
+
+def _normalize_pypi_name(package_name: str) -> str:
+    """Normalize a PyPI package name using the PEP 503 canonical form."""
+
+    return _PYPI_NAME_NORMALIZER.sub("-", package_name).lower()
+
+
+def _extract_repo_url(info: dict[str, Any]) -> str | None:
+    """Extract the most repository-like URL from PyPI project metadata."""
+
+    project_urls = as_str_key_dict(info.get("project_urls"))
+    for key in ("Repository", "Source", "Source Code", "Homepage", "Home"):
+        value = project_urls.get(key)
+        if isinstance(value, str) and value:
+            return _normalize_repo_url(value)
+
+    first_project_url = next(
+        (value for value in project_urls.values() if isinstance(value, str) and value),
+        None,
+    )
+    if first_project_url:
+        return _normalize_repo_url(first_project_url)
+
+    home_page_obj = info.get("home_page")
+    if isinstance(home_page_obj, str) and home_page_obj:
+        return _normalize_repo_url(home_page_obj)
+
+    return None
+
+
+def _normalize_repo_url(repo_url: str) -> str | None:
+    """Normalize a project URL into a repository URL candidate."""
+
+    normalized = repo_url.strip()
+    if not normalized:
+        return None
+
+    if normalized.startswith("git+"):
+        normalized = normalized[4:]
+
+    normalized = normalized.split("#", 1)[0].rstrip("/")
+    return normalized or None

--- a/pg_atlas/crawlers/pypi.py
+++ b/pg_atlas/crawlers/pypi.py
@@ -14,10 +14,18 @@ import logging
 import re
 from typing import Any
 
-import pypistats
+import httpx
+import pypistats  # pyright: ignore[reportMissingTypeStubs]
 from packaging.requirements import InvalidRequirement, Requirement
 
-from pg_atlas.crawlers.base import CrawledDependency, CrawledDependent, CrawledPackage, RegistryCrawler, as_str_key_dict
+from pg_atlas.crawlers.base import (
+    CrawledDependency,
+    CrawledDependent,
+    CrawledPackage,
+    ExhaustedRetries,
+    RegistryCrawler,
+    as_str_key_dict,
+)
 from pg_atlas.db_models.release import Release, preferred_latest_version, sorted_releases_desc
 
 logger = logging.getLogger(__name__)
@@ -25,7 +33,7 @@ logger = logging.getLogger(__name__)
 _PYPI_NAME_NORMALIZER = re.compile(r"[-_.]+")
 
 
-class PypiCrawler(RegistryCrawler):
+class PyPICrawler(RegistryCrawler):
     """
     Crawler for the official PyPI JSON API plus PyPIStats.
 
@@ -58,16 +66,15 @@ class PypiCrawler(RegistryCrawler):
         """
         Fetch mirror-inclusive monthly download totals from PyPIStats.
 
-        The ``pypistats`` package exposes the API base URL and user-agent string,
-        but its ``recent()`` wrapper does not currently surface the ``mirrors``
-        query parameter. Use the underlying API endpoint directly so the crawler
-        can request the exact semantics required by A10.
+        The ``pypistats`` package does not expose download counts from mirrors.
+        We replicate its endpoint semantics here, and depend on the package only
+        to conveniently reference API changes and sync them to our custom implementation.
         """
 
         stats_url = f"{pypistats.BASE_URL}packages/{package_name}/recent?period=month&mirrors=true"
         try:
             stats_resp = await self._request_with_retry(stats_url)
-        except Exception as exc:
+        except (httpx.HTTPStatusError, httpx.TimeoutException, ExhaustedRetries) as exc:
             logger.warning(f"Failed to fetch PyPIStats downloads for {package_name}: {exc}")
 
             return None, {}

--- a/pg_atlas/instruments/tee.py
+++ b/pg_atlas/instruments/tee.py
@@ -17,7 +17,7 @@ import logging
 import sys
 from collections.abc import Callable, Iterator
 from pathlib import Path
-from typing import TextIO, TypeAlias
+from typing import Protocol, TextIO, TypeAlias, TypeGuard
 
 
 class _StreamTee(io.TextIOBase):
@@ -56,8 +56,11 @@ class _StreamTee(io.TextIOBase):
         return getattr(self._primary, name)
 
 
-_StreamHandlerText: TypeAlias = logging.StreamHandler[io.TextIOBase]
-_StreamHandlerPatch: TypeAlias = tuple[_StreamHandlerText, io.TextIOBase]
+class _HasTextStream(Protocol):
+    stream: io.TextIOBase
+
+
+_StreamHandlerPatch: TypeAlias = tuple[_HasTextStream, io.TextIOBase]
 
 
 def _iter_loggers() -> Iterator[logging.Logger]:
@@ -68,18 +71,24 @@ def _iter_loggers() -> Iterator[logging.Logger]:
             yield logger
 
 
-def _patch_stream_handlers(original_stream: object, replacement: io.TextIOBase) -> list[_StreamHandlerPatch]:
+def _is_text_stream_handler(handler: object) -> TypeGuard[_HasTextStream]:
+    if not isinstance(handler, logging.StreamHandler):
+        return False
+
+    stream = getattr(handler, "stream", None)  # pyright: ignore[reportUnknownArgumentType]
+    return isinstance(stream, io.TextIOBase)
+
+
+def _patch_stream_handlers(original_stream: TextIO | io.TextIOBase, replacement: io.TextIOBase) -> list[_StreamHandlerPatch]:
     patched: list[_StreamHandlerPatch] = []
 
     for logger in _iter_loggers():
         for handler in logger.handlers:
-            if not isinstance(handler, logging.StreamHandler):
+            if not _is_text_stream_handler(handler):
                 continue
 
-            if handler.stream is original_stream:  # pyright: ignore[reportUnknownMemberType]
-                patched.append(
-                    (handler, handler.stream)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
-                )
+            if handler.stream is original_stream:
+                patched.append((handler, handler.stream))
                 handler.stream = replacement
 
     return patched

--- a/pg_atlas/procrastinate/tasks.py
+++ b/pg_atlas/procrastinate/tasks.py
@@ -35,7 +35,7 @@ from procrastinate.exceptions import AlreadyEnqueued
 from sqlalchemy import select
 
 from pg_atlas.config import settings
-from pg_atlas.crawlers.base import AllPackagesFailed
+from pg_atlas.crawlers.base import USER_AGENT, AllPackagesFailed
 from pg_atlas.crawlers.factory import build_registry_crawler, normalize_registry_system
 from pg_atlas.db_models.base import ActivityStatus, ProjectType, SubmissionStatus
 from pg_atlas.db_models.release import Release, preferred_latest_version, sorted_releases_desc
@@ -220,6 +220,7 @@ async def sync_opengrants(
 
     logger.info(f"sync_opengrants: {len(projects)} projects from OpenGrants")
 
+    project_batch_data: list[dict[str, Any]] = []
     for proj in projects:
         # Enrich from manual mapping when an override is present.
         if proj.canonical_id in git_mapping:
@@ -227,18 +228,15 @@ async def sync_opengrants(
             proj.git_owner_url = mapping.get("git_owner_url")
             proj.git_repo_url = mapping.get("git_repo_url")
 
-        await process_project.defer_async(
-            project_canonical_id=proj.canonical_id,
-            display_name=proj.display_name,
-            activity_status=proj.activity_status.value,
-            git_owner_url=proj.git_owner_url,
-            git_repo_url=proj.git_repo_url,
-            category=proj.category,
-            project_metadata=proj.project_metadata,
-            extended_universe=extended_universe,
+        project_batch_data.append(
+            {
+                **asdict(proj),
+                "extended_universe": extended_universe,
+            }
         )
 
-    logger.info(f"sync_opengrants: deferred {len(projects)} process_project tasks")
+    await process_project.batch_defer_async(*project_batch_data)
+    logger.info(f"sync_opengrants: deferred {len(project_batch_data)} process_project tasks")
 
 
 # ---------------------------------------------------------------------------
@@ -344,38 +342,8 @@ async def process_project(
     )
 
     # ----- Defer crawl_github_repo for each repo to crawl -----
-    for repo_info in repos_to_crawl:
-        repo_full = repo_info.full_name
-        depsdev_key = f"github.com/{repo_full}".lower()
-        depsdev_info = depsdev_projects.get(depsdev_key)
-
-        packages: list[ProjectPackage] = []
-        adoption_stars = repo_info.stars
-        adoption_forks = repo_info.forks
-        # normalize datetime to UTC before DB persistence
-        pushed_at_utc: dt.datetime | None = None
-        if repo_info.pushed_at:
-            pushed_at_utc = repo_info.pushed_at.astimezone(dt.UTC)
-
-        if depsdev_info:
-            packages = depsdev_info.packages
-            adoption_stars = max(adoption_stars, depsdev_info.stars_count)
-            adoption_forks = max(adoption_forks, depsdev_info.forks_count)
-
-        parts = repo_full.split("/", 1)
-        repo_owner = parts[0]
-        repo_name = parts[1] if len(parts) > 1 else repo_full
-
-        await crawl_github_repo.defer_async(
-            owner=repo_owner,
-            repo=repo_name,
-            project_id=project_id,
-            packages=[asdict(pkg) for pkg in packages],
-            pushed_at_isodt=pushed_at_utc.isoformat() if pushed_at_utc is not None else None,
-            adoption_stars=adoption_stars,
-            adoption_forks=adoption_forks,
-        )
-
+    repo_batch_data = (build_repo_defer_data(repo_info, project_id, depsdev_projects) for repo_info in repos_to_crawl)
+    await crawl_github_repo.batch_defer_async(*repo_batch_data)
     logger.info(f"process_project: deferred {len(repos_to_crawl)} crawl_github_repo tasks for {project_canonical_id}")
 
 
@@ -581,7 +549,7 @@ async def crawl_package_registry(
     async with httpx.AsyncClient(
         timeout=httpx.Timeout(settings.CRAWLER_TIMEOUT, connect=10.0),
         follow_redirects=True,
-        headers={"User-Agent": "pg-atlas-crawler/0.1"},
+        headers={"User-Agent": USER_AGENT},
     ) as client:
         crawler = build_registry_crawler(
             normalized_system,
@@ -833,3 +801,43 @@ def _load_git_mapping() -> dict[str, dict[str, str]]:
         data: dict[str, dict[str, str]] = yaml.safe_load(f) or {}
 
     return data
+
+
+# ---------------------------------------------------------------------------
+# Batch defer helpers
+# ---------------------------------------------------------------------------
+
+
+def build_repo_defer_data(
+    repo_info: GitHubRepoMetadata, project_id: int, projects_info: dict[str, DepsDevProjectInfo]
+) -> dict[str, Any]:
+    repo_full = repo_info.full_name
+    depsdev_key = f"github.com/{repo_full}".lower()
+    depsdev_info = projects_info.get(depsdev_key)
+
+    packages: list[ProjectPackage] = []
+    adoption_stars = repo_info.stars
+    adoption_forks = repo_info.forks
+    # normalize datetime to UTC before DB persistence
+    pushed_at_utc: dt.datetime | None = None
+    if repo_info.pushed_at:
+        pushed_at_utc = repo_info.pushed_at.astimezone(dt.UTC)
+
+    if depsdev_info:
+        packages = depsdev_info.packages
+        adoption_stars = max(adoption_stars, depsdev_info.stars_count)
+        adoption_forks = max(adoption_forks, depsdev_info.forks_count)
+
+    parts = repo_full.split("/", 1)
+    repo_owner = parts[0]
+    repo_name = parts[1] if len(parts) > 1 else repo_full
+
+    return dict(
+        owner=repo_owner,
+        repo=repo_name,
+        project_id=project_id,
+        packages=[asdict(pkg) for pkg in packages],
+        pushed_at_isodt=pushed_at_utc.isoformat() if pushed_at_utc is not None else None,
+        adoption_stars=adoption_stars,
+        adoption_forks=adoption_forks,
+    )

--- a/pg_atlas/procrastinate/tasks.py
+++ b/pg_atlas/procrastinate/tasks.py
@@ -76,7 +76,7 @@ from pg_atlas.procrastinate.upserts import (
 logger = logging.getLogger(__name__)
 
 # TODO: refactor into single source of truth; should live in crawlers and depsdev.
-REGISTRY_CRAWL_SYSTEMS = frozenset({"DART", "COMPOSER"})
+REGISTRY_CRAWL_SYSTEMS = frozenset({"DART", "COMPOSER", "NPM", "CARGO", "PYPI"})
 DEPSDEV_SUPPORTED_SYSTEMS = frozenset({"PYPI", "NPM", "CARGO", "MAVEN", "GO", "RUBYGEMS", "NUGET"})
 
 
@@ -405,21 +405,19 @@ async def crawl_github_repo(
     5. Group registry-crawl packages by registry system and defer one
         ``crawl_package_registry`` task per supported system.
 
-    Supported direct-registry crawl systems are intentionally limited to
-    ``DART`` and ``COMPOSER``. Other ecosystems are logged as unsupported for
-    observability.
+    Registry-supported ecosystems are crawled directly for adoption signals,
+    even when they also flow through deps.dev for release and dependency data.
+    Ecosystems without a direct registry crawler are logged for observability.
     """
     logger.info(f"crawl_github_repo: {owner}/{repo} (project_id={project_id})")
 
     # ----- Proceed with Deps.dev packages, or detect published packages from repo manifests -----
     package_refs = [PackageReference.from_payload(pkg) for pkg in packages]
-    received_depsdev_payload = bool(package_refs)
     if not package_refs:
         package_refs = detect_packages_from_repo(owner, repo)
         logger.info(f"Detected {len(package_refs)} packages in {owner}/{repo}")
 
-    depsdev_packages, registry_packages, misc_packages = _partition_package_refs(package_refs)
-    mixed_package_list = bool(depsdev_packages) and bool(registry_packages or misc_packages)
+    depsdev_packages, registry_packages, unsupported_registry_packages = _partition_package_refs(package_refs)
 
     # ----- Build releases from deps.dev-supported package info -----
     releases: list[Release] = []
@@ -539,14 +537,7 @@ async def crawl_github_repo(
         if enqueued:
             deferred_registry_tasks += 1
 
-    warning_packages = list(misc_packages)
-    if mixed_package_list:
-        warning_packages.extend(depsdev_packages)
-
-    if received_depsdev_payload and not mixed_package_list:
-        warning_packages = list(misc_packages)
-
-    unsupported_registry_purls = _build_registry_warning_purls(warning_packages)
+    unsupported_registry_purls = _build_registry_warning_purls(unsupported_registry_packages)
     for system, purls in sorted(unsupported_registry_purls.items()):
         joined_purls = " ".join(sorted(purls))
         logger.warning(f"registry-crawl unsupported ecosystem: system={system} purls={joined_purls}")
@@ -787,27 +778,30 @@ def _partition_package_refs(
     """
     Split package references by processing path.
 
-    Returns ``(depsdev_packages, registry_packages, misc_packages)``.
+    Returns ``(depsdev_packages, registry_packages, unsupported_registry_packages)``.
+
+    One package reference may appear in both the deps.dev and registry lists
+    when the ecosystem supports both flows. The third list contains only
+    packages that lack a direct registry crawler.
     """
 
     depsdev_packages: list[PackageReference] = []
     registry_packages: list[PackageReference] = []
-    misc_packages: list[PackageReference] = []
+    unsupported_registry_packages: list[PackageReference] = []
 
     for package_ref in package_refs:
         system = package_ref.system.upper()
         if system in DEPSDEV_SUPPORTED_SYSTEMS:
             depsdev_packages.append(package_ref)
-            continue
 
         normalized_registry_system = normalize_registry_system(system)
         if normalized_registry_system in REGISTRY_CRAWL_SYSTEMS:
             registry_packages.append(package_ref)
             continue
 
-        misc_packages.append(package_ref)
+        unsupported_registry_packages.append(package_ref)
 
-    return depsdev_packages, registry_packages, misc_packages
+    return depsdev_packages, registry_packages, unsupported_registry_packages
 
 
 def _build_registry_warning_purls(package_refs: list[PackageReference]) -> dict[str, set[str]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "numpy>=1.26",
     "msgspec>=0.21.0",
     "pyrate-limiter>=4.1.0",
+    "pypistats>=1.13.0",
+    "packaging>=26.0",
 ]
 
 [dependency-groups]

--- a/tests/bootstrap/test_tasks.py
+++ b/tests/bootstrap/test_tasks.py
@@ -280,7 +280,11 @@ async def test_crawl_github_repo_defers_package_deps(mocker: Any) -> None:
         adoption_forks=44,
     )
 
-    assert defer_mock.call_count == 1
+    deps_defer_calls = [call for call in defer_mock.call_args_list if call.args[0] is crawl_package_deps]
+    registry_defer_calls = [call for call in defer_mock.call_args_list if call.args[0] is crawl_package_registry]
+
+    assert len(deps_defer_calls) == 1
+    assert len(registry_defer_calls) == 1
 
 
 async def test_crawl_github_repo_processes_all_depsdev_package_refs(mocker: Any) -> None:
@@ -308,7 +312,11 @@ async def test_crawl_github_repo_processes_all_depsdev_package_refs(mocker: Any)
     # 1 upsert for github repo; per-package loop calls absorb, not upsert_repo.
     assert upsert_repo_mock.call_count == 1
     assert absorb_mock.call_count == 2
-    assert defer_mock.call_count == 2
+    deps_defer_calls = [call for call in defer_mock.call_args_list if call.args[0] is crawl_package_deps]
+    registry_defer_calls = [call for call in defer_mock.call_args_list if call.args[0] is crawl_package_registry]
+
+    assert len(deps_defer_calls) == 2
+    assert len(registry_defer_calls) == 1
 
 
 async def test_crawl_package_deps_uses_source_repo_canonical_id(mocker: Any) -> None:
@@ -507,3 +515,48 @@ async def test_crawl_github_repo_defers_and_runs_registry_crawl_for_php(mocker: 
 
     build_crawler_mock.assert_called_once()
     fake_crawler.crawl_and_persist.assert_awaited_once_with(package_names=["soneso/stellar-php-sdk"])
+
+
+@pytest.mark.parametrize(
+    ("system", "package_name"),
+    [
+        ("NPM", "lodash"),
+        ("CARGO", "serde"),
+        ("PYPI", "requests"),
+    ],
+)
+async def test_crawl_github_repo_supports_new_registry_systems_without_warning(
+    mocker: Any,
+    caplog: pytest.LogCaptureFixture,
+    system: str,
+    package_name: str,
+) -> None:
+    """Supported direct-registry systems should enqueue registry crawls without unsupported warnings."""
+
+    mocker.patch(
+        "pg_atlas.procrastinate.tasks.detect_packages_from_repo",
+        return_value=[PackageReference(system=system, name=package_name)],
+    )
+    mocker.patch("pg_atlas.procrastinate.tasks.get_package", new=mocker.AsyncMock(side_effect=DepsDevError("missing")))
+    mocker.patch("pg_atlas.procrastinate.tasks.latest_version_from_repo", return_value="")
+    mocker.patch("pg_atlas.procrastinate.tasks.upsert_repo", new=mocker.AsyncMock(return_value=10))
+    mocker.patch("pg_atlas.procrastinate.tasks.absorb_external_repo", new=mocker.AsyncMock(return_value=False))
+    mocker.patch("pg_atlas.procrastinate.tasks.associate_repo_with_project", new=mocker.AsyncMock())
+    defer_mock = mocker.patch("pg_atlas.procrastinate.tasks.defer_with_lock", new=mocker.AsyncMock(return_value=True))
+
+    with caplog.at_level("WARNING"):
+        await crawl_github_repo(
+            owner="test-org",
+            repo="test-repo",
+            project_id=1,
+            packages=[],
+            adoption_stars=123,
+            adoption_forks=44,
+        )
+
+    assert "registry-crawl unsupported ecosystem" not in caplog.text
+
+    registry_defer_calls = [call for call in defer_mock.call_args_list if call.args[0] is crawl_package_registry]
+    assert len(registry_defer_calls) == 1
+    assert registry_defer_calls[0].kwargs["system"] == system
+    assert registry_defer_calls[0].kwargs["package_names"] == [package_name]

--- a/tests/bootstrap/test_tasks.py
+++ b/tests/bootstrap/test_tasks.py
@@ -113,14 +113,17 @@ async def test_sync_opengrants_defers_each_project_with_mapping(mocker: Any) -> 
             }
         },
     )
-    defer_mock = mocker.patch.object(process_project, "defer_async", new=mocker.AsyncMock())
+    defer_mock = mocker.patch.object(process_project, "batch_defer_async", new=mocker.AsyncMock())
 
     await sync_opengrants()
 
-    assert defer_mock.call_count == 2
-    first_call: dict[str, Any] = defer_mock.call_args_list[0].kwargs
-    assert first_call["git_owner_url"] == "https://github.com/enriched"
-    assert first_call["category"] == "Developer Tooling"
+    defer_mock.assert_awaited_once()
+    defer_data: tuple[dict[str, Any], ...] = defer_mock.call_args_list[0].args
+    assert len(defer_data) == 2
+    assert defer_data[0]["git_owner_url"] == "https://github.com/enriched"
+    assert defer_data[0]["category"] == "Developer Tooling"
+    assert defer_data[1]["git_repo_url"] == "https://github.com/a/b"
+    assert defer_data[1]["category"] == "Smart Contracts"
 
 
 async def test_sync_opengrants_filters_projects_by_canonical_id(mocker: Any) -> None:
@@ -145,13 +148,14 @@ async def test_sync_opengrants_filters_projects_by_canonical_id(mocker: Any) -> 
 
     mocker.patch("pg_atlas.procrastinate.tasks.fetch_scf_projects", new=mocker.AsyncMock(return_value=projects))
     mocker.patch("pg_atlas.procrastinate.tasks._load_git_mapping", return_value={})
-    defer_mock = mocker.patch.object(process_project, "defer_async", new=mocker.AsyncMock())
+    defer_mock = mocker.patch.object(process_project, "batch_defer_async", new=mocker.AsyncMock())
 
     await sync_opengrants(canonical_ids=["daoip-5:scf:project:python_stellar_sdk"])
 
     defer_mock.assert_awaited_once()
-    deferred_call: dict[str, Any] = defer_mock.call_args.kwargs
-    assert deferred_call["project_canonical_id"] == "daoip-5:scf:project:python_stellar_sdk"
+    defer_data: tuple[dict[str, Any], ...] = defer_mock.call_args_list[0].args
+    assert len(defer_data) == 1
+    assert defer_data[0]["canonical_id"] == "daoip-5:scf:project:python_stellar_sdk"
 
 
 async def test_sync_opengrants_raises_for_unknown_canonical_ids(mocker: Any) -> None:
@@ -227,7 +231,7 @@ async def test_process_project_enriches_packages_from_depsdev(mocker: Any) -> No
         ),
     )
     upsert_project_mock = mocker.patch("pg_atlas.procrastinate.tasks.upsert_project", new=mocker.AsyncMock(return_value=101))
-    crawl_defer_mock = mocker.patch.object(crawl_github_repo, "defer_async", new=mocker.AsyncMock())
+    crawl_defer_mock = mocker.patch.object(crawl_github_repo, "batch_defer_async", new=mocker.AsyncMock())
 
     await process_project(
         project_canonical_id="proj:1",
@@ -240,8 +244,10 @@ async def test_process_project_enriches_packages_from_depsdev(mocker: Any) -> No
     )
 
     assert upsert_project_mock.call_args.kwargs["project_type"] == ProjectType.public_good
-    call_kwargs: dict[str, Any] = crawl_defer_mock.call_args.kwargs
-    assert call_kwargs["packages"] == [
+    crawl_defer_mock.assert_awaited_once()
+    defer_data: tuple[dict[str, Any], ...] = crawl_defer_mock.call_args_list[0].args
+    assert len(defer_data) == 1
+    assert defer_data[0]["packages"] == [
         {
             "system": "PYPI",
             "name": "stellar-sdk",

--- a/tests/crawlers/conftest.py
+++ b/tests/crawlers/conftest.py
@@ -84,6 +84,48 @@ def packagist_dependents_empty_data() -> dict[str, Any]:
 
 
 @pytest.fixture
+def npm_package_data() -> dict[str, Any]:
+    """npm registry metadata fixture."""
+    return _load_fixture("npm_package.json")
+
+
+@pytest.fixture
+def npm_downloads_data() -> dict[str, Any]:
+    """npm downloads API response fixture."""
+    return _load_fixture("npm_downloads.json")
+
+
+@pytest.fixture
+def crates_package_data() -> dict[str, Any]:
+    """crates.io crate metadata fixture."""
+    return _load_fixture("crates_package.json")
+
+
+@pytest.fixture
+def crates_dependencies_data() -> dict[str, Any]:
+    """crates.io version dependency fixture."""
+    return _load_fixture("crates_dependencies.json")
+
+
+@pytest.fixture
+def crates_reverse_dependencies_data() -> dict[str, Any]:
+    """crates.io reverse dependencies fixture."""
+    return _load_fixture("crates_reverse_dependencies.json")
+
+
+@pytest.fixture
+def pypi_package_data() -> dict[str, Any]:
+    """PyPI project JSON fixture."""
+    return _load_fixture("pypi_package.json")
+
+
+@pytest.fixture
+def pypi_stats_recent_data() -> dict[str, Any]:
+    """PyPIStats recent-downloads JSON fixture."""
+    return _load_fixture("pypi_stats_recent.json")
+
+
+@pytest.fixture
 def mock_http_client() -> AsyncMock:
     """Mock httpx.AsyncClient for unit tests."""
     return AsyncMock(spec=httpx.AsyncClient)

--- a/tests/crawlers/data_fixtures/crates_dependencies.json
+++ b/tests/crawlers/data_fixtures/crates_dependencies.json
@@ -1,0 +1,22 @@
+{
+  "dependencies": [
+    {
+      "crate_id": "serde_core",
+      "req": "=1.0.228",
+      "kind": "normal",
+      "optional": false
+    },
+    {
+      "crate_id": "serde_derive",
+      "req": "^1",
+      "kind": "normal",
+      "optional": true
+    },
+    {
+      "crate_id": "tempfile",
+      "req": "^3",
+      "kind": "dev",
+      "optional": false
+    }
+  ]
+}

--- a/tests/crawlers/data_fixtures/crates_package.json
+++ b/tests/crawlers/data_fixtures/crates_package.json
@@ -1,0 +1,25 @@
+{
+  "crate": {
+    "name": "serde",
+    "repository": "https://github.com/serde-rs/serde",
+    "homepage": null,
+    "documentation": "https://docs.rs/serde",
+    "max_stable_version": "1.0.228",
+    "max_version": "1.0.228",
+    "recent_downloads": 156720146
+  },
+  "versions": [
+    {
+      "num": "1.0.228",
+      "created_at": "2026-04-10T12:00:00.000000Z"
+    },
+    {
+      "num": "1.0.227",
+      "created_at": "2026-03-01T08:30:00.000000Z"
+    },
+    {
+      "num": "1.0.0-beta.1",
+      "created_at": "2025-12-01T00:00:00.000000Z"
+    }
+  ]
+}

--- a/tests/crawlers/data_fixtures/crates_reverse_dependencies.json
+++ b/tests/crawlers/data_fixtures/crates_reverse_dependencies.json
@@ -1,0 +1,47 @@
+{
+  "dependencies": [
+    {
+      "id": 14077245,
+      "version_id": 654541,
+      "crate_id": "serde",
+      "req": "^1",
+      "optional": false,
+      "default_features": true,
+      "features": [],
+      "target": null,
+      "kind": "normal",
+      "downloads": 7981325
+    },
+    {
+      "id": 14077246,
+      "version_id": 961817,
+      "crate_id": "serde",
+      "req": "^1",
+      "optional": false,
+      "default_features": true,
+      "features": [],
+      "target": null,
+      "kind": "build",
+      "downloads": 42787
+    }
+  ],
+  "versions": [
+    {
+      "id": 654541,
+      "crate": "podcast",
+      "num": "0.20.0",
+      "created_at": "2022-11-01T01:35:24.143212Z",
+      "repository": "https://github.com/njaremko/podcast"
+    },
+    {
+      "id": 961817,
+      "crate": "libvpx-native-sys",
+      "num": "5.0.13",
+      "created_at": "2023-11-20T20:15:27.868152Z",
+      "repository": "https://github.com/kornelski/rust-vpx"
+    }
+  ],
+  "meta": {
+    "total": 12
+  }
+}

--- a/tests/crawlers/data_fixtures/npm_downloads.json
+++ b/tests/crawlers/data_fixtures/npm_downloads.json
@@ -1,0 +1,6 @@
+{
+  "downloads": 17095128,
+  "start": "2026-03-21",
+  "end": "2026-04-19",
+  "package": "@npmcli/arborist"
+}

--- a/tests/crawlers/data_fixtures/npm_package.json
+++ b/tests/crawlers/data_fixtures/npm_package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@npmcli/arborist",
+  "dist-tags": {
+    "latest": "9.4.2",
+    "backport": "8.0.5"
+  },
+  "versions": {
+    "8.0.5": {
+      "name": "@npmcli/arborist",
+      "version": "8.0.5",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/cli.git",
+        "directory": "workspaces/arborist"
+      },
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "9.4.2": {
+      "name": "@npmcli/arborist",
+      "version": "9.4.2",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/cli.git",
+        "directory": "workspaces/arborist"
+      },
+      "dependencies": {
+        "nopt": "^9.0.0",
+        "semver": "^7.3.7",
+        "@npmcli/fs": "^4.0.0"
+      }
+    }
+  },
+  "time": {
+    "created": "2024-01-01T00:00:00.000Z",
+    "modified": "2026-03-18T21:20:35.937Z",
+    "8.0.5": "2025-12-11T14:58:53.612566Z",
+    "9.4.2": "2026-03-18T21:20:35.937Z"
+  }
+}

--- a/tests/crawlers/data_fixtures/pypi_package.json
+++ b/tests/crawlers/data_fixtures/pypi_package.json
@@ -1,0 +1,43 @@
+{
+  "info": {
+    "name": "requests",
+    "version": "2.33.1",
+    "downloads": {
+      "last_day": -1,
+      "last_month": -1,
+      "last_week": -1
+    },
+    "requires_dist": [
+      "charset_normalizer<4,>=2",
+      "idna<4,>=2.5",
+      "PySocks!=1.5.7,>=1.5.6; extra == \"socks\"",
+      "colorama>=0.4; sys_platform == \"win32\""
+    ],
+    "project_urls": {
+      "Documentation": "https://requests.readthedocs.io",
+      "Source": "https://github.com/psf/requests"
+    },
+    "home_page": null
+  },
+  "releases": {
+    "2.33.1": [
+      {
+        "upload_time_iso_8601": "2026-03-30T16:09:13.830020Z",
+        "filename": "requests-2.33.1-py3-none-any.whl",
+        "packagetype": "bdist_wheel"
+      },
+      {
+        "upload_time_iso_8601": "2026-03-30T16:09:15.531306Z",
+        "filename": "requests-2.33.1.tar.gz",
+        "packagetype": "sdist"
+      }
+    ],
+    "2.33.0": [
+      {
+        "upload_time_iso_8601": "2026-03-01T10:00:00.000000Z",
+        "filename": "requests-2.33.0-py3-none-any.whl",
+        "packagetype": "bdist_wheel"
+      }
+    ]
+  }
+}

--- a/tests/crawlers/data_fixtures/pypi_stats_recent.json
+++ b/tests/crawlers/data_fixtures/pypi_stats_recent.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "last_month": 350
+  },
+  "package": "requests",
+  "type": "recent_downloads"
+}

--- a/tests/crawlers/test_base.py
+++ b/tests/crawlers/test_base.py
@@ -20,6 +20,7 @@ from pg_atlas.crawlers.base import (
     CrawledDependent,
     CrawledPackage,
     CrawlResult,
+    ExhaustedRetries,
     RegistryCrawler,
 )
 
@@ -153,7 +154,7 @@ async def test_request_with_retry_exhausted_429(mock_http_client: AsyncMock) -> 
     )
     crawler = StubCrawler(mock_http_client, rate_limit=0.0, max_retries=3)
 
-    with pytest.raises(RuntimeError, match="Exhausted retries"):
+    with pytest.raises(ExhaustedRetries, match="Exhausted retries"):
         await crawler._request_with_retry("https://example.com/test")
     assert mock_http_client.get.call_count == 3
 

--- a/tests/crawlers/test_cargo.py
+++ b/tests/crawlers/test_cargo.py
@@ -110,3 +110,55 @@ async def test_fetch_dependents_paginates_and_filters_non_runtime_edges(
         "pkg:cargo/podcast",
         "pkg:cargo/versions-extra",
     ]
+
+
+async def test_fetch_package_handles_malformed_metadata_payload(
+    mock_http_client: AsyncMock,
+    caplog: Any,
+) -> None:
+    """Malformed metadata payload logs a warning and still returns a crawled package."""
+
+    malformed_metadata: dict[str, Any] = {
+        "crate": {
+            "name": ["serde"],
+            "recent_downloads": "bad-value",
+        },
+        "versions": "not-a-list",
+    }
+    mock_http_client.get = AsyncMock(side_effect=[_response(malformed_metadata)])
+    crawler = _make_crawler(mock_http_client)
+
+    with caplog.at_level("WARNING"):
+        pkg = await crawler.fetch_package("serde")
+
+    assert "Failed to decode crates.io metadata payload" in caplog.text
+    assert pkg.canonical_id == "pkg:cargo/"
+    assert pkg.dependencies == []
+    assert pkg.releases == []
+    assert pkg.downloads_30d is None
+
+
+async def test_fetch_dependents_handles_malformed_page_payload(
+    mock_http_client: AsyncMock,
+    caplog: Any,
+) -> None:
+    """Malformed reverse-dependency pages log warnings and return partial dependents."""
+
+    page_one: dict[str, Any] = {
+        "dependencies": [{"version_id": 1, "kind": "normal"}],
+        "versions": [{"id": 1, "crate": "dep-ok"}],
+        "meta": {"total": 20},
+    }
+    malformed_page_two: dict[str, Any] = {
+        "dependencies": "not-a-list",
+        "versions": [],
+        "meta": {"total": "unknown"},
+    }
+    mock_http_client.get = AsyncMock(side_effect=[_response(page_one), _response(malformed_page_two)])
+    crawler = _make_crawler(mock_http_client)
+
+    with caplog.at_level("WARNING"):
+        dependents = await crawler.fetch_dependents("serde")
+
+    assert "Failed to decode crates.io reverse dependencies payload" in caplog.text
+    assert [dependent.canonical_id for dependent in dependents] == ["pkg:cargo/dep-ok"]

--- a/tests/crawlers/test_cargo.py
+++ b/tests/crawlers/test_cargo.py
@@ -1,0 +1,112 @@
+"""
+Tests for the crates.io registry crawler.
+
+Unit tests use mocked HTTP responses and do not write to the database.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+
+from pg_atlas.crawlers.cargo import CargoCrawler
+
+
+def _response(data: dict[str, Any], status_code: int = 200) -> httpx.Response:
+    """Create a mock crates.io API response."""
+
+    return httpx.Response(
+        status_code=status_code,
+        json=data,
+        request=httpx.Request("GET", "https://crates.io/api/v1"),
+    )
+
+
+def _make_crawler(client: AsyncMock) -> CargoCrawler:
+    """Create a Cargo crawler backed by mocked HTTP and DB clients."""
+
+    session_factory = AsyncMock()
+    return CargoCrawler(
+        client=client,
+        session_factory=session_factory,
+        rate_limit=0.0,
+        max_retries=3,
+    )
+
+
+async def test_fetch_package_parses_metadata_downloads_and_dependencies(
+    mock_http_client: AsyncMock,
+    crates_package_data: dict[str, Any],
+    crates_dependencies_data: dict[str, Any],
+) -> None:
+    """crates.io package fetch captures repo URL, releases, monthly downloads, and normal deps."""
+
+    mock_http_client.get = AsyncMock(side_effect=[_response(crates_package_data), _response(crates_dependencies_data)])
+    crawler = _make_crawler(mock_http_client)
+    pkg = await crawler.fetch_package("serde")
+
+    assert pkg.canonical_id == "pkg:cargo/serde"
+    assert pkg.display_name == "serde"
+    assert pkg.latest_version == "1.0.228"
+    assert pkg.repo_url == "https://github.com/serde-rs/serde"
+    assert pkg.downloads_30d == 52240048
+    assert pkg.metadata["recent_downloads_90d"] == 156720146
+    assert pkg.metadata["download_count_30d"] == 52240048
+    assert [(release.version, release.release_date) for release in pkg.releases] == [
+        ("1.0.228", "2026-04-10T12:00:00.000000Z"),
+        ("1.0.227", "2026-03-01T08:30:00.000000Z"),
+        ("1.0.0-beta.1", "2025-12-01T00:00:00.000000Z"),
+    ]
+
+    dep_ids = {dep.canonical_id for dep in pkg.dependencies}
+    assert dep_ids == {
+        "pkg:cargo/serde_core",
+        "pkg:cargo/serde_derive",
+    }
+
+
+async def test_fetch_dependents_paginates_and_filters_non_runtime_edges(
+    mock_http_client: AsyncMock,
+    crates_reverse_dependencies_data: dict[str, Any],
+) -> None:
+    """Reverse dependencies page until exhausted and keep only normal reverse dependents."""
+
+    page_two: dict[str, Any] = {
+        "dependencies": [
+            {
+                "id": 14077247,
+                "version_id": 1457812,
+                "crate_id": "serde",
+                "req": "^1",
+                "optional": False,
+                "default_features": True,
+                "features": [],
+                "target": None,
+                "kind": "normal",
+                "downloads": 1000,
+            }
+        ],
+        "versions": [
+            {
+                "id": 1457812,
+                "crate": "versions-extra",
+                "num": "1.0.0",
+                "created_at": "2025-02-25T06:38:36.053622Z",
+                "repository": "https://github.com/example/versions-extra",
+            }
+        ],
+        "meta": {"total": 12},
+    }
+    mock_http_client.get = AsyncMock(side_effect=[_response(crates_reverse_dependencies_data), _response(page_two)])
+    crawler = _make_crawler(mock_http_client)
+    dependents = await crawler.fetch_dependents("serde")
+
+    assert [dependent.canonical_id for dependent in dependents] == [
+        "pkg:cargo/podcast",
+        "pkg:cargo/versions-extra",
+    ]

--- a/tests/crawlers/test_db_integration.py
+++ b/tests/crawlers/test_db_integration.py
@@ -146,15 +146,25 @@ def _unique_suffix() -> str:
     return uuid.uuid4().hex[:8]
 
 
+@pytest.mark.parametrize(
+    "package_canonical_id",
+    [
+        "pkg:pub/my-sdk",
+        "pkg:npm/my-sdk",
+        "pkg:cargo/my-sdk",
+        "pkg:pypi/my-sdk",
+    ],
+)
 async def test_crawl_writes_downloads_to_source_repo_metadata(
     db_session_factory: async_sessionmaker[AsyncSession],
+    package_canonical_id: str,
 ) -> None:
     """Crawler should write download counts into source repo metadata map only."""
 
     suffix = _unique_suffix()
     source_repo_url = f"https://github.com/test-org/source-repo-{suffix}"
     source_repo_canonical_id = f"pkg:github/test-org/source-repo-{suffix}"
-    package_canonical_id = f"pkg:pub/my-sdk-{suffix}"
+    package_canonical_id = f"{package_canonical_id}-{suffix}"
 
     async with db_session_factory() as session:
         await _seed_source_repo(

--- a/tests/crawlers/test_factory.py
+++ b/tests/crawlers/test_factory.py
@@ -14,7 +14,7 @@ import pytest
 from pg_atlas.crawlers.cargo import CargoCrawler
 from pg_atlas.crawlers.factory import build_registry_crawler, normalize_registry_system
 from pg_atlas.crawlers.npm import NpmCrawler
-from pg_atlas.crawlers.pypi import PypiCrawler
+from pg_atlas.crawlers.pypi import PyPICrawler
 
 
 @pytest.mark.parametrize(
@@ -41,7 +41,7 @@ def test_normalize_registry_system_supports_new_aliases(alias: str, canonical: s
     [
         ("NPM", NpmCrawler),
         ("CARGO", CargoCrawler),
-        ("PYPI", PypiCrawler),
+        ("PYPI", PyPICrawler),
     ],
 )
 def test_build_registry_crawler_supports_new_systems(system: str, crawler_type: type[object]) -> None:

--- a/tests/crawlers/test_factory.py
+++ b/tests/crawlers/test_factory.py
@@ -1,0 +1,60 @@
+"""
+Tests for registry crawler factory helpers.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pg_atlas.crawlers.cargo import CargoCrawler
+from pg_atlas.crawlers.factory import build_registry_crawler, normalize_registry_system
+from pg_atlas.crawlers.npm import NpmCrawler
+from pg_atlas.crawlers.pypi import PypiCrawler
+
+
+@pytest.mark.parametrize(
+    ("alias", "canonical"),
+    [
+        ("npm", "NPM"),
+        ("node", "NPM"),
+        ("nodejs", "NPM"),
+        ("cargo", "CARGO"),
+        ("crates", "CARGO"),
+        ("cratesio", "CARGO"),
+        ("pypi", "PYPI"),
+        ("pip", "PYPI"),
+    ],
+)
+def test_normalize_registry_system_supports_new_aliases(alias: str, canonical: str) -> None:
+    """New direct-registry ecosystems normalize to canonical system tokens."""
+
+    assert normalize_registry_system(alias) == canonical
+
+
+@pytest.mark.parametrize(
+    ("system", "crawler_type"),
+    [
+        ("NPM", NpmCrawler),
+        ("CARGO", CargoCrawler),
+        ("PYPI", PypiCrawler),
+    ],
+)
+def test_build_registry_crawler_supports_new_systems(system: str, crawler_type: type[object]) -> None:
+    """Factory builds the expected crawler subclass for each new system."""
+
+    client = AsyncMock()
+    session_factory = AsyncMock()
+    crawler = build_registry_crawler(
+        system,
+        client=client,
+        session_factory=session_factory,
+        rate_limit=0.0,
+        max_retries=3,
+    )
+
+    assert isinstance(crawler, crawler_type)

--- a/tests/crawlers/test_live_apis.py
+++ b/tests/crawlers/test_live_apis.py
@@ -21,8 +21,11 @@ import httpx
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from pg_atlas.crawlers.cargo import CargoCrawler
+from pg_atlas.crawlers.npm import NpmCrawler
 from pg_atlas.crawlers.packagist import PackagistCrawler
 from pg_atlas.crawlers.pubdev import PubDevCrawler
+from pg_atlas.crawlers.pypi import PypiCrawler
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("PG_ATLAS_TEST_LIVE_APIS"),
@@ -122,3 +125,44 @@ async def test_packagist_live_dependents(live_client: httpx.AsyncClient) -> None
     assert isinstance(dependents, list)
     for dep in dependents:
         assert dep.canonical_id.startswith("pkg:composer/")
+
+
+# ---------------------------------------------------------------------------
+# npm / crates.io / PyPI live tests
+# ---------------------------------------------------------------------------
+
+
+async def test_npm_live_fetch(live_client: httpx.AsyncClient) -> None:
+    """Fetch lodash from the live npm APIs and validate the parsed structure."""
+
+    crawler = NpmCrawler(client=live_client, session_factory=_dummy_session_factory(), rate_limit=0.0)
+    pkg = await crawler.fetch_package("lodash")
+
+    assert pkg.canonical_id == "pkg:npm/lodash"
+    assert pkg.display_name == "lodash"
+    assert pkg.latest_version
+    assert isinstance(pkg.dependencies, list)
+
+
+async def test_cargo_live_fetch(live_client: httpx.AsyncClient) -> None:
+    """Fetch serde from the live crates.io APIs and validate the parsed structure."""
+
+    crawler = CargoCrawler(client=live_client, session_factory=_dummy_session_factory(), rate_limit=0.0)
+    pkg = await crawler.fetch_package("serde")
+
+    assert pkg.canonical_id == "pkg:cargo/serde"
+    assert pkg.display_name == "serde"
+    assert pkg.latest_version
+    assert isinstance(pkg.dependencies, list)
+
+
+async def test_pypi_live_fetch(live_client: httpx.AsyncClient) -> None:
+    """Fetch requests from live PyPI and PyPIStats and validate the parsed structure."""
+
+    crawler = PypiCrawler(client=live_client, session_factory=_dummy_session_factory(), rate_limit=0.0)
+    pkg = await crawler.fetch_package("requests")
+
+    assert pkg.canonical_id == "pkg:pypi/requests"
+    assert pkg.display_name == "requests"
+    assert pkg.latest_version
+    assert isinstance(pkg.dependencies, list)

--- a/tests/crawlers/test_live_apis.py
+++ b/tests/crawlers/test_live_apis.py
@@ -21,11 +21,12 @@ import httpx
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from pg_atlas.crawlers.base import USER_AGENT
 from pg_atlas.crawlers.cargo import CargoCrawler
 from pg_atlas.crawlers.npm import NpmCrawler
 from pg_atlas.crawlers.packagist import PackagistCrawler
 from pg_atlas.crawlers.pubdev import PubDevCrawler
-from pg_atlas.crawlers.pypi import PypiCrawler
+from pg_atlas.crawlers.pypi import PyPICrawler
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("PG_ATLAS_TEST_LIVE_APIS"),
@@ -39,7 +40,7 @@ async def live_client() -> AsyncGenerator[httpx.AsyncClient, None]:
     async with httpx.AsyncClient(
         timeout=httpx.Timeout(30.0, connect=10.0),
         follow_redirects=True,
-        headers={"User-Agent": "pg-atlas-crawler-test/0.1"},
+        headers={"User-Agent": USER_AGENT},
     ) as client:
         yield client
 
@@ -159,7 +160,7 @@ async def test_cargo_live_fetch(live_client: httpx.AsyncClient) -> None:
 async def test_pypi_live_fetch(live_client: httpx.AsyncClient) -> None:
     """Fetch requests from live PyPI and PyPIStats and validate the parsed structure."""
 
-    crawler = PypiCrawler(client=live_client, session_factory=_dummy_session_factory(), rate_limit=0.0)
+    crawler = PyPICrawler(client=live_client, session_factory=_dummy_session_factory(), rate_limit=0.0)
     pkg = await crawler.fetch_package("requests")
 
     assert pkg.canonical_id == "pkg:pypi/requests"

--- a/tests/crawlers/test_npm.py
+++ b/tests/crawlers/test_npm.py
@@ -1,0 +1,114 @@
+"""
+Tests for the npm registry crawler.
+
+Unit tests use mocked HTTP responses and do not write to the database.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+
+from pg_atlas.crawlers.npm import NpmCrawler
+
+
+def _response(data: dict[str, Any], status_code: int = 200) -> httpx.Response:
+    """Create a mock npm API response."""
+
+    return httpx.Response(
+        status_code=status_code,
+        json=data,
+        request=httpx.Request("GET", "https://registry.npmjs.org"),
+    )
+
+
+def _make_crawler(client: AsyncMock) -> NpmCrawler:
+    """Create an npm crawler backed by mocked HTTP and DB clients."""
+
+    session_factory = AsyncMock()
+    return NpmCrawler(
+        client=client,
+        session_factory=session_factory,
+        rate_limit=0.0,
+        max_retries=3,
+    )
+
+
+async def test_fetch_package_parses_metadata_and_releases(
+    mock_http_client: AsyncMock,
+    npm_package_data: dict[str, Any],
+    npm_downloads_data: dict[str, Any],
+) -> None:
+    """Scoped package metadata is normalized into a package PURL and release list."""
+
+    mock_http_client.get = AsyncMock(side_effect=[_response(npm_package_data), _response(npm_downloads_data)])
+    crawler = _make_crawler(mock_http_client)
+    pkg = await crawler.fetch_package("@npmcli/arborist")
+
+    assert pkg.canonical_id == "pkg:npm/%40npmcli/arborist"
+    assert pkg.display_name == "@npmcli/arborist"
+    assert pkg.latest_version == "9.4.2"
+    assert pkg.repo_url == "https://github.com/npm/cli.git"
+    assert pkg.releases
+    assert [(release.version, release.release_date) for release in pkg.releases] == [
+        ("9.4.2", "2026-03-18T21:20:35.937Z"),
+        ("8.0.5", "2025-12-11T14:58:53.612566Z"),
+    ]
+
+
+async def test_fetch_package_parses_dependencies_and_downloads(
+    mock_http_client: AsyncMock,
+    npm_package_data: dict[str, Any],
+    npm_downloads_data: dict[str, Any],
+) -> None:
+    """Runtime dependencies and last-month downloads are captured from npm APIs."""
+
+    mock_http_client.get = AsyncMock(side_effect=[_response(npm_package_data), _response(npm_downloads_data)])
+    crawler = _make_crawler(mock_http_client)
+    pkg = await crawler.fetch_package("@npmcli/arborist")
+
+    dep_ids = {dep.canonical_id for dep in pkg.dependencies}
+    assert dep_ids == {
+        "pkg:npm/nopt",
+        "pkg:npm/semver",
+        "pkg:npm/%40npmcli/fs",
+    }
+    assert pkg.downloads_30d == 17095128
+    assert pkg.metadata["download_count_30d"] == 17095128
+    assert pkg.metadata["downloads_start"] == "2026-03-21"
+    assert pkg.metadata["downloads_end"] == "2026-04-19"
+
+
+async def test_fetch_package_handles_missing_downloads(
+    mock_http_client: AsyncMock,
+    npm_package_data: dict[str, Any],
+) -> None:
+    """Download endpoint failures keep the package crawl usable without adoption data."""
+
+    mock_http_client.get = AsyncMock(
+        side_effect=[
+            _response(npm_package_data),
+            _response({"error": "not found"}, status_code=404),
+        ]
+    )
+    crawler = _make_crawler(mock_http_client)
+    pkg = await crawler.fetch_package("@npmcli/arborist")
+
+    assert pkg.canonical_id == "pkg:npm/%40npmcli/arborist"
+    assert pkg.downloads_30d is None
+    assert "download_count_30d" not in pkg.metadata
+
+
+async def test_fetch_dependents_is_explicit_stub(mock_http_client: AsyncMock) -> None:
+    """npm dependents are intentionally stubbed until a practical first-party API exists."""
+
+    crawler = _make_crawler(mock_http_client)
+    dependents = await crawler.fetch_dependents("@npmcli/arborist")
+
+    assert dependents == []
+    mock_http_client.get.assert_not_called()

--- a/tests/crawlers/test_pubdev.py
+++ b/tests/crawlers/test_pubdev.py
@@ -314,3 +314,55 @@ async def test_fetch_dependents_stops_paginating_at_limit(
     # All 600 from the single page are returned, but the "next" page is not fetched
     assert len(dependents) == 600
     assert mock_http_client.get.call_count == 1
+
+
+async def test_fetch_package_handles_malformed_package_payload(
+    mock_http_client: AsyncMock,
+    pubdev_metrics_data: dict[str, Any],
+    caplog: Any,
+) -> None:
+    """Malformed package payload logs warning and still returns a safe package result."""
+
+    malformed_package_data: dict[str, Any] = {
+        "name": ["stellar_flutter_sdk"],
+        "latest": "invalid",
+        "versions": "invalid",
+    }
+    mock_http_client.get = AsyncMock(side_effect=[_response(malformed_package_data), _response(pubdev_metrics_data)])
+    crawler = _make_crawler(mock_http_client)
+
+    with caplog.at_level("WARNING"):
+        pkg = await crawler.fetch_package("stellar_flutter_sdk")
+
+    assert "Failed to decode pub.dev package payload" in caplog.text
+    assert pkg.canonical_id == "pkg:pub/"
+    assert pkg.dependencies == []
+    assert pkg.releases == []
+
+
+async def test_fetch_package_converts_float_download_metrics(
+    mock_http_client: AsyncMock,
+    pubdev_package_data: dict[str, Any],
+) -> None:
+    """Float metrics are normalized to int at decode boundary."""
+
+    metrics_with_floats: dict[str, Any] = {
+        "score": {
+            "downloadCount30Days": 1469.9,
+            "grantedPoints": 140.0,
+            "maxPoints": 160.0,
+        },
+        "scorecard": {
+            "weeklyVersionDownloads": {
+                "totalWeeklyDownloads": [10.2, 20.8, 30.0, 40.4],
+            }
+        },
+    }
+    mock_http_client.get = AsyncMock(side_effect=[_response(pubdev_package_data), _response(metrics_with_floats)])
+    crawler = _make_crawler(mock_http_client)
+    pkg = await crawler.fetch_package("stellar_flutter_sdk")
+
+    assert pkg.downloads_30d == 1469
+    assert pkg.metadata["download_count_4w"] == 100
+    assert pkg.metadata["pub_points"] == 140
+    assert pkg.metadata["pub_points_max"] == 160

--- a/tests/crawlers/test_pypi.py
+++ b/tests/crawlers/test_pypi.py
@@ -1,0 +1,116 @@
+"""
+Tests for the PyPI registry crawler.
+
+Unit tests use mocked HTTP responses and monkeypatched PyPIStats calls.
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+
+from pg_atlas.crawlers.pypi import PypiCrawler
+
+
+def _response(
+    data: dict[str, Any],
+    status_code: int = 200,
+    url: str = "https://pypi.org/pypi",
+) -> httpx.Response:
+    """Create a mock PyPI JSON API response."""
+
+    return httpx.Response(
+        status_code=status_code,
+        json=data,
+        request=httpx.Request("GET", url),
+    )
+
+
+def _make_crawler(client: AsyncMock) -> PypiCrawler:
+    """Create a PyPI crawler backed by mocked HTTP and DB clients."""
+
+    session_factory = AsyncMock()
+    return PypiCrawler(
+        client=client,
+        session_factory=session_factory,
+        rate_limit=0.0,
+        max_retries=3,
+    )
+
+
+async def test_fetch_package_parses_metadata_dependencies_and_downloads(
+    mock_http_client: AsyncMock,
+    pypi_package_data: dict[str, Any],
+    pypi_stats_recent_data: dict[str, Any],
+) -> None:
+    """PyPI JSON plus PyPIStats monthly totals become repo metadata, releases, and runtime deps."""
+
+    mock_http_client.get = AsyncMock(
+        side_effect=[
+            _response(pypi_package_data, url="https://pypi.org/pypi/requests/json"),
+            _response(
+                pypi_stats_recent_data,
+                url="https://pypistats.org/api/packages/requests/recent?period=month&mirrors=true",
+            ),
+        ]
+    )
+    crawler = _make_crawler(mock_http_client)
+    pkg = await crawler.fetch_package("requests")
+
+    assert pkg.canonical_id == "pkg:pypi/requests"
+    assert pkg.display_name == "requests"
+    assert pkg.latest_version == "2.33.1"
+    assert pkg.repo_url == "https://github.com/psf/requests"
+    assert pkg.downloads_30d == 350
+    assert pkg.metadata["download_count_30d"] == 350
+    assert pkg.metadata["download_source"] == "pypistats"
+    assert pkg.metadata["download_period"] == "month"
+    assert [(release.version, release.release_date) for release in pkg.releases] == [
+        ("2.33.1", "2026-03-30T16:09:13.830020Z"),
+        ("2.33.0", "2026-03-01T10:00:00.000000Z"),
+    ]
+
+    dep_ids = {dep.canonical_id for dep in pkg.dependencies}
+    assert dep_ids == {
+        "pkg:pypi/charset-normalizer",
+        "pkg:pypi/idna",
+        "pkg:pypi/colorama",
+    }
+    assert all(dep.canonical_id != "pkg:pypi/pysocks" for dep in pkg.dependencies)
+
+
+async def test_fetch_package_handles_stats_failure(
+    mock_http_client: AsyncMock,
+    pypi_package_data: dict[str, Any],
+) -> None:
+    """A PyPIStats failure leaves the package crawl usable with metadata-only fields."""
+
+    mock_http_client.get = AsyncMock(
+        side_effect=[
+            _response(pypi_package_data, url="https://pypi.org/pypi/requests/json"),
+            httpx.TimeoutException("boom"),
+            httpx.TimeoutException("boom"),
+            httpx.TimeoutException("boom"),
+        ]
+    )
+    crawler = _make_crawler(mock_http_client)
+    pkg = await crawler.fetch_package("requests")
+
+    assert pkg.canonical_id == "pkg:pypi/requests"
+    assert pkg.downloads_30d is None
+    assert "download_count_30d" not in pkg.metadata
+
+
+async def test_fetch_dependents_is_explicit_stub(mock_http_client: AsyncMock) -> None:
+    """PyPI dependents are intentionally stubbed until there is a practical first-party API."""
+
+    crawler = _make_crawler(mock_http_client)
+    dependents = await crawler.fetch_dependents("requests")
+
+    assert dependents == []
+    mock_http_client.get.assert_not_called()

--- a/tests/crawlers/test_pypi.py
+++ b/tests/crawlers/test_pypi.py
@@ -123,3 +123,71 @@ async def test_fetch_dependents_is_explicit_stub(mock_http_client: AsyncMock) ->
 
     assert dependents == []
     mock_http_client.get.assert_not_called()
+
+
+async def test_fetch_package_handles_malformed_pypi_payload(
+    mock_http_client: AsyncMock,
+    pypi_stats_recent_data: dict[str, Any],
+    caplog: Any,
+) -> None:
+    """Malformed PyPI package JSON logs warning and still returns a safe package payload."""
+
+    malformed_package_payload: dict[str, Any] = {
+        "info": {
+            "name": ["requests"],
+            "version": 123,
+            "requires_dist": "not-a-list",
+        },
+        "releases": "not-a-dict",
+    }
+    mock_http_client.get = AsyncMock(
+        side_effect=[
+            _response(malformed_package_payload, url="https://pypi.org/pypi/requests/json"),
+            _response(
+                pypi_stats_recent_data,
+                url="https://pypistats.org/api/packages/requests/recent?period=month&mirrors=true",
+            ),
+        ]
+    )
+    crawler = _make_crawler(mock_http_client)
+
+    with caplog.at_level("WARNING"):
+        pkg = await crawler.fetch_package("requests")
+
+    assert "Failed to decode PyPI package payload" in caplog.text
+    assert pkg.canonical_id == "pkg:pypi/"
+    assert pkg.dependencies == []
+    assert pkg.releases == []
+    assert pkg.downloads_30d == 350
+
+
+async def test_fetch_package_handles_malformed_pypistats_payload(
+    mock_http_client: AsyncMock,
+    pypi_package_data: dict[str, Any],
+    caplog: Any,
+) -> None:
+    """Malformed PyPIStats payload logs warning and proceeds without download counts."""
+
+    malformed_stats_payload: dict[str, Any] = {
+        "data": {
+            "last_month": "invalid",
+        }
+    }
+    mock_http_client.get = AsyncMock(
+        side_effect=[
+            _response(pypi_package_data, url="https://pypi.org/pypi/requests/json"),
+            _response(
+                malformed_stats_payload,
+                url="https://pypistats.org/api/packages/requests/recent?period=month&mirrors=true",
+            ),
+        ]
+    )
+    crawler = _make_crawler(mock_http_client)
+
+    with caplog.at_level("WARNING"):
+        pkg = await crawler.fetch_package("requests")
+
+    assert "Failed to decode PyPIStats payload" in caplog.text
+    assert pkg.canonical_id == "pkg:pypi/requests"
+    assert pkg.downloads_30d is None
+    assert "download_count_30d" not in pkg.metadata

--- a/tests/crawlers/test_pypi.py
+++ b/tests/crawlers/test_pypi.py
@@ -1,7 +1,8 @@
 """
 Tests for the PyPI registry crawler.
 
-Unit tests use mocked HTTP responses and monkeypatched PyPIStats calls.
+Unit tests mock HTTP responses by stubbing ``httpx.AsyncClient.get`` for both
+the PyPI JSON API and the PyPIStats endpoint.
 
 SPDX-FileCopyrightText: 2026 PG Atlas contributors
 SPDX-License-Identifier: MPL-2.0
@@ -13,8 +14,9 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import httpx
+from pytest import MonkeyPatch
 
-from pg_atlas.crawlers.pypi import PypiCrawler
+from pg_atlas.crawlers.pypi import PyPICrawler
 
 
 def _response(
@@ -31,11 +33,11 @@ def _response(
     )
 
 
-def _make_crawler(client: AsyncMock) -> PypiCrawler:
+def _make_crawler(client: AsyncMock) -> PyPICrawler:
     """Create a PyPI crawler backed by mocked HTTP and DB clients."""
 
     session_factory = AsyncMock()
-    return PypiCrawler(
+    return PyPICrawler(
         client=client,
         session_factory=session_factory,
         rate_limit=0.0,
@@ -87,6 +89,7 @@ async def test_fetch_package_parses_metadata_dependencies_and_downloads(
 async def test_fetch_package_handles_stats_failure(
     mock_http_client: AsyncMock,
     pypi_package_data: dict[str, Any],
+    monkeypatch: MonkeyPatch,
 ) -> None:
     """A PyPIStats failure leaves the package crawl usable with metadata-only fields."""
 
@@ -98,6 +101,12 @@ async def test_fetch_package_handles_stats_failure(
             httpx.TimeoutException("boom"),
         ]
     )
+
+    # patch asyncio.sleep to be a no-op
+    async def no_sleep(wait: float): ...
+
+    monkeypatch.setattr("pg_atlas.crawlers.base.asyncio.sleep", no_sleep)
+
     crawler = _make_crawler(mock_http_client)
     pkg = await crawler.fetch_package("requests")
 

--- a/uv.lock
+++ b/uv.lock
@@ -341,6 +341,15 @@ wheels = [
 ]
 
 [[package]]
+name = "chardet"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -504,6 +513,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
     { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
     { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+]
+
+[[package]]
+name = "dataproperty"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mbstrdecoder" },
+    { name = "typepy", extra = ["datetime"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/81/8c8b64ae873cb9014815214c07b63b12e3b18835780fb342223cfe3fe7d8/dataproperty-1.1.0.tar.gz", hash = "sha256:b038437a4097d1a1c497695c3586ea34bea67fdd35372b9a50f30bf044d77d04", size = 42574, upload-time = "2024-12-31T14:37:26.033Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/c2/e12e95e289e6081a40454199ab213139ef16a528c7c86432de545b05a23a/DataProperty-1.1.0-py3-none-any.whl", hash = "sha256:c61fcb2e2deca35e6d1eb1f251a7f22f0dcde63e80e61f0cc18c19f42abfd25b", size = 27581, upload-time = "2024-12-31T14:37:22.657Z" },
+]
+
+[[package]]
+name = "dominate"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/f3/1c8088ff19a0fcd9c3234802a0ee47006ea64bd8852f1019194f0e3583ff/dominate-2.9.1.tar.gz", hash = "sha256:558284687d9b8aae1904e3d6051ad132dd4a8c0cf551b37ea4e7e42a31d19dc4", size = 37715, upload-time = "2023-12-24T20:45:19.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/19/0380af745f151a1648657bbcef0fb49ac28bf09083d94498163ffd9b32dc/dominate-2.9.1-py2.py3-none-any.whl", hash = "sha256:cb7b6b79d33b15ae0a6e87856b984879927c7c2ebb29522df4c75b28ffd9b989", size = 29976, upload-time = "2023-12-24T20:45:17.154Z" },
 ]
 
 [[package]]
@@ -858,6 +889,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mbstrdecoder"
+version = "1.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/ab/05ae008357c8bdb6245ebf8a101d99f26c096e0ea20800b318153da23796/mbstrdecoder-1.1.4.tar.gz", hash = "sha256:8105ef9cf6b7d7d69fe7fd6b68a2d8f281ca9b365d7a9b670be376b2e6c81b21", size = 14527, upload-time = "2025-01-18T10:07:31.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/ac/5ce64a1d4cce00390beab88622a290420401f1cabf05caf2fc0995157c21/mbstrdecoder-1.1.4-py3-none-any.whl", hash = "sha256:03dae4ec50ec0d2ff4743e63fdbd5e0022815857494d35224b60775d3d934a8c", size = 7933, upload-time = "2025-01-18T10:07:29.562Z" },
+]
+
+[[package]]
 name = "msgspec"
 version = "0.21.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1037,6 +1080,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathvalidate"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
+]
+
+[[package]]
 name = "pg-atlas-backend"
 version = "0.6.0"
 source = { editable = "." }
@@ -1052,11 +1104,13 @@ dependencies = [
     { name = "msgspec" },
     { name = "networkx" },
     { name = "numpy" },
+    { name = "packaging" },
     { name = "procrastinate" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic-settings" },
     { name = "pygithub" },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "pypistats" },
     { name = "pyrate-limiter" },
     { name = "spdx-tools" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -1095,11 +1149,13 @@ requires-dist = [
     { name = "msgspec", specifier = ">=0.21.0" },
     { name = "networkx", specifier = ">=3.0" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "packaging", specifier = ">=26.0" },
     { name = "procrastinate", specifier = ">=3.8.1" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.3.3" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "pygithub", specifier = ">=2.8.1" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.11.0" },
+    { name = "pypistats", specifier = ">=1.13.0" },
     { name = "pyrate-limiter", specifier = ">=4.1.0" },
     { name = "spdx-tools", specifier = ">=0.8.3" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.47" },
@@ -1126,6 +1182,15 @@ proto-build = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1141,6 +1206,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
+]
+
+[[package]]
+name = "prettytable"
+version = "3.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
 ]
 
 [[package]]
@@ -1428,12 +1505,52 @@ wheels = [
 ]
 
 [[package]]
+name = "pypistats"
+version = "1.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "prettytable" },
+    { name = "pytablewriter", extra = ["html"] },
+    { name = "python-slugify" },
+    { name = "termcolor" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/9b/b4b4a8d9053fa83312ce4258c122e7c26b97b239e0c717b473d561f78e45/pypistats-1.13.0.tar.gz", hash = "sha256:0e0bf01f844cbd8ca57b6658a30f6f3a586c25d65c738907d991d813b3097591", size = 125762, upload-time = "2026-01-26T18:58:40.848Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/5f/3732c2790050a73d337d25440accc72a88af21cc50c5a932300e02911d8e/pypistats-1.13.0-py3-none-any.whl", hash = "sha256:eac5d387745b94592ee171eb69827505e052e8619f0f54c8ad0dd9b2fd1fb9f8", size = 15522, upload-time = "2026-01-26T18:58:39.73Z" },
+]
+
+[[package]]
 name = "pyrate-limiter"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/33/0c/6e78218e6ef726be35a4c0a5e2e281e36ddd940566800219e96d13de99ad/pyrate_limiter-4.1.0.tar.gz", hash = "sha256:be1ac413a263aa410b98757d1b01a880650948a1fc3a959512f15865eb58dbf3", size = 306136, upload-time = "2026-03-22T14:43:03.739Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/fd/57181fafae08385d00ea2702be246ab8035352a0a8e1f63391c2bcad74d4/pyrate_limiter-4.1.0-py3-none-any.whl", hash = "sha256:2696b4e4a6cffb3d40fc76662baccb766697893f0979e12bebbfc7d3b6b19603", size = 38197, upload-time = "2026-03-22T14:43:01.975Z" },
+]
+
+[[package]]
+name = "pytablewriter"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dataproperty" },
+    { name = "mbstrdecoder" },
+    { name = "pathvalidate" },
+    { name = "setuptools" },
+    { name = "tabledata" },
+    { name = "tcolorpy" },
+    { name = "typepy", extra = ["datetime"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/a1/617730f290f04d347103ab40bf67d317df6691b14746f6e1ea039fb57062/pytablewriter-1.2.1.tar.gz", hash = "sha256:7bd0f4f397e070e3b8a34edcf1b9257ccbb18305493d8350a5dbc9957fced959", size = 619241, upload-time = "2025-01-01T15:37:00.04Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/4c/c199512f01c845dfe5a7840ab3aae6c60463b5dc2a775be72502dfd9170a/pytablewriter-1.2.1-py3-none-any.whl", hash = "sha256:e906ff7ff5151d70a5f66e0f7b75642a7f2dce8d893c265b79cc9cf6bc04ddb4", size = 91083, upload-time = "2025-01-01T15:36:55.63Z" },
+]
+
+[package.optional-dependencies]
+html = [
+    { name = "dominate" },
 ]
 
 [[package]]
@@ -1509,6 +1626,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
 ]
 
 [[package]]
@@ -1709,6 +1847,65 @@ wheels = [
 ]
 
 [[package]]
+name = "tabledata"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dataproperty" },
+    { name = "typepy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/35/171c8977162f1163368406deddde4c59673b62bd0cb2f34948a02effb075/tabledata-1.3.4.tar.gz", hash = "sha256:e9649cab129d718f3bff4150083b77f8a78c30f6634a30caf692b10fdc60cb97", size = 25074, upload-time = "2024-12-31T14:12:31.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/64/fa4160151976ee4b2cf0c1217a99443ffaeb991956feddfeac9eee9952f8/tabledata-1.3.4-py3-none-any.whl", hash = "sha256:1f56e433bfdeb89f4487abfa48c4603a3b07c5d3a3c7e05ff73dd018c24bd0d4", size = 11820, upload-time = "2024-12-31T14:12:28.584Z" },
+]
+
+[[package]]
+name = "tcolorpy"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/cc/44f2d81d8f9093aad81c3467a5bf5718d2b5f786e887b6e4adcfc17ec6b9/tcolorpy-0.1.7.tar.gz", hash = "sha256:0fbf6bf238890bbc2e32662aa25736769a29bf6d880328f310c910a327632614", size = 299437, upload-time = "2024-12-29T15:24:23.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a2/ed023f2edd1e011b4d99b6727bce8253842d66c3fbf9ed0a26fc09a92571/tcolorpy-0.1.7-py3-none-any.whl", hash = "sha256:26a59d52027e175a37e0aba72efc99dda43f074db71f55b316d3de37d3251378", size = 8096, upload-time = "2024-12-29T15:24:21.33Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "typepy"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mbstrdecoder" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/59/4c39942077d7de285f762a91024dbda731be693591732977358f77d120fb/typepy-1.3.4.tar.gz", hash = "sha256:89c1f66de6c6133209c43a94d23431d320ba03ef5db18f241091ea594035d9de", size = 39558, upload-time = "2024-12-29T09:18:15.774Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/31/e393c3830bdedd01735bd195c85ac3034b6bcaf6c18142bab60a4047ca36/typepy-1.3.4-py3-none-any.whl", hash = "sha256:d5ed3e0c7f49521bff0603dd08cf8d453371cf68d65a29d3d0038552ccc46e2e", size = 31449, upload-time = "2024-12-29T09:18:13.135Z" },
+]
+
+[package.optional-dependencies]
+datetime = [
+    { name = "packaging" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+]
+
+[[package]]
 name = "types-aiobotocore-custom"
 version = "3.3.0"
 source = { path = "vendored/types_aiobotocore_custom-3.3.0-py3-none-any.whl" }
@@ -1888,6 +2085,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -539,7 +539,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.0"
+version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -548,9 +548,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/d9/e66315807e41e69e7f6a1b42a162dada2f249c5f06ad3f1a95f84ab336ef/fastapi-0.136.0.tar.gz", hash = "sha256:cf08e067cc66e106e102d9ba659463abfac245200752f8a5b7b1e813de4ff73e", size = 396607, upload-time = "2026-04-16T11:47:13.623Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/a3/0bd5f0cdb0bbc92650e8dc457e9250358411ee5d1b65e42b6632387daf81/fastapi-0.136.0-py3-none-any.whl", hash = "sha256:8793d44ec7378e2be07f8a013cf7f7aa47d6327d0dfe9804862688ec4541a6b4", size = 117556, upload-time = "2026-04-16T11:47:11.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
@@ -1984,11 +1984,11 @@ wheels = [
 
 [[package]]
 name = "tzdata"
-version = "2026.1"
+version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #65.

## Summary
- add direct registry crawlers for NPM, Cargo, and PyPI using the shared `RegistryCrawler` contract
- wire the new systems through crawler factory aliases, CLI entrypoints, and Procrastinate registry scheduling
- extend fixtures, parser/unit tests, DB integration coverage, live API checks, and bootstrap task coverage for the new ecosystems
- document A10 completion and the registry-specific conventions discovered during implementation

## Notes
- `crawl_github_repo()` now allows deps.dev-supported systems that also have direct registry crawlers to flow through both paths instead of treating them as mutually exclusive.
- PyPI download counts now use the PyPIStats `recent` endpoint with `period=month&mirrors=true` via `_request_with_retry()`.
- npm and PyPI still leave reverse dependents empty with explicit TODOs; Cargo paginates reverse dependencies up to the 50-page / 500-item ceiling.
- `pub.dev` metrics parsing now coerces weekly download counts to `int` because the live API can emit float values.

## Verification
```text
uv run ruff check .
uv run ruff format --check .
uv run mypy pg_atlas/
uv run basedpyright $(git diff --name-only -- '*.py')
PG_ATLAS_TEST_LIVE_APIS=1 PG_ATLAS_API_URL=https://test.pg-atlas.example uv run pytest tests/crawlers/test_live_apis.py -q
PG_ATLAS_DATABASE_URL=postgresql://atlas:changeme@localhost:5432/pg_atlas PG_ATLAS_API_URL=https://test.pg-atlas.example uv run pytest -k 'not test_handle_sbom_submission_latency_regression_guardrail'
PG_ATLAS_DATABASE_URL=postgresql://atlas:changeme@localhost:5432/pg_atlas_issue65_final PG_ATLAS_API_URL=https://test.pg-atlas.example uv run alembic upgrade heads
PG_ATLAS_DATABASE_URL=postgresql://atlas:changeme@localhost:5432/pg_atlas_issue65_final ... uv run python -m pg_atlas.procrastinate.worker --queue=opengrants --drain-rounds=4 --concurrency=8 --tee=opengrants-worker.log
  opengrants_succeeded=3 opengrants_failed=0 opengrants_todo=0
PG_ATLAS_DATABASE_URL=postgresql://atlas:changeme@localhost:5432/pg_atlas_issue65_final ... uv run python -m pg_atlas.procrastinate.worker --queue=registry-crawl --drain-rounds=2 --concurrency=2 --tee=registry-crawl-worker.log
  registry_crawl_succeeded=3 registry_crawl_failed=0 registry_crawl_todo=0 unsupported_ecosystem_group_count=0
repo_metadata samples:
  pkg:github/openai/openai-node -> {"pkg:npm/openai": 71415506}
  pkg:github/reclaimprotocol/stellar-sdk-onchain-integration -> {"pkg:cargo/reclaim": 39}
  pkg:github/psf/requests -> {"pkg:pypi/requests": 1400159721}
```
