### PR TITLE
feat(bootstrap): new option to process only selected projects

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -18,6 +18,11 @@ on:
   schedule:
     - cron: "11 10 * * 2"   # weekly, Tuesday 10:11 UTC
   workflow_dispatch:
+    inputs:
+      projects:
+        description: Optional project filter (takes space-separated canonical IDs)
+        required: false
+        type: string
 
 concurrency:
   group: shadow
@@ -49,7 +54,7 @@ jobs:
         run: uv sync --frozen
 
       - name: Queue bootstrap tasks
-        run: uv run python -m pg_atlas.procrastinate.seed_opengrants
+        run: uv run python -m pg_atlas.procrastinate.seed_opengrants ${{ github.event.inputs.projects }}
 
       - name: Run worker — opengrants queue
         timeout-minutes: 320

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # PG Atlas Backend
 
-Backend for [PG Atlas](https://scf-public-goods-maintenance.github.io/pg-atlas) — the metrics
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/SCF-Public-Goods-Maintenance/pg-atlas-backend)
+[![GitHub contributors](https://img.shields.io/github/contributors/SCF-Public-Goods-Maintenance/pg-atlas-backend?logo=github)](https://www.pgatlas.xyz/repos/pkg%3Agithub%2FSCF-Public-Goods-Maintenance%2Fpg-atlas-backend)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/SCF-Public-Goods-Maintenance/pg-atlas-backend/ci.yml?branch=main&logo=github&logoColor=lightsalmon&label=CI)](https://github.com/SCF-Public-Goods-Maintenance/pg-atlas-backend/actions/workflows/ci.yml)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/SCF-Public-Goods-Maintenance/pg-atlas-backend/bootstrap.yml?branch=main&logo=github&logoColor=deeppink&label=bootstrap)](https://github.com/SCF-Public-Goods-Maintenance/pg-atlas-backend/actions/workflows/bootstrap.yml)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/SCF-Public-Goods-Maintenance/pg-atlas-backend/gitlog-queue.yml?branch=main&logo=github&logoColor=aqua&label=gitlog)](https://github.com/SCF-Public-Goods-Maintenance/pg-atlas-backend/actions/workflows/gitlog-queue.yml)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/SCF-Public-Goods-Maintenance/pg-atlas-backend/sbom-queue.yml?branch=main&logo=github&logoColor=darkorchid&label=SBOM)](https://github.com/SCF-Public-Goods-Maintenance/pg-atlas-backend/actions/workflows/sbom-queue.yml)
+
+Backend for [PG Atlas](https://www.pgatlas.xyz) — the metrics
 backbone for the SCF Public Goods dependency graph. Provides the ingestion pipeline, storage layer,
 metric computation engine, and REST API.
 

--- a/pg_atlas/data/project-git-mapping.yml
+++ b/pg_atlas/data/project-git-mapping.yml
@@ -1,7 +1,9 @@
 # project-git-mapping.yml
 #
 # Manually curated mapping of OpenGrants projectId → GitHub URLs.
-# Used by sync_opengrants to enrich projects where org.stellar.communityfund.code is missing.
+# Used by sync_opengrants to enrich projects where org.stellar.communityfund.code is missing,
+# or when an outdated repo url is present and needs to be overridden with a new repo,
+# or with a full owner repo list.
 #
 # Structure:
 #   <projectId>:
@@ -19,6 +21,10 @@
 daoip-5:scf:project:python_stellar_sdk:
   git_owner_url: "https://github.com/StellarCN"
   repo_name: "py-stellar-base"
+
+daoip-5:scf:project:stellarchain.io:
+  git_owner_url: "https://github.com/stellarchain"
+  repo_name:
 
 # --- Placeholder entries (need manual review) ---
 # Add DAOIP-5 project ID keys below as they are discovered during testing.

--- a/pg_atlas/procrastinate/seed_opengrants.py
+++ b/pg_atlas/procrastinate/seed_opengrants.py
@@ -15,6 +15,7 @@ SPDX-License-Identifier: MPL-2.0
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import logging
 
@@ -27,8 +28,10 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-async def seed() -> None:
-    """Defer the root ``sync_opengrants`` task and exit."""
+async def seed(canonical_id: list[str] | None = None) -> None:
+    """Defer the root ``sync_opengrants`` task with an optional project filter."""
+
+    selected_canonical_ids = canonical_id or []
 
     stalled_marked = await mark_stalled_jobs_failed(queue_name="opengrants")
     if stalled_marked > 0:
@@ -37,10 +40,20 @@ async def seed() -> None:
     async with app.open_async():
         from pg_atlas.procrastinate.tasks import sync_opengrants
 
-        job_id = await sync_opengrants.defer_async()
+        job_id = await sync_opengrants.defer_async(canonical_ids=selected_canonical_ids)
         logger.info(f"Deferred sync_opengrants task: job_id={job_id}")
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for the OpenGrants seed command."""
+
+    parser = argparse.ArgumentParser(description="Defer the OpenGrants bootstrap root task")
+    parser.add_argument("canonical_id", nargs="*", help="optional project filter.")
+
+    return parser.parse_args()
 
 
 if __name__ == "__main__":
     # TODO: add a CLI flag for `extended_universe`
-    asyncio.run(seed())
+    args = _parse_args()
+    asyncio.run(seed(canonical_id=args.canonical_id))

--- a/pg_atlas/procrastinate/tasks.py
+++ b/pg_atlas/procrastinate/tasks.py
@@ -85,7 +85,7 @@ DEPSDEV_SUPPORTED_SYSTEMS = frozenset({"PYPI", "NPM", "CARGO", "MAVEN", "GO", "R
 # ---------------------------------------------------------------------------
 
 #: Path to the manually-curated project → git URL mapping.
-_MAPPING_PATH = Path(__file__).parent / "project-git-mapping.yml"
+_MAPPING_PATH = Path(__file__).parent.parent / "data" / "project-git-mapping.yml"
 
 _MAX_RELEASE_ENTRIES = 555
 
@@ -205,8 +205,8 @@ async def sync_opengrants(extended_universe: bool = False) -> None:
     logger.info(f"sync_opengrants: {len(projects)} projects from OpenGrants")
 
     for proj in projects:
-        # Enrich from manual mapping when org.stellar.communityfund.code was missing.
-        if proj.git_owner_url is None and proj.canonical_id in git_mapping:
+        # Enrich from manual mapping when an override is present.
+        if proj.canonical_id in git_mapping:
             mapping = git_mapping[proj.canonical_id]
             proj.git_owner_url = mapping.get("git_owner_url")
             proj.git_repo_url = mapping.get("git_repo_url")

--- a/pg_atlas/procrastinate/tasks.py
+++ b/pg_atlas/procrastinate/tasks.py
@@ -62,7 +62,7 @@ from pg_atlas.procrastinate.github import (
     latest_version_from_repo,
     list_org_repos,
 )
-from pg_atlas.procrastinate.opengrants import fetch_scf_projects
+from pg_atlas.procrastinate.opengrants import ScfProject, fetch_scf_projects
 from pg_atlas.procrastinate.upserts import (
     absorb_external_repo,
     associate_repo_with_project,
@@ -188,7 +188,10 @@ async def process_gitlog_batch(repo_ids: list[int], seed_run_ordinal: int = 0) -
 
 
 @app.task(queue="opengrants", queueing_lock="sync_opengrants")
-async def sync_opengrants(extended_universe: bool = False) -> None:
+async def sync_opengrants(
+    extended_universe: bool = False,
+    canonical_ids: list[str] | None = None,
+) -> None:
     """
     Root bootstrap task: fetch all SCF projects and fan out.
 
@@ -200,7 +203,20 @@ async def sync_opengrants(extended_universe: bool = False) -> None:
     git_mapping = _load_git_mapping()
 
     async with httpx.AsyncClient(timeout=60.0) as client:
-        projects = await fetch_scf_projects(client)
+        projects: list[ScfProject] = await fetch_scf_projects(client)
+
+    # ----- Continue only with selected projects -----
+    # use cases: testing and targeted reprocessing
+    selected_canonical_ids = canonical_ids or []
+    if selected_canonical_ids:
+        requested_ids = set(selected_canonical_ids)
+        projects = [project for project in projects if project.canonical_id in requested_ids]
+
+        available_ids = {project.canonical_id for project in projects}
+        missing_ids = requested_ids.difference(available_ids)
+        if missing_ids:
+            missing_ids_text = ", ".join(sorted(missing_ids))
+            raise ValueError(f"sync_opengrants: canonical_id not found in OpenGrants results: {missing_ids_text}")
 
     logger.info(f"sync_opengrants: {len(projects)} projects from OpenGrants")
 

--- a/tests/bootstrap/test_app_worker_seed.py
+++ b/tests/bootstrap/test_app_worker_seed.py
@@ -124,7 +124,28 @@ async def test_seed_defers_sync_opengrants(mocker: pytest_mock.MockerFixture) ->
     await seed()
 
     mark_mock.assert_awaited_once_with(queue_name="opengrants")
-    task_mock.defer_async.assert_called_once()
+    task_mock.defer_async.assert_called_once_with(canonical_ids=[])
+
+
+async def test_seed_defers_sync_opengrants_with_project_filter(mocker: pytest_mock.MockerFixture) -> None:
+    from pg_atlas.procrastinate.seed_opengrants import seed
+
+    mocker.patch(
+        "pg_atlas.procrastinate.seed_opengrants.mark_stalled_jobs_failed",
+        new=mocker.AsyncMock(return_value=0),
+    )
+    app_mock = mocker.patch("pg_atlas.procrastinate.seed_opengrants.app")
+    ctx = mocker.AsyncMock()
+    app_mock.open_async.return_value = ctx
+
+    task_mock = mocker.patch("pg_atlas.procrastinate.tasks.sync_opengrants")
+    task_mock.defer_async = mocker.AsyncMock(return_value=1)
+
+    await seed(canonical_id=["daoip-5:scf:project:python_stellar_sdk", "daoip-5:scf:project:stellarchain.io"])
+
+    task_mock.defer_async.assert_called_once_with(
+        canonical_ids=["daoip-5:scf:project:python_stellar_sdk", "daoip-5:scf:project:stellarchain.io"]
+    )
 
 
 async def test_seed_gitlog_defers_batches(mocker: pytest_mock.MockerFixture) -> None:

--- a/tests/bootstrap/test_tasks.py
+++ b/tests/bootstrap/test_tasks.py
@@ -123,6 +123,67 @@ async def test_sync_opengrants_defers_each_project_with_mapping(mocker: Any) -> 
     assert first_call["category"] == "Developer Tooling"
 
 
+async def test_sync_opengrants_filters_projects_by_canonical_id(mocker: Any) -> None:
+    projects = [
+        ScfProject(
+            canonical_id="daoip-5:scf:project:python_stellar_sdk",
+            display_name="Python SDK",
+            activity_status=ActivityStatus.live,
+            git_owner_url="https://github.com/stellar",
+            git_repo_url="https://github.com/stellar/python-stellar-sdk",
+            category="Developer Tooling",
+        ),
+        ScfProject(
+            canonical_id="daoip-5:scf:project:stellarchain.io",
+            display_name="StellarChain",
+            activity_status=ActivityStatus.live,
+            git_owner_url="https://github.com/stellarchain",
+            git_repo_url="https://github.com/stellarchain/web",
+            category="Developer Tooling",
+        ),
+    ]
+
+    mocker.patch("pg_atlas.procrastinate.tasks.fetch_scf_projects", new=mocker.AsyncMock(return_value=projects))
+    mocker.patch("pg_atlas.procrastinate.tasks._load_git_mapping", return_value={})
+    defer_mock = mocker.patch.object(process_project, "defer_async", new=mocker.AsyncMock())
+
+    await sync_opengrants(canonical_ids=["daoip-5:scf:project:python_stellar_sdk"])
+
+    defer_mock.assert_awaited_once()
+    deferred_call: dict[str, Any] = defer_mock.call_args.kwargs
+    assert deferred_call["project_canonical_id"] == "daoip-5:scf:project:python_stellar_sdk"
+
+
+async def test_sync_opengrants_raises_for_unknown_canonical_ids(mocker: Any) -> None:
+    projects = [
+        ScfProject(
+            canonical_id="daoip-5:scf:project:python_stellar_sdk",
+            display_name="Python SDK",
+            activity_status=ActivityStatus.live,
+            git_owner_url="https://github.com/stellar",
+            git_repo_url="https://github.com/stellar/python-stellar-sdk",
+            category="Developer Tooling",
+        )
+    ]
+
+    mocker.patch("pg_atlas.procrastinate.tasks.fetch_scf_projects", new=mocker.AsyncMock(return_value=projects))
+    mocker.patch("pg_atlas.procrastinate.tasks._load_git_mapping", return_value={})
+    defer_mock = mocker.patch.object(process_project, "defer_async", new=mocker.AsyncMock())
+
+    with pytest.raises(ValueError, match="not found") as exc_info:
+        await sync_opengrants(
+            canonical_ids=[
+                "daoip-5:scf:project:python_stellar_sdk",
+                "daoip-5:scf:project:missing_one",
+                "daoip-5:scf:project:missing_two",
+            ]
+        )
+
+    assert "daoip-5:scf:project:missing_one" in str(exc_info.value)
+    assert "daoip-5:scf:project:missing_two" in str(exc_info.value)
+    defer_mock.assert_not_awaited()
+
+
 async def test_process_gitlog_batch_calls_runtime(mocker: Any) -> None:
     runtime_mock = mocker.patch("pg_atlas.procrastinate.tasks.process_gitlog_repo_batch", new=mocker.AsyncMock())
 

--- a/tests/bootstrap/test_tasks.py
+++ b/tests/bootstrap/test_tasks.py
@@ -69,6 +69,7 @@ def test_purl_type_for_system() -> None:
 def test_load_git_mapping() -> None:
     mapping = _load_git_mapping()
     assert "daoip-5:scf:project:python_stellar_sdk" in mapping
+    assert "daoip-5:scf:project:stellarchain.io" in mapping
 
 
 async def test_defer_with_lock_handles_already_enqueued(mocker: Any) -> None:


### PR DESCRIPTION
When a new override of source data becomes available, it's not always a good option to wait until the next scheduled bootstrap run to apply this overrode.

The PR adds CLI and workflow tooling to process one or a few targeted projects. It does so rather inefficiently by still loading all the OpenGrants pages and filtering them in Python. This is done for simplicity.

I also added a project => git mapping for Stellarchain, and I put some badges at the top of the readme.