### PR TITLE
feat(data): allow Public Goods proposals to patch bootstrapped project info

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,10 +25,8 @@ commit is created.
 
 ## Known Issues and PR Context
 
-As mandatory preparation for any task, use your GitHub tools to list all open _and_ closed issues
-for the current repo. Read the open and closed issues in full with all their comments when they are
-relevant for the current task. Memorize the entire issue list so you can read full issues during
-task implementation, as they become relevant.
+As mandatory preparation for any task, use your GitHub tools to list all open issues for the current
+repo. Read the open issues in full with all their comments when they are relevant for the current task.
 
 Work is always done on feature branches. If the current branch is `main`, WARN the user. Check if
 the feature branch is associated with a PR: read the full PR including its comments to understand
@@ -42,9 +40,8 @@ comments.
 
 ## Deliverable Naming
 
-Work is organised into deliverables labelled A1, A2, A3 … (from the proposal in
-`SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io`). Current scope is defined by
-whichever is being built; stubs for later deliverables are marked `# TODO A<n>:` in code.
+Previous work was organised into deliverables labelled A1, A2, A3 … (from the proposal in
+`SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io`).
 
 ## Tooling
 
@@ -114,8 +111,6 @@ These rules MUST be enforced manually. No ruff rules are available to enforce th
 ## Current Deployment State
 
 This is a compact list. Keep it compact.
-When you start work on a new deliverable, read `.github/agent-handoff/implementation-notes.md`.
-When you have validated that a deliverable has been completed, update `implementation-notes.md`.
 
 - **A1 complete**: CI green, DO App Platform live at
   `https://api.pgatlas.xyz` (`basic-xxs`, region `ams3`).

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ htmlcov/
 artifact_store/
 logs/
 
+# data for human review
+pg_atlas/data/projects/new.*.yml
 
 #Ignore windsurf AI rules
 .windsurfrules

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 .mypy_cache/
+.github_cache/
 *.egg-info/
 dist/
 build/

--- a/pg_atlas/data/projects/pg-proposal-overrides.yml
+++ b/pg_atlas/data/projects/pg-proposal-overrides.yml
@@ -14,88 +14,255 @@ daoip-5:scf:project:.net_stellar_sdk:
   display_name: ".NET Stellar SDK"
   activity_status: "live"
   git_owner_url: "https://github.com/Beans-BV"
+  git_repo_urls:
+    - "https://github.com/Beans-BV/dotnet-stellar-sdk"
+  category: "SDKs"
+  metadata:
+    description: ".NET Stellar SDK that supports API backends with Horizon and Soroban."
+    website: "https://beans-bv.github.io/dotnet-stellar-sdk/"
+    first_released: "April 2018"
 
 daoip-5:scf:project:flutter_stellar_sdk:
   display_name: "Stellar Flutter SDK"
   activity_status: "live"
   git_owner_url: "https://github.com/Soneso"
+  git_repo_urls:
+    - "https://github.com/Soneso/stellar_flutter_sdk"
+  category: "SDKs"
+  metadata:
+    description: "The Stellar SDK for Flutter, providing transaction building, Horizon and Soroban RPC access, high-level
+      Soroban smart contract support, and implements 18 Stellar Ecosystem Proposals (SEPs) across iOS, Android, and web."
+    website: "https://github.com/Soneso/stellar_flutter_sdk"
+    first_released: "June 2020"
 
 daoip-5:scf:project:java_stellar_sdk:
   display_name: "Java Stellar SDK"
   activity_status: "live"
   git_owner_url: "https://github.com/lightsail-network"
+  git_repo_urls:
+    - "https://github.com/lightsail-network/java-stellar-sdk"
+  category: "SDKs"
+  metadata:
+    description: "The Java Stellar SDK provides APIs to build transactions, query Horizon, and interact with Soroban RPC,
+      with Android support and implementations of several Stellar Ecosystem Proposals."
+    website: "https://github.com/lightsail-network/java-stellar-sdk"
+    first_released: "November 2015"
+
+daoip-5:scf:project:kmp_stellar_sdk:
+  display_name: "KMP Stellar SDK"
+  activity_status: "live"
+  git_owner_url: "https://github.com/Soneso"
+  git_repo_urls:
+    - "https://github.com/Soneso/kmp-stellar-sdk"
+  category: "SDKs"
+  metadata:
+    description: "Write your Stellar integration once in Kotlin and run it across Mobile, Web, Desktop, and Server: transactions,
+      Stellar RPC and Horizon, smart contracts, OpenZeppelin smart accounts, and 17 SEPs."
+    website: "https://developers.stellar.org/docs/tools/sdks/client-sdks#kotlin-multiplatform-sdk"
+    first_released: "October 2025"
 
 daoip-5:scf:project:obsrvr_radar:
   display_name: "OBSRVR Radar"
   activity_status: "live"
   git_owner_url: "https://github.com/withObsrvr"
+  git_repo_urls:
+    - "https://github.com/withObsrvr/stellarbeat"
+  category: "Infrastructure Monitoring"
+  metadata:
+    description: "A Stellar network explorer that turns validator, quorum, organization, and history archive data into plain-language
+      network health insights."
+    website: "https://radar.withobsrvr.com"
+    first_released: "June 2025"
 
 daoip-5:scf:project:opengrants:
   display_name: "OpenGrants"
   activity_status: "live"
   git_owner_url: "https://github.com/metagov"
+  git_repo_urls:
+    - "https://github.com/metagov/opengrants-platform"
+    - "https://github.com/metagov/Grants-Gateway-API"
+  category: "Other"
+  metadata:
+    description: "OpenGrants is open data infrastructure for Web3 grants that maintains the largest cross-ecosystem funding
+      data set, including all completed SCF rounds."
+    website: "https://opengrants.daostar.org/"
+    first_released: "September 2025"
 
 daoip-5:scf:project:python_stellar_sdk:
   display_name: "Python Stellar SDK"
   activity_status: "live"
   git_owner_url: "https://github.com/StellarCN"
+  git_repo_urls:
+    - "https://github.com/StellarCN/py-stellar-base"
+  category: "SDKs"
+  metadata:
+    description: "The Python Stellar SDK provides APIs to build transactions, query Horizon, and interact with Soroban RPC,
+      with implementations of several Stellar Ecosystem Proposals."
+    website: "https://stellar-sdk.readthedocs.io"
+    first_released: "October 2016"
 
 daoip-5:scf:project:refractorspace:
   display_name: "RefractorSpace"
   activity_status: "live"
   git_owner_url: "https://github.com/stellar-expert"
+  git_repo_urls:
+    - "https://github.com/stellar-expert/refractor"
+  category: "Governance Tools"
+  metadata:
+    description: "Pending transactions storage and multisig aggregator for Stellar Network."
+    website: "https://refractor.space"
+    first_released: "March 2021"
 
 daoip-5:scf:project:scaffold_stellar:
   display_name: "Stellar Scaffold"
   activity_status: "live"
   git_owner_url: "https://github.com/stellar-scaffold"
+  git_repo_urls:
+    - "https://github.com/stellar-scaffold/cli"
+  category: "Developer Experience"
+  metadata:
+    description: "Go from idea to app faster with a custom, pluggable CLI; a multi-framework template system; and a customizable,
+      modern frontend."
+    website: "https://scaffoldstellar.org/"
+    first_released: "May 2025"
 
 daoip-5:scf:project:scout:
   display_name: "Scout"
   activity_status: "live"
   git_owner_url: "https://github.com/CoinFabrik"
+  git_repo_urls:
+    - "https://github.com/CoinFabrik/scout-audit"
+  category: "Security & Auditing Tools"
+  metadata:
+    description: "Scout is an extensible open source vulnerability analyzer built for Soroban."
+    website: "https://www.coinfabrik.com/products/scout/"
+    first_released: "30 June 2023"
 
 daoip-5:scf:project:solidity_contracts_on_soroban:
   display_name: "Hyperledger Solang"
   activity_status: "live"
   git_owner_url: "https://github.com/hyperledger-solang"
+  git_repo_urls:
+    - "https://github.com/hyperledger-solang/solang"
+  category: "Developer Experience"
+  metadata:
+    description: "A Solidity compiler for Stellar"
+    website: "https://solang.io/"
+    first_released: "November 2025"
 
 daoip-5:scf:project:soroban_security_portal:
   display_name: "Soroban Security Portal"
   activity_status: "live"
   git_owner_url: "https://github.com/inferara"
+  git_repo_urls:
+    - "https://github.com/inferara/soroban-security-portal"
+  category: "Developer Experience"
+  metadata:
+    description: "A Soroban specific knowledge base which lets users access audits, individual vulnerabilities and code in
+      an organized fashion."
+    website: "https://sorobansecurity.com/"
+    first_released: "July 2025 (website) September 2025 (all milestones)"
 
 daoip-5:scf:project:soropg:
   display_name: "SoroPG"
   activity_status: "live"
   git_owner_url: "https://github.com/jamesbachini"
+  git_repo_urls:
+    - "https://github.com/jamesbachini/Soroban-Playground"
+  category: "Developer Experience"
+  metadata:
+    description: "SoroPG is an open-source, browser-based Soroban IDE that lets developers write, test, run security checks,
+      deploy, and interact with Stellar smart contracts with zero local setup."
+    website: "https://soropg.com"
+    first_released: "May 2025"
 
 daoip-5:scf:project:stellar_hardware_wallet_support:
   display_name: "Stellar Hardware Wallet Support"
   activity_status: "live"
   git_owner_url: "https://github.com/lightsail-network"
+  git_repo_urls:
+    - "https://github.com/LedgerHQ/app-stellar"
+    - "https://github.com/ledgerhq/ledger-live"
+    - "https://github.com/trezor/trezor-firmware"
+    - "https://github.com/trezor/trezor-suite"
+    - "https://github.com/lightsail-network/strledger"
+  category: "Wallet Support"
+  metadata:
+    description: "Hardware wallet integration for Stellar, enabling secure transaction signing on Ledger and Trezor devices."
+    website: "https://lightsail.network"
+    first_released: "July 2021"
 
 daoip-5:scf:project:stellar_ios_mac_sdk:
   display_name: "Stellar iOS SDK"
   activity_status: "live"
   git_owner_url: "https://github.com/Soneso"
-
-daoip-5:scf:project:stellar_php_sdk:
-  display_name: "Stellar PHP SDK"
-  activity_status: "live"
-  git_owner_url: "https://github.com/Soneso"
-
-daoip-5:scf:project:stellar_registry:
-  display_name: "Stellar Registry"
-  activity_status: "live"
-  git_owner_url: "https://github.com/stellar-registry"
-
-daoip-5:scf:project:stellarchain.io:
-  display_name: "Stellarchain"
-  activity_status: "live"
-  git_owner_url: "https://github.com/stellarchain"
+  git_repo_urls:
+    - "https://github.com/Soneso/stellar-ios-mac-sdk"
+  category: "SDKs"
+  metadata:
+    description: "The Stellar SDK for iOS and macOS, providing transaction building, Horizon and Soroban RPC access, high-level
+      Soroban smart contract support, and implements 18 Stellar Ecosystem Proposals (SEPs)."
+    website: "https://github.com/Soneso/stellar-ios-mac-sdk"
+    first_released: "March 2018"
 
 daoip-5:scf:project:stellar_light:
   display_name: "Stellar Light"
   activity_status: "live"
   git_owner_url: "https://github.com/Stellar-Light"
+  git_repo_urls:
+    - "https://github.com/Stellar-Light/stellarlight"
+    - "https://github.com/Stellar-Light/scout-mcp"
+    - "https://github.com/Stellar-Light/stellar-scout"
+  category: "Ecosystem Visibility"
+  metadata:
+    description: "stellar light is the ecosystem data layer for stellar — a single, machine-readable source of truth for projects,
+      code, funding, stablecoins, dev activity, partners, and builders, queryable by humans, tools, and ai agents."
+    website: "https://stellarlight.xyz"
+    first_released: "Jan 2026"
+
+daoip-5:scf:project:stellar_php_sdk:
+  display_name: "Stellar PHP SDK"
+  activity_status: "live"
+  git_owner_url: "https://github.com/Soneso"
+  git_repo_urls:
+    - "https://github.com/Soneso/stellar-php-sdk"
+  category: "SDKs"
+  metadata:
+    description: "The Stellar SDK for PHP, providing transaction building, Horizon and Soroban RPC access, high-level Soroban
+      smart contract support, and implements 19 Stellar Ecosystem Proposals (SEPs)."
+    website: "https://github.com/Soneso/stellar-php-sdk"
+    first_released: "May 2022"
+
+daoip-5:scf:project:stellar_registry:
+  display_name: "Stellar Registry"
+  activity_status: "live"
+  git_owner_url: "https://github.com/stellar-registry"
+  category: "Developer Experience"
+  metadata:
+    description: "Stellar Registry is an on-chain smart contract registry for Soroban that lets developers publish, version,
+      discover, and deploy Wasm binaries and contract instances, making contracts reusable across the ecosystem like packages."
+    website: "https://rgstry.xyz"
+    first_released: "March 2026"
+
+daoip-5:scf:project:stellarchain.io:
+  display_name: "Stellarchain"
+  activity_status: "live"
+  git_owner_url: "https://github.com/stellarchain"
+  git_repo_urls:
+    - "https://github.com/stellarchain/v4"
+  category: "Infrastructure Monitoring"
+  metadata:
+    description: "Explore the Stellar blockchain - transactions, accounts, contracts, ledgers, assets, markets, and operations."
+    website: "https://stellarchain.io"
+    first_released: "March 2024"
+
+daoip-5:scf:project:tansu_-_soroban_versioning:
+  display_name: "Tansu"
+  activity_status: "live"
+  git_owner_url: "https://github.com/Consulting-Manao"
+  git_repo_urls:
+    - "https://github.com/Consulting-Manao/tansu"
+  metadata:
+    description: "Tansu provides cryptographic proof of code integrity and transparent governance for open-source projects."
+    website: "https://tansu.dev"
+    first_released: "October 2025"

--- a/pg_atlas/data/projects/pg-proposal-overrides.yml
+++ b/pg_atlas/data/projects/pg-proposal-overrides.yml
@@ -1,0 +1,101 @@
+# Automatically drafted overrides for project fields. Always reviewed and corrected by the human reviewer.
+#
+# This patch file is meant to be updated quarterly, during the PG Award's discussion period.
+# It exclusively contains patches and new entries based on PG Award proposals.
+# The overrides allow PG Atlas to provide the most recent data before it is captured by other sources.
+#
+# Schema: ../schema-override-project.yml
+#
+#
+# SPDX-FileCopyrightText: 2026 PG Atlas contributors
+# SPDX-License-Identifier: MPL-2.0
+
+daoip-5:scf:project:.net_stellar_sdk:
+  display_name: ".NET Stellar SDK"
+  activity_status: "live"
+  git_owner_url: "https://github.com/Beans-BV"
+
+daoip-5:scf:project:flutter_stellar_sdk:
+  display_name: "Stellar Flutter SDK"
+  activity_status: "live"
+  git_owner_url: "https://github.com/Soneso"
+
+daoip-5:scf:project:java_stellar_sdk:
+  display_name: "Java Stellar SDK"
+  activity_status: "live"
+  git_owner_url: "https://github.com/lightsail-network"
+
+daoip-5:scf:project:obsrvr_radar:
+  display_name: "OBSRVR Radar"
+  activity_status: "live"
+  git_owner_url: "https://github.com/withObsrvr"
+
+daoip-5:scf:project:opengrants:
+  display_name: "OpenGrants"
+  activity_status: "live"
+  git_owner_url: "https://github.com/metagov"
+
+daoip-5:scf:project:python_stellar_sdk:
+  display_name: "Python Stellar SDK"
+  activity_status: "live"
+  git_owner_url: "https://github.com/StellarCN"
+
+daoip-5:scf:project:refractorspace:
+  display_name: "RefractorSpace"
+  activity_status: "live"
+  git_owner_url: "https://github.com/stellar-expert"
+
+daoip-5:scf:project:scaffold_stellar:
+  display_name: "Stellar Scaffold"
+  activity_status: "live"
+  git_owner_url: "https://github.com/stellar-scaffold"
+
+daoip-5:scf:project:scout:
+  display_name: "Scout"
+  activity_status: "live"
+  git_owner_url: "https://github.com/CoinFabrik"
+
+daoip-5:scf:project:solidity_contracts_on_soroban:
+  display_name: "Hyperledger Solang"
+  activity_status: "live"
+  git_owner_url: "https://github.com/hyperledger-solang"
+
+daoip-5:scf:project:soroban_security_portal:
+  display_name: "Soroban Security Portal"
+  activity_status: "live"
+  git_owner_url: "https://github.com/inferara"
+
+daoip-5:scf:project:soropg:
+  display_name: "SoroPG"
+  activity_status: "live"
+  git_owner_url: "https://github.com/jamesbachini"
+
+daoip-5:scf:project:stellar_hardware_wallet_support:
+  display_name: "Stellar Hardware Wallet Support"
+  activity_status: "live"
+  git_owner_url: "https://github.com/lightsail-network"
+
+daoip-5:scf:project:stellar_ios_mac_sdk:
+  display_name: "Stellar iOS SDK"
+  activity_status: "live"
+  git_owner_url: "https://github.com/Soneso"
+
+daoip-5:scf:project:stellar_php_sdk:
+  display_name: "Stellar PHP SDK"
+  activity_status: "live"
+  git_owner_url: "https://github.com/Soneso"
+
+daoip-5:scf:project:stellar_registry:
+  display_name: "Stellar Registry"
+  activity_status: "live"
+  git_owner_url: "https://github.com/stellar-registry"
+
+daoip-5:scf:project:stellarchain.io:
+  display_name: "Stellarchain"
+  activity_status: "live"
+  git_owner_url: "https://github.com/stellarchain"
+
+daoip-5:scf:project:stellar_light:
+  display_name: "Stellar Light"
+  activity_status: "live"
+  git_owner_url: "https://github.com/Stellar-Light"

--- a/pg_atlas/data/schema-override-project.yml
+++ b/pg_atlas/data/schema-override-project.yml
@@ -37,7 +37,6 @@ additionalProperties:
       type: object
       required:
         - description
-        - open_source
       properties:
         description:
           type: string
@@ -49,6 +48,8 @@ additionalProperties:
         x_profile:
           type: string
           format: uri
+        first_released:
+          type: string
 
       additionalProperties: false
 

--- a/pg_atlas/procrastinate/github.py
+++ b/pg_atlas/procrastinate/github.py
@@ -259,36 +259,40 @@ def list_org_repos(owner: str) -> list[GitHubRepoMetadata]:
         return []
 
 
-def get_single_repo(owner: str, repo_name: str) -> list[GitHubRepoMetadata]:
+def fetch_repo_list(git_repo_urls: list[str]) -> list[GitHubRepoMetadata]:
     """
-    Return metadata for a single public repo owned by *owner*.
+    Return metadata for a list of public repos.
+
+    Logs GitHub API errors and returns the available results.
     """
     gh = get_github_client()
+    metadata: list[GitHubRepoMetadata] = []
 
-    try:
-        repo = gh.get_repo(f"{owner}/{repo_name}")
-        return [
-            GitHubRepoMetadata(
-                name=repo.name,
-                full_name=repo.full_name,
-                description=repo.description or "",
-                default_branch=repo.default_branch,
-                stars=repo.stargazers_count,
-                forks=repo.forks_count,
-                pushed_at=repo.pushed_at,
-                language=repo.language or "",
-                topics=repo.topics,
+    for repo_url in git_repo_urls:
+        owner, repo_name = repo_url.rstrip("/").rsplit("/", 2)[-2:]
+        try:
+            repo = gh.get_repo(f"{owner}/{repo_name}")
+            metadata.append(
+                GitHubRepoMetadata(
+                    name=repo.name,
+                    full_name=repo.full_name,
+                    description=repo.description or "",
+                    default_branch=repo.default_branch,
+                    stars=repo.stargazers_count,
+                    forks=repo.forks_count,
+                    pushed_at=repo.pushed_at,
+                    language=repo.language or "",
+                    topics=repo.topics,
+                )
             )
-        ]
+        except GithubException as exc:
+            if exc.status in (404, 409):
+                msg = str(exc.data.get("message", "")) if hasattr(exc.data, "get") else ""  # pyright: ignore[reportUnknownMemberType]
+                logger.warning(f"GitHub repo unavailable ({exc.status}): {owner}/{repo_name} - {msg}")
+            else:
+                logger.error(f"GitHub API error getting repo {owner}/{repo_name}: {exc}")
 
-    except GithubException as exc:
-        if exc.status in (404, 409):
-            msg = str(exc.data.get("message", "")) if hasattr(exc.data, "get") else ""  # pyright: ignore[reportUnknownMemberType]
-            logger.warning(f"GitHub repo unavailable ({exc.status}): {owner}/{repo_name} - {msg}")
-        else:
-            logger.error(f"GitHub API error getting repo {owner}/{repo_name}: {exc}")
-
-        return []
+    return metadata
 
 
 def detect_packages_from_repo(owner: str, repo_name: str) -> list[PackageReference]:

--- a/pg_atlas/procrastinate/opengrants.py
+++ b/pg_atlas/procrastinate/opengrants.py
@@ -60,7 +60,7 @@ class ScfProject:
     Intermediate representation of an SCF project extracted from OpenGrants.
 
     Fields correspond 1-to-1 with the columns needed for a ``Project`` upsert.
-    ``git_repo_url`` is not stored on ``Project`` but is passed to the
+    ``git_repo_urls`` is not stored on ``Project`` but is passed to the
     downstream ``process_project`` task so it can target deps.dev lookups.
     """
 
@@ -68,7 +68,7 @@ class ScfProject:
     display_name: str
     activity_status: ActivityStatus
     git_owner_url: str | None
-    git_repo_url: str | None
+    git_repo_urls: list[str] = field(default_factory=list[str])
     category: str | None = None
     project_metadata: dict[str, Any] = field(default_factory=lambda: {})
 
@@ -510,7 +510,7 @@ def _map_application(
     activity_status = _activity_status_from_tranche(app)
 
     git_owner_url: str | None = None
-    git_repo_url: str | None = None
+    git_repo_urls: list[str] = []
 
     raw_code_url = _get_ext(app, "org.stellar.communityfund.code")
 
@@ -523,7 +523,7 @@ def _map_application(
             )
         else:
             git_owner_url = org_url
-            git_repo_url = repo_url
+            git_repo_urls = [repo_url] if repo_url else []
 
     project_metadata = _build_project_metadata(project=None, latest_app=app, scf_submissions=scf_submissions)
 
@@ -532,7 +532,7 @@ def _map_application(
         display_name=display_name,
         activity_status=activity_status,
         git_owner_url=git_owner_url,
-        git_repo_url=git_repo_url,
+        git_repo_urls=git_repo_urls,
         project_metadata=project_metadata,
     )
 
@@ -567,7 +567,7 @@ def _merge_project_and_applications(
 
     # --- GitHub URL: latest application first, then project socials ---
     git_owner_url: str | None = None
-    git_repo_url: str | None = None
+    git_repo_urls: list[str] = []
 
     if latest_app is not None:
         raw_code_url = _get_ext(latest_app, "org.stellar.communityfund.code")
@@ -579,11 +579,12 @@ def _merge_project_and_applications(
                 logger.warning(f"Invalid GitHub URL in application code for project {canonical_id}: {raw_code_url!r}")
             else:
                 git_owner_url = org_url
-                git_repo_url = repo_url
+                git_repo_urls = [repo_url] if repo_url else []
 
     if git_owner_url is None:
         socials = project.get("socials", [])
-        git_owner_url, git_repo_url = _extract_github_from_socials(socials)
+        git_owner_url, repo_url = _extract_github_from_socials(socials)
+        git_repo_urls = [repo_url] if repo_url else []
 
     # --- Metadata ---
     project_metadata = _build_project_metadata(
@@ -597,7 +598,7 @@ def _merge_project_and_applications(
         display_name=display_name,
         activity_status=activity_status,
         git_owner_url=git_owner_url,
-        git_repo_url=git_repo_url,
+        git_repo_urls=git_repo_urls,
         category=category,
         project_metadata=project_metadata,
     )

--- a/pg_atlas/procrastinate/tasks.py
+++ b/pg_atlas/procrastinate/tasks.py
@@ -58,7 +58,7 @@ from pg_atlas.procrastinate.github import (
     GitHubRepoMetadata,
     PackageReference,
     detect_packages_from_repo,
-    get_single_repo,
+    fetch_repo_list,
     latest_version_from_repo,
     list_org_repos,
 )
@@ -241,7 +241,7 @@ async def sync_opengrants(
         metadata = fields.pop("metadata", {})
         project_data = {
             "canonical_id": canonical_id,
-            "git_repo_url": None,
+            "git_repo_urls": list[str](),
             **fields,
             "project_metadata": metadata,
         }
@@ -262,7 +262,7 @@ async def process_project(
     display_name: str,
     activity_status: str,
     git_owner_url: str | None,
-    git_repo_url: str | None,
+    git_repo_urls: list[str],
     project_metadata: dict[str, Any] | None,
     category: str | None = None,
     extended_universe: bool = False,
@@ -309,12 +309,12 @@ async def process_project(
 
     repos_to_crawl: list[GitHubRepoMetadata] = []
     if owner:
-        if extended_universe or not git_repo_url:
+        if extended_universe or not git_repo_urls:
             repos_to_crawl = list_org_repos(owner)
         else:
-            repo_name = git_repo_url.rstrip("/").rsplit("/", 1)[-1]
-            repos_to_crawl = get_single_repo(owner, repo_name)
-            logger.info(f"Restricting {git_owner_url} crawl to {repo_name} only.")
+            repos_to_crawl = fetch_repo_list(git_repo_urls)
+            repo_names = [repo.full_name for repo in repos_to_crawl]
+            logger.info(f"Restricting {canonical_id} crawl to {repo_names}.")
 
     # ----- deps.dev GetProjectBatch -----
     # Build project IDs of the form "github.com/owner/repo".

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "pyrate-limiter>=4.1.0",
     "pypistats>=1.13.0",
     "packaging>=26.0",
-    "mistletoe>=1.6.0",
 ]
 
 [dependency-groups]
@@ -45,6 +44,8 @@ dev = [
     "types-networkx>=3.6.1.20260402",
     "types-aiobotocore-custom",
     "basedpyright>=1.39.0",
+    "mistletoe>=1.6.0",
+    "ruamel-yaml>=0.19.1",
 ]
 proto-build = [
     "betterproto2-compiler>=0.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pyrate-limiter>=4.1.0",
     "pypistats>=1.13.0",
     "packaging>=26.0",
+    "mistletoe>=1.6.0",
 ]
 
 [dependency-groups]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,5 @@
+# scripts/
+
+The scripts in this directory are intended for human-in-the-loop usage. They are the automations that achieve part of a larger task. Each script starts with a docstring that explains its purpose and gives basic usage instructions.
+
+Python scripts import from `pg_atlas`, never the other way around. They are executed in the same virtualenv with `uv run ...`, and _may_ be registered in `pyproject.toml` under `[project.scripts]`.

--- a/scripts/draft_pg_proposal_overrides.py
+++ b/scripts/draft_pg_proposal_overrides.py
@@ -1,0 +1,907 @@
+"""
+Draft PG proposal overrides from open proposal PRs.
+
+This script is intended for human-in-the-loop operation. It reads open pull
+requests with label ``pg-award-proposal`` from the public-goods docs
+repository, extracts patchable project fields from proposal markdown files, and
+writes a review draft to:
+
+    pg_atlas/data/projects/new.pg-proposal-overrides.yml
+
+The canonical baseline and matching source is:
+
+    pg_atlas/data/projects/pg-proposal-overrides.yml
+
+Usage:
+    uv run python scripts/draft_pg_proposal_overrides.py
+
+SPDX-FileCopyrightText: 2026 PG Atlas contributors
+SPDX-License-Identifier: MPL-2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from io import StringIO
+from pathlib import Path
+from typing import Any, cast
+from urllib.parse import urlparse
+
+from github import GithubException
+from mistletoe import Document
+from mistletoe.block_token import Heading, Paragraph, Table
+from mistletoe.span_token import LineBreak
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
+
+from pg_atlas.procrastinate.github import get_github_client
+
+_DOCS_OWNER = "SCF-Public-Goods-Maintenance"
+_DOCS_REPO = "scf-public-goods-maintenance.github.io"
+_QUERY = "repo:SCF-Public-Goods-Maintenance/scf-public-goods-maintenance.github.io is:pr is:open label:pg-award-proposal"
+_DOCS_REPO_URL = f"https://github.com/{_DOCS_OWNER}/{_DOCS_REPO}"
+
+_DAOIP_PREFIX = "daoip-5:scf:project:"
+
+_PROJECTS_DIR = Path("pg_atlas/data/projects")
+_CANONICAL_PATH = _PROJECTS_DIR / "pg-proposal-overrides.yml"
+_OUTPUT_PATH = _PROJECTS_DIR / "new.pg-proposal-overrides.yml"
+_CACHE_DIR = Path("scripts/.github_cache")
+_ENTRY_KEY_ORDER = (
+    "display_name",
+    "activity_status",
+    "git_owner_url",
+    "git_repo_urls",
+    "category",
+    "metadata",
+)
+
+yaml: YAML = YAML(typ="rt")
+yaml.preserve_quotes = True
+yaml.indent(mapping=2, sequence=4, offset=2)
+yaml.width = 120
+
+
+def main() -> int:
+    """Generate draft proposal override patches from open labeled proposal PRs."""
+
+    args = _build_parser().parse_args()
+
+    try:
+        canonical_template, canonical_overrides = _load_canonical_overrides()
+    except Exception as exc:
+        _print_error(f"Failed to load canonical overrides: {exc}")
+
+        return 1
+
+    merged_overrides: dict[str, dict[str, Any]] = {key: dict(value) for key, value in canonical_overrides.items()}
+
+    name_map = _collect_existing_name_map(canonical_overrides)
+
+    gh = get_github_client()
+
+    try:
+        docs_repo = gh.get_repo(f"{_DOCS_OWNER}/{_DOCS_REPO}")
+        search_results = gh.search_issues(query=_QUERY)
+    except GithubException as exc:
+        _print_error(f"GitHub query failed: {exc}")
+
+        return 1
+    except Exception as exc:
+        _print_error(f"Unexpected GitHub initialization failure: {exc}")
+
+        return 1
+
+    processed: list[str] = []
+    skipped = 0
+
+    for issue in search_results:
+        pr_number = issue.number
+
+        pull_head_sha: str | None = None
+        cached_pr = _load_cached_pr(pr_number) if args.read_cache else None
+        if cached_pr is not None:
+            pull_raw, changed_files = cached_pr
+            pull_head_sha = _pull_head_sha_from_raw(pull_raw)
+        else:
+            try:
+                pull = docs_repo.get_pull(pr_number)
+                changed_files = [file.filename for file in pull.get_files()]
+                pull_head_sha = pull.head.sha
+                _save_cached_pr(pr_number, pull.raw_data, changed_files)
+            except GithubException as exc:
+                print(f"WARNING PR #{pr_number}: failed to inspect changed files: {exc}")
+                skipped += 1
+                continue
+
+        valid_single, project_path = _is_valid_single_project_file(changed_files)
+        if not valid_single or project_path is None:
+            print(f"INFO PR #{pr_number}: skipped (changed files={len(changed_files)})")
+            skipped += 1
+            continue
+
+        markdown_text = _load_cached_markdown(pr_number, project_path) if args.read_cache else None
+        if markdown_text is None:
+            if not pull_head_sha:
+                print(f"WARNING PR #{pr_number}: missing head sha for {project_path}")
+                skipped += 1
+                continue
+
+            try:
+                source = docs_repo.get_contents(project_path, ref=pull_head_sha)
+                if isinstance(source, list):
+                    raise ValueError(f"Expected file content, got directory listing for {project_path}")
+
+                content_bytes = source.decoded_content
+                markdown_text = content_bytes.decode("utf-8")
+                _save_cached_markdown(pr_number, project_path, content_bytes)
+            except GithubException as exc:
+                print(f"WARNING PR #{pr_number}: failed to fetch {project_path}: {exc}")
+                skipped += 1
+                continue
+            except Exception as exc:
+                print(f"WARNING PR #{pr_number}: failed to decode {project_path}: {exc}")
+                skipped += 1
+                continue
+
+        try:
+            candidate = _extract_markdown_fields(markdown_text, pr_number, project_path)
+        except Exception as exc:
+            print(f"WARNING PR #{pr_number}: failed to parse {project_path}: {exc}")
+            skipped += 1
+            continue
+
+        slug = _extract_slug_from_path(project_path)
+        normalized_slug = _normalize_alpha(slug)
+
+        matched_key: str | None = None
+
+        if normalized_slug:
+            matching_keys = name_map.get(normalized_slug, [])
+            if matching_keys:
+                matched_key = matching_keys[0]
+                if len(matching_keys) > 1:
+                    print(f"WARNING PR #{pr_number}: multiple name matches for slug={slug!r}; using {matched_key!r}")
+
+        if matched_key is None:
+            extracted_repo_urls = candidate.get("git_repo_urls")
+            repo_urls_for_match = (
+                [url for url in cast(list[Any], extracted_repo_urls) if isinstance(url, str)]
+                if isinstance(extracted_repo_urls, list)
+                else []
+            )
+            repo_match, scored_matches = _get_existing_repo_overlap(canonical_overrides, repo_urls_for_match)
+            if repo_match is not None:
+                matched_key = repo_match
+                if len(scored_matches) > 1:
+                    joined = ", ".join(f"{key}:{score}" for key, score in scored_matches)
+                    print(
+                        f"WARNING PR #{pr_number}: more than one repo-overlap match for {project_path}; "
+                        f"selected {repo_match!r}. candidates={joined}"
+                    )
+
+        if matched_key is None:
+            suffix = _slug_to_canonical_suffix(slug)
+            if not suffix:
+                print(f"WARNING PR #{pr_number}: unable to derive canonical key from slug {slug!r}; skipped")
+                skipped += 1
+                continue
+
+            matched_key = f"{_DAOIP_PREFIX}{suffix}"
+
+        source_tag = f"PR #{pr_number} ({project_path})"
+        existing_entry = merged_overrides.get(matched_key, {})
+        has_front_matter = candidate.get("_has_front_matter") is True
+        if has_front_matter and "display_name" not in candidate:
+            candidate["display_name"] = _slug_to_display_name(slug)
+
+        merged_entry = _merge_patch_entry(existing_entry, candidate, source_tag=source_tag)
+        if not has_front_matter and not existing_entry:
+            merged_entry["display_name"] = None
+
+        merged_entry = _ensure_required_properties(merged_entry, fallback_display_name=_slug_to_display_name(slug))
+        merged_overrides[matched_key] = merged_entry
+
+        processed.append(matched_key)
+
+    for key, value in list(merged_overrides.items()):
+        suffix = key[len(_DAOIP_PREFIX) :] if key.startswith(_DAOIP_PREFIX) else key
+        merged_overrides[key] = _ensure_required_properties(
+            value,
+            fallback_display_name=_slug_to_display_name(suffix),
+        )
+
+    output_text = _render_sorted_yaml(merged_overrides, canonical_template)
+
+    try:
+        _OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _OUTPUT_PATH.write_text(output_text, encoding="utf-8")
+    except OSError as exc:
+        _print_error(f"Failed to write draft file {_OUTPUT_PATH}: {exc}")
+
+        return 1
+
+    print(f"Processed proposal PRs: {len(processed)}")
+    print(f"Skipped proposal PRs: {skipped}")
+    print(f"Draft overrides written to {_OUTPUT_PATH}")
+
+    print("\nTo apply these overrides selectively, run the Reference Graph Bootstrap with:")
+    print(" ".join(processed))
+
+    return 0
+
+
+def _yaml_load(text: str) -> Any:
+    """Typed wrapper around ruamel YAML load."""
+
+    return cast(Any, yaml).load(text)
+
+
+def _yaml_dump(data: Any, stream: StringIO) -> None:
+    """Typed wrapper around ruamel YAML dump."""
+
+    cast(Any, yaml).dump(data, stream)
+
+
+def _print_error(message: str) -> None:
+    """Print a major failure message to stderr."""
+
+    print(message, file=sys.stderr)
+
+
+def _normalize_alpha(value: str) -> str:
+    """Return lowercased string with only ``a-z`` characters preserved."""
+
+    lowered = value.lower()
+
+    return "".join(ch for ch in lowered if "a" <= ch <= "z")
+
+
+def _slug_to_canonical_suffix(slug: str) -> str:
+    """Convert proposal slug to canonical suffix using underscore normalization."""
+
+    lowered = slug.lower()
+    normalized = re.sub(r"[^a-z0-9]+", "_", lowered).strip("_")
+
+    return normalized
+
+
+def _extract_slug_from_path(path: str) -> str:
+    """Extract proposal slug from docs/projects markdown file path."""
+
+    return Path(path).stem
+
+
+def _as_string_key_dict(value: Any) -> dict[str, Any] | None:
+    """Return a ``dict[str, Any]`` when all keys are strings, else ``None``."""
+
+    if not isinstance(value, dict):
+        return None
+
+    normalized: dict[str, Any] = {}
+    raw_dict = cast(dict[Any, Any], value)
+    for key, item in raw_dict.items():
+        if not isinstance(key, str):
+            return None
+
+        normalized[key] = item
+
+    return normalized
+
+
+def _load_canonical_overrides() -> tuple[CommentedMap, dict[str, dict[str, Any]]]:
+    """Load canonical overrides and return round-trip mapping plus normalized dict."""
+
+    if not _CANONICAL_PATH.exists():
+        raise FileNotFoundError(f"Canonical override file not found: {_CANONICAL_PATH}")
+
+    raw_text = _CANONICAL_PATH.read_text(encoding="utf-8")
+    loaded = _yaml_load(raw_text)
+    parsed_opt = _as_string_key_dict(loaded)
+    if parsed_opt is None and loaded is not None:
+        raise ValueError(f"Canonical override file must parse to a mapping: {_CANONICAL_PATH}")
+    parsed = parsed_opt or {}
+
+    normalized: dict[str, dict[str, Any]] = {}
+    for key, value in parsed.items():
+        value_dict = _as_string_key_dict(value)
+        if value_dict is None:
+            raise ValueError(f"Override value for {key!r} must be a mapping")
+
+        normalized[key] = value_dict
+
+    canonical_map = loaded if isinstance(loaded, CommentedMap) else CommentedMap()
+
+    return canonical_map, normalized
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Create CLI parser for script runtime flags."""
+
+    parser = argparse.ArgumentParser(description="Draft PG proposal overrides from open proposal PRs.")
+    parser.add_argument(
+        "--read-cache",
+        action="store_true",
+        help="Read PR/file data from scripts/.github_cache when available before calling GitHub APIs.",
+    )
+
+    return parser
+
+
+def _cache_pr_json_path(pr_number: int) -> Path:
+    """Return cache path for a PR metadata JSON snapshot."""
+
+    return _CACHE_DIR / f"pr_{pr_number}.json"
+
+
+def _cache_project_file_path(pr_number: int, project_path: str) -> Path:
+    """Return cache path for a proposal markdown file preserving original filename."""
+
+    return _CACHE_DIR / f"pr_{pr_number}" / project_path
+
+
+def _load_cached_pr(pr_number: int) -> tuple[dict[str, Any], list[str]] | None:
+    """Load cached PR metadata and changed files for a PR number."""
+
+    cache_path = _cache_pr_json_path(pr_number)
+    if not cache_path.exists():
+        return None
+
+    try:
+        payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    except OSError, json.JSONDecodeError:
+        return None
+
+    pull_raw = payload.get("pull")
+    changed_files_raw = payload.get("changed_files")
+    pull_data = _as_string_key_dict(pull_raw)
+    if pull_data is None or not isinstance(changed_files_raw, list):
+        return None
+
+    changed_files_any = cast(list[Any], changed_files_raw)
+    changed_files = [item for item in changed_files_any if isinstance(item, str)]
+
+    return pull_data, changed_files
+
+
+def _save_cached_pr(pr_number: int, pull_raw: dict[str, Any], changed_files: list[str]) -> None:
+    """Persist PR metadata and changed file list as pretty JSON."""
+
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cache_path = _cache_pr_json_path(pr_number)
+    payload = {
+        "pull": pull_raw,
+        "changed_files": changed_files,
+    }
+    cache_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _load_cached_markdown(pr_number: int, project_path: str) -> str | None:
+    """Load cached markdown content if available."""
+
+    cache_path = _cache_project_file_path(pr_number, project_path)
+    if not cache_path.exists():
+        return None
+
+    try:
+        return cache_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _save_cached_markdown(pr_number: int, project_path: str, content_bytes: bytes) -> None:
+    """Persist fetched markdown bytes preserving original filename."""
+
+    cache_path = _cache_project_file_path(pr_number, project_path)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_bytes(content_bytes)
+
+
+def _pull_head_sha_from_raw(pull_raw: dict[str, Any]) -> str | None:
+    """Extract head SHA from cached pull raw payload."""
+
+    head_raw = pull_raw.get("head")
+    head = _as_string_key_dict(head_raw)
+    if head is None:
+        return None
+
+    sha = head.get("sha")
+    if not isinstance(sha, str) or not sha:
+        return None
+
+    return sha
+
+
+def _parse_front_matter(markdown_text: str, *, pr_number: int, source_path: str) -> tuple[dict[str, Any], str, bool]:
+    """Parse YAML front matter and return ``(front_matter, markdown_body, has_front_matter)``."""
+
+    if not markdown_text.startswith("---\n"):
+        print(f"WARNING PR #{pr_number}: missing YAML front matter in {source_path}")
+
+        return {}, markdown_text, False
+
+    end_index = markdown_text.find("\n---\n", 4)
+    if end_index == -1:
+        print(f"WARNING PR #{pr_number}: malformed YAML front matter in {source_path}")
+
+        return {}, markdown_text, False
+
+    fm_text = markdown_text[4:end_index]
+    body = markdown_text[end_index + len("\n---\n") :]
+
+    loaded = _yaml_load(fm_text)
+    parsed = _as_string_key_dict(loaded)
+    if parsed is None:
+        raise ValueError("Front matter must be a YAML mapping")
+
+    return parsed, body, True
+
+
+def _extract_plain_text(token: Any) -> str:
+    """Extract plain text from a mistletoe token recursively."""
+
+    if token is None:
+        return ""
+
+    if isinstance(token, LineBreak):
+        if token.soft:
+            return " "
+
+        return "\n"
+
+    if hasattr(token, "content") and isinstance(token.content, str):
+        return token.content
+
+    children = getattr(token, "children", None)
+    if not children:
+        return ""
+
+    parts = [_extract_plain_text(child) for child in children]
+
+    return "".join(parts)
+
+
+def _table_rows_to_pairs(table_token: Table) -> list[tuple[str, str]]:
+    """Convert mistletoe table rows to ``(key, value)`` pairs."""
+
+    rows: list[tuple[str, str]] = []
+    table_rows = table_token.children or []
+    for row in table_rows:
+        cells = getattr(row, "children", [])
+        if not cells:
+            continue
+
+        rendered_cells = [" ".join(_extract_plain_text(cell).split()) for cell in cells]
+
+        if len(rendered_cells) >= 2:
+            key = rendered_cells[0]
+            value = rendered_cells[1]
+            rows.append((key, value))
+
+    return rows
+
+
+def _normalize_row_header(value: str) -> str:
+    """Normalize table row labels for flexible matching."""
+
+    normalized = value.strip().lower()
+    normalized = normalized.replace("**", "")
+
+    return " ".join(normalized.split())
+
+
+def _extract_project_description_after_h1(doc: Document) -> str | None:
+    """Extract first paragraph after first H1 heading and trim outer underscores."""
+
+    blocks = list(doc.children or [])
+    seen_h1 = False
+
+    for block in blocks:
+        if isinstance(block, Heading):
+            level = getattr(block, "level", 0)
+            if level == 1:
+                seen_h1 = True
+                continue
+
+            if seen_h1 and level == 1:
+                return None
+
+        if seen_h1 and isinstance(block, Paragraph):
+            text = " ".join(_extract_plain_text(block).split())
+            if text.strip().startswith("<!--"):
+                continue
+
+            cleaned = re.sub(r"<!--\s*markdownlint-(?:disable|enable)\s+MD036\s*-->", "", text, flags=re.IGNORECASE)
+            trimmed = cleaned.strip("_").strip()
+            if trimmed:
+                return trimmed
+
+    return None
+
+
+def _is_valid_url(url_value: str) -> bool:
+    """Return whether a string is a valid absolute URL with scheme and host."""
+
+    try:
+        parsed = urlparse(url_value)
+    except ValueError:
+        return False
+
+    return bool(parsed.scheme and parsed.netloc)
+
+
+def _is_github_url(url_value: str) -> bool:
+    """Return whether a URL points to github.com."""
+
+    if not _is_valid_url(url_value):
+        return False
+
+    parsed = urlparse(url_value)
+
+    return (parsed.netloc or "").lower() in {"github.com", "www.github.com"}
+
+
+def _normalize_github_repo_url(url_value: str) -> str | None:
+    """Normalize GitHub repo URL to canonical lowercase host/owner/repo form."""
+
+    if not _is_github_url(url_value):
+        return None
+
+    parsed = urlparse(url_value)
+    parts = [segment for segment in parsed.path.split("/") if segment]
+    if len(parts) < 2:
+        return None
+
+    owner = parts[0]
+    repo = parts[1]
+    if repo.endswith(".git"):
+        repo = repo[:-4]
+
+    if not owner or not repo:
+        return None
+
+    normalized = f"https://github.com/{owner}/{repo}"
+    if normalized.lower() == _DOCS_REPO_URL.lower():
+        return None
+
+    return normalized
+
+
+def _extract_github_owner_url(repo_urls: list[str]) -> str | None:
+    """Derive owner URL when all repository URLs share the same owner."""
+
+    owners: set[str] = set()
+    for repo_url in repo_urls:
+        parsed = urlparse(repo_url)
+        parts = [segment for segment in parsed.path.split("/") if segment]
+        if len(parts) < 2:
+            continue
+
+        owners.add(parts[0])
+
+    if len(owners) != 1:
+        return None
+
+    owner = next(iter(owners))
+
+    return f"https://github.com/{owner}"
+
+
+def _extract_markdown_fields(markdown_text: str, pr_number: int, source_path: str) -> dict[str, Any]:
+    """Extract candidate patch fields from proposal markdown content."""
+
+    front_matter, body, has_front_matter = _parse_front_matter(
+        markdown_text,
+        pr_number=pr_number,
+        source_path=source_path,
+    )
+    doc = Document(body)
+
+    candidate: dict[str, Any] = {}
+    candidate["_has_front_matter"] = has_front_matter
+
+    title = front_matter.get("title")
+    if isinstance(title, str) and title.strip():
+        candidate["display_name"] = title.strip()
+
+    front_category = front_matter.get("category")
+    if isinstance(front_category, str) and front_category.strip():
+        candidate["category"] = front_category.strip()
+
+    description = _extract_project_description_after_h1(doc)
+    if description:
+        candidate.setdefault("metadata", {})
+        candidate["metadata"]["description"] = description
+
+    first_table: Table | None = None
+    for block in doc.children or []:
+        if isinstance(block, Table):
+            first_table = block
+            break
+
+    if first_table is None:
+        return candidate
+
+    row_pairs = _table_rows_to_pairs(first_table)
+    row_map: dict[str, str] = {}
+
+    all_values: list[str] = []
+    for raw_key, raw_value in row_pairs:
+        key = _normalize_row_header(raw_key)
+        value = raw_value.strip()
+        if not key or not value:
+            continue
+
+        row_map[key] = value
+        all_values.append(value)
+
+    github_urls: list[str] = []
+    for value in all_values:
+        if normalized_repo := _normalize_github_repo_url(value):
+            github_urls.append(normalized_repo)
+
+    if not github_urls:
+        if repository_value := row_map.get("repository"):
+            if fallback_repo := _normalize_github_repo_url(repository_value):
+                github_urls = [fallback_repo]
+
+    if github_urls:
+        candidate["git_repo_urls"] = github_urls
+
+    table_category = row_map.get("category")
+    if (
+        table_category
+        and isinstance(front_category, str)
+        and front_category.strip()
+        and table_category.strip().lower() != front_category.strip().lower()
+    ):
+        print(
+            f"WARNING PR #{pr_number}: category mismatch for {source_path}: "
+            f"front matter={front_category!r}, table={table_category!r}"
+        )
+
+    website_value = row_map.get("website")
+    if website_value:
+        if _is_valid_url(website_value):
+            candidate.setdefault("metadata", {})
+            candidate["metadata"]["website"] = website_value
+        else:
+            print(f"WARNING PR #{pr_number}: invalid website value for {source_path}: {website_value!r}")
+
+    first_released_value = row_map.get("first released")
+    if first_released_value:
+        candidate.setdefault("metadata", {})
+        candidate["metadata"]["first_released"] = first_released_value
+
+    return candidate
+
+
+def _collect_existing_name_map(overrides: dict[str, dict[str, Any]]) -> dict[str, list[str]]:
+    """Build normalized name to canonical key list mapping from existing overrides."""
+
+    name_map: dict[str, list[str]] = {}
+    for key in overrides:
+        if not key.startswith(_DAOIP_PREFIX):
+            continue
+
+        suffix = key[len(_DAOIP_PREFIX) :]
+        normalized = _normalize_alpha(suffix)
+        if not normalized:
+            continue
+
+        name_map.setdefault(normalized, []).append(key)
+
+    for values in name_map.values():
+        values.sort()
+
+    return name_map
+
+
+def _get_existing_repo_overlap(
+    existing_overrides: dict[str, dict[str, Any]],
+    extracted_repo_urls: list[str],
+) -> tuple[str | None, list[tuple[str, int]]]:
+    """Return best canonical key by repo URL overlap and scored candidates."""
+
+    extracted_set = {url for url in extracted_repo_urls if _normalize_github_repo_url(url)}
+    if not extracted_set:
+        return None, []
+
+    scored: list[tuple[str, int]] = []
+    for key, entry in existing_overrides.items():
+        raw_urls_value = entry.get("git_repo_urls")
+        if not isinstance(raw_urls_value, list):
+            continue
+
+        raw_urls_any = cast(list[Any], raw_urls_value)
+        raw_urls = [url for url in raw_urls_any if isinstance(url, str)]
+
+        existing_set = {normalized for url in raw_urls for normalized in [_normalize_github_repo_url(url)] if normalized}
+        if not existing_set:
+            continue
+
+        overlap = len(existing_set.intersection(extracted_set))
+        if overlap > 0:
+            scored.append((key, overlap))
+
+    if not scored:
+        return None, []
+
+    scored_sorted = sorted(scored, key=lambda item: (-item[1], item[0]))
+
+    return scored_sorted[0][0], scored_sorted
+
+
+def _merge_patch_entry(existing: dict[str, Any], candidate: dict[str, Any], *, source_tag: str) -> dict[str, Any]:
+    """Merge extracted candidate into existing entry with non-overwrite semantics."""
+
+    merged = dict(existing)
+
+    if "display_name" not in merged:
+        display_name = candidate.get("display_name")
+        if isinstance(display_name, str) and display_name:
+            merged["display_name"] = display_name
+
+    if "activity_status" not in merged:
+        merged["activity_status"] = "live"
+
+    if "git_owner_url" not in merged:
+        source_repo_urls: list[str] = []
+        merged_repo_urls = merged.get("git_repo_urls")
+        if isinstance(merged_repo_urls, list):
+            merged_repo_urls_any = cast(list[Any], merged_repo_urls)
+            source_repo_urls = [url for url in merged_repo_urls_any if isinstance(url, str)]
+        else:
+            extracted_repo_urls = candidate.get("git_repo_urls")
+            if isinstance(extracted_repo_urls, list):
+                extracted_repo_urls_any = cast(list[Any], extracted_repo_urls)
+                source_repo_urls = [url for url in extracted_repo_urls_any if isinstance(url, str)]
+
+        owner_url = _extract_github_owner_url(source_repo_urls)
+        if owner_url is not None:
+            merged["git_owner_url"] = owner_url
+        else:
+            merged["git_owner_url"] = None
+            print(f"WARNING {source_tag}: git_owner_url ambiguous; set to null")
+
+    extracted_repo_urls = candidate.get("git_repo_urls")
+    if isinstance(extracted_repo_urls, list) and extracted_repo_urls:
+        merged["git_repo_urls"] = extracted_repo_urls
+
+    category = candidate.get("category")
+    if isinstance(category, str) and category:
+        merged["category"] = category
+
+    candidate_metadata = _as_string_key_dict(candidate.get("metadata"))
+    if candidate_metadata is not None:
+        existing_metadata = merged.get("metadata")
+        existing_metadata_dict = _as_string_key_dict(existing_metadata)
+        metadata: dict[str, Any] = dict(existing_metadata_dict) if existing_metadata_dict is not None else {}
+
+        description = candidate_metadata.get("description")
+        if isinstance(description, str) and description:
+            metadata["description"] = description
+
+        website = candidate_metadata.get("website")
+        if isinstance(website, str) and website:
+            metadata["website"] = website
+
+        first_released = candidate_metadata.get("first_released")
+        if isinstance(first_released, str) and first_released:
+            metadata["first_released"] = first_released
+
+        if metadata:
+            merged["metadata"] = metadata
+
+    return merged
+
+
+def _ensure_required_properties(entry: dict[str, Any], fallback_display_name: str) -> dict[str, Any]:
+    """Ensure required override keys are present; use null for unknown values."""
+
+    ensured = dict(entry)
+
+    if "display_name" not in ensured:
+        ensured["display_name"] = fallback_display_name or None
+
+    if "activity_status" not in ensured:
+        ensured["activity_status"] = "live"
+
+    if "git_owner_url" not in ensured:
+        ensured["git_owner_url"] = None
+
+    return ensured
+
+
+def _to_quoted_yaml_value(value: Any) -> Any:
+    """Recursively convert string scalar values to double-quoted scalars."""
+
+    if isinstance(value, str):
+        return DoubleQuotedScalarString(value)
+
+    if isinstance(value, list):
+        values_any = cast(list[Any], value)
+
+        return [_to_quoted_yaml_value(item) for item in values_any]
+
+    if isinstance(value, dict):
+        mapped = CommentedMap()
+        raw_dict = cast(dict[Any, Any], value)
+        for key, item in raw_dict.items():
+            mapped[key] = _to_quoted_yaml_value(item)
+
+        return mapped
+
+    return value
+
+
+def _order_entry_keys(entry: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of an override entry with canonical key ordering."""
+
+    ordered: dict[str, Any] = {}
+    for key in _ENTRY_KEY_ORDER:
+        if key in entry:
+            ordered[key] = entry[key]
+
+    for key, value in entry.items():
+        if key in ordered:
+            continue
+
+        ordered[key] = value
+
+    return ordered
+
+
+def _render_sorted_yaml(overrides: dict[str, dict[str, Any]], template_map: CommentedMap) -> str:
+    """Render deterministic YAML sorted by DAOIP key using round-trip formatting."""
+
+    sorted_keys = sorted(overrides)
+    ordered_map = CommentedMap()
+    cast(Any, ordered_map).ca.comment = cast(Any, template_map).ca.comment
+
+    for index, key in enumerate(sorted_keys):
+        ordered_entry = _order_entry_keys(overrides[key])
+        ordered_map[key] = _to_quoted_yaml_value(ordered_entry)
+        if index > 0:
+            cast(Any, ordered_map).yaml_set_comment_before_after_key(key, before="\n")
+
+    buffer = StringIO()
+    _yaml_dump(ordered_map, buffer)
+    rendered = buffer.getvalue()
+
+    return rendered
+
+
+def _slug_to_display_name(slug: str) -> str:
+    """Build a human-readable fallback display name from a proposal slug."""
+
+    cleaned = slug.replace("_", " ").replace("-", " ").strip()
+    words = [word for word in cleaned.split() if word]
+
+    if not words:
+        return slug
+
+    return " ".join(word.capitalize() for word in words)
+
+
+def _is_valid_single_project_file(pr_file_paths: list[str]) -> tuple[bool, str | None]:
+    """Validate the strict single changed-file rule for proposal PR selection."""
+
+    if len(pr_file_paths) != 1:
+        return False, None
+
+    only_path = pr_file_paths[0]
+    if not only_path.startswith("docs/projects/"):
+        return False, None
+    if not only_path.endswith(".md"):
+        return False, None
+
+    return True, only_path
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/bootstrap/test_opengrants.py
+++ b/tests/bootstrap/test_opengrants.py
@@ -271,7 +271,7 @@ def test_merge_project_and_applications() -> None:
     assert result.display_name == "Test Project"
     assert result.activity_status == ActivityStatus.live
     assert result.git_owner_url == "https://github.com/test-org"
-    assert result.git_repo_urls == "https://github.com/test-org/test-repo"
+    assert result.git_repo_urls == ["https://github.com/test-org/test-repo"]
     assert result.category == "Developer Tooling"
     assert result.project_metadata["description"] == "A test project description"
 
@@ -290,7 +290,7 @@ def test_merge_project_no_app_uses_socials_for_github() -> None:
     result = _merge_project_and_applications(project, None, [])
 
     assert result.git_owner_url == "https://github.com/stellar"
-    assert result.git_repo_urls == "https://github.com/stellar/go"
+    assert result.git_repo_urls == ["https://github.com/stellar/go"]
     assert result.activity_status == ActivityStatus.in_dev
 
 

--- a/tests/bootstrap/test_opengrants.py
+++ b/tests/bootstrap/test_opengrants.py
@@ -271,7 +271,7 @@ def test_merge_project_and_applications() -> None:
     assert result.display_name == "Test Project"
     assert result.activity_status == ActivityStatus.live
     assert result.git_owner_url == "https://github.com/test-org"
-    assert result.git_repo_url == "https://github.com/test-org/test-repo"
+    assert result.git_repo_urls == "https://github.com/test-org/test-repo"
     assert result.category == "Developer Tooling"
     assert result.project_metadata["description"] == "A test project description"
 
@@ -290,7 +290,7 @@ def test_merge_project_no_app_uses_socials_for_github() -> None:
     result = _merge_project_and_applications(project, None, [])
 
     assert result.git_owner_url == "https://github.com/stellar"
-    assert result.git_repo_url == "https://github.com/stellar/go"
+    assert result.git_repo_urls == "https://github.com/stellar/go"
     assert result.activity_status == ActivityStatus.in_dev
 
 

--- a/tests/bootstrap/test_tasks.py
+++ b/tests/bootstrap/test_tasks.py
@@ -90,7 +90,7 @@ async def test_sync_opengrants_defers_each_project_with_overrides(mocker: Any) -
             display_name="No Code",
             activity_status=ActivityStatus.live,
             git_owner_url=None,
-            git_repo_url=None,
+            git_repo_urls=[],
             category="Developer Tooling",
         ),
         ScfProject(
@@ -98,7 +98,7 @@ async def test_sync_opengrants_defers_each_project_with_overrides(mocker: Any) -
             display_name="With Code",
             activity_status=ActivityStatus.in_dev,
             git_owner_url="https://github.com/a",
-            git_repo_url="https://github.com/a/b",
+            git_repo_urls=["https://github.com/a/b"],
             category="Smart Contracts",
         ),
     ]
@@ -115,7 +115,10 @@ async def test_sync_opengrants_defers_each_project_with_overrides(mocker: Any) -
             "proj:no-code": {
                 "category": "Visibility",
                 "git_owner_url": "https://github.com/enriched",
-                "git_repo_url": "https://github.com/enriched/repo",
+                "git_repo_urls": [
+                    "https://github.com/enriched/repo",
+                    "https://github.com/upstream/opera",
+                ],
             },
             "proj:with-code": {
                 "activity_status": "live",
@@ -131,16 +134,17 @@ async def test_sync_opengrants_defers_each_project_with_overrides(mocker: Any) -
     defer_data: tuple[dict[str, Any], ...] = defer_mock.call_args_list[0].args
     assert len(defer_data) == 3
     assert defer_data[0]["git_owner_url"] == "https://github.com/enriched"
+    assert defer_data[0]["git_repo_urls"] == ["https://github.com/enriched/repo", "https://github.com/upstream/opera"]
     assert defer_data[0]["category"] == "Visibility"
     assert defer_data[1]["activity_status"] == ActivityStatus.live
-    assert defer_data[1]["git_repo_url"] == "https://github.com/a/b"
+    assert defer_data[1]["git_repo_urls"] == ["https://github.com/a/b"]
     assert defer_data[1]["category"] == "Smart Contracts"
     assert defer_data[1]["project_metadata"]["description"] == "Contracts launched on mainnet!"
     assert defer_data[2]["canonical_id"] == "proj:to-be-inserted"
     assert defer_data[2]["display_name"] == "To be inserted"
     assert defer_data[2]["activity_status"] == "non-responsive"
     assert defer_data[2]["git_owner_url"] == "https://github.com/sloth"
-    assert defer_data[2]["git_repo_url"] is None
+    assert defer_data[2]["git_repo_urls"] == []
 
 
 async def test_sync_opengrants_filters_projects_by_canonical_id(mocker: Any) -> None:
@@ -150,7 +154,7 @@ async def test_sync_opengrants_filters_projects_by_canonical_id(mocker: Any) -> 
             display_name="Python SDK",
             activity_status=ActivityStatus.live,
             git_owner_url="https://github.com/stellar",
-            git_repo_url="https://github.com/stellar/python-stellar-sdk",
+            git_repo_urls=["https://github.com/stellar/python-stellar-sdk"],
             category="Developer Tooling",
         ),
         ScfProject(
@@ -158,7 +162,7 @@ async def test_sync_opengrants_filters_projects_by_canonical_id(mocker: Any) -> 
             display_name="StellarChain",
             activity_status=ActivityStatus.live,
             git_owner_url="https://github.com/stellarchain",
-            git_repo_url="https://github.com/stellarchain/web",
+            git_repo_urls=["https://github.com/stellarchain/web"],
             category="Developer Tooling",
         ),
     ]
@@ -182,7 +186,7 @@ async def test_sync_opengrants_raises_for_unknown_canonical_ids(mocker: Any) -> 
             display_name="Python SDK",
             activity_status=ActivityStatus.live,
             git_owner_url="https://github.com/stellar",
-            git_repo_url="https://github.com/stellar/python-stellar-sdk",
+            git_repo_urls=["https://github.com/stellar/python-stellar-sdk"],
             category="Developer Tooling",
         )
     ]
@@ -259,7 +263,7 @@ async def test_process_project_enriches_packages_from_depsdev(mocker: Any) -> No
         display_name="Project 1",
         activity_status="live",
         git_owner_url="https://github.com/org",
-        git_repo_url=None,
+        git_repo_urls=[],
         project_metadata={"k": "v"},
         category="Developer Tooling",
     )
@@ -439,7 +443,7 @@ async def test_process_project_edu_community_skips_crawl(mocker: Any) -> None:
         display_name="Stellar Academy",
         activity_status="live",
         git_owner_url="https://github.com/stellar-academy",
-        git_repo_url=None,
+        git_repo_urls=[],
         project_metadata={"k": "v"},
         category="Education & Community",
     )
@@ -640,7 +644,7 @@ class TestDeferredPayloadJsonSerializable:
             display_name="Test Project",
             activity_status=ActivityStatus.live,
             git_owner_url="https://github.com/test-org",
-            git_repo_url="https://github.com/test-org/test-repo",
+            git_repo_urls=["https://github.com/test-org/test-repo"],
             category="Infrastructure",
             project_metadata={"round": 25, "tags": ["defi"]},
         )
@@ -666,7 +670,7 @@ class TestDeferredPayloadJsonSerializable:
                 display_name=f"Project {status.value}",
                 activity_status=status,
                 git_owner_url=None,
-                git_repo_url=None,
+                git_repo_urls=[],
             )
             payload = {**asdict(proj), "extended_universe": False}
             data = self._assert_json_round_trips(payload)

--- a/uv.lock
+++ b/uv.lock
@@ -901,6 +901,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mistletoe"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/ea/ee6e364d62197e427f1d260500eac659a8855df207a77f74451658d749f3/mistletoe-1.6.0.tar.gz", hash = "sha256:92f066c4720a25fa24bf260e6413702bbff3a5b8a93af314cb6cd8589726a8e1", size = 113730, upload-time = "2026-07-11T14:14:18.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/5c/3681c676d79726e3b8b72bc78e83ac472b0c96e3c99b28d72b9470f12170/mistletoe-1.6.0-py3-none-any.whl", hash = "sha256:53f9dfb859e9b2d309915d0f06c3876253d1e24d568d0b728a32679eb4f0a187", size = 55931, upload-time = "2026-07-11T14:14:17.056Z" },
+]
+
+[[package]]
 name = "msgspec"
 version = "0.21.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1101,6 +1110,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "mistletoe" },
     { name = "msgspec" },
     { name = "networkx" },
     { name = "numpy" },
@@ -1146,6 +1156,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.5" },
     { name = "fastapi", specifier = ">=0.133.1" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "mistletoe", specifier = ">=1.6.0" },
     { name = "msgspec", specifier = ">=0.21.0" },
     { name = "networkx", specifier = ">=3.0" },
     { name = "numpy", specifier = ">=1.26" },

--- a/uv.lock
+++ b/uv.lock
@@ -1110,7 +1110,6 @@ dependencies = [
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx" },
-    { name = "mistletoe" },
     { name = "msgspec" },
     { name = "networkx" },
     { name = "numpy" },
@@ -1130,11 +1129,13 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "basedpyright" },
+    { name = "mistletoe" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "ruamel-yaml" },
     { name = "ruff", version = "0.15.11", source = { registry = "https://pypi.org/simple" } },
     { name = "types-aiobotocore-custom" },
     { name = "types-cachetools" },
@@ -1156,7 +1157,6 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.5" },
     { name = "fastapi", specifier = ">=0.133.1" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "mistletoe", specifier = ">=1.6.0" },
     { name = "msgspec", specifier = ">=0.21.0" },
     { name = "networkx", specifier = ">=3.0" },
     { name = "numpy", specifier = ">=1.26" },
@@ -1176,11 +1176,13 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = ">=1.39.0" },
+    { name = "mistletoe", specifier = ">=1.6.0" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-mock" },
+    { name = "ruamel-yaml", specifier = ">=0.19.1" },
     { name = "ruff", specifier = ">=0.15.2" },
     { name = "types-aiobotocore-custom", path = "vendored/types_aiobotocore_custom-3.3.0-py3-none-any.whl" },
     { name = "types-cachetools" },
@@ -1711,6 +1713,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
One of the barriers to adopting PG Atlas in the Public Goods Award process is that the project data associated with proposals can be incomplete or outdated. Some projects have a history with the SCF (Build Award), and the info that was provided in their initial SCF submission does not track the current reality.  Others have entered SCF through the PG Award, and their data is not yet available in OpenGrants' SCF dataset.

This PR adds support for semi-automated project data and repo crawl overrides, populated from the PG project pages and live proposals. A script creates or updates the project patches, after which it should be checked and corrected if needed. The override mechanism that applies the patches is already present, built in #72.

The patch file is meant to be updated quarterly, during the PG Award's discussion period. It will remain in use even if OpenGrants adds PG funding data for SCF. OpenGrants data is retrospective, while the PG Atlas data needs to be up-to-date whilst proposals are written and edited. The 2026 Q2 and Q3 rounds have both seen proposals flip the visiblity of repos to public during the discussion period, so the patching cycle may need to occur multiple times during a live round.